### PR TITLE
install cmake 3.16.3 for lgtm

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -9,6 +9,10 @@ queries:
 
 extraction:
   cpp:
+     after_prepare:
+        - "mkdir custom_cmake"
+        - "wget --quiet -O - https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.tar.gz | tar --strip-components=1 -xz -C custom_cmake"
+        - "export PATH=$(pwd)/custom_cmake/bin:${PATH}"
      index:
         build_command:
           - cd $LGTM_SRC


### PR DESCRIPTION
Hi, I have the same issue when using cmake on lgtm. Fortunately, I found a way to install cmake 3.16.3 on the environment.

This PR fixed #69 