### PR TITLE
New Data Layout for Gain Cache

### DIFF
--- a/mt-kahypar/datastructures/delta_partitioned_graph.h
+++ b/mt-kahypar/datastructures/delta_partitioned_graph.h
@@ -258,7 +258,7 @@ class DeltaPartitionedGraph {
       _incident_weight_in_part_delta.get_if_contained(incident_weight_index(u, part_id));
     const HyperedgeWeight incident_weight_u = _pg->incidentWeightInPart(u, part_id) +
                                               (incident_weight_delta_u ? *incident_weight_delta_u : 0);
-    return -incident_weight_u;
+    return incident_weight_u;
   }
 
   HyperedgeWeight moveToBenefit(const HypernodeID u, const PartitionID p) const {
@@ -268,14 +268,14 @@ class DeltaPartitionedGraph {
       _incident_weight_in_part_delta.get_if_contained(incident_weight_index(u, p));
     const HyperedgeWeight incident_weight_p = _pg->incidentWeightInPart(u, p) +
                                               (incident_weight_delta_p ? *incident_weight_delta_p : 0);
-    return -incident_weight_p;
+    return incident_weight_p;
   }
 
   Gain km1Gain(const HypernodeID u, const PartitionID from, const PartitionID to) const {
     unused(from);
     ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
     ASSERT(from != to, "The gain computation doesn't work for from = to");
-    return moveFromPenalty(u) - moveToBenefit(u, to);
+    return moveToBenefit(u, to) - moveFromPenalty(u);
   }
 
   void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& benefit_aggregator) {

--- a/mt-kahypar/datastructures/delta_partitioned_graph.h
+++ b/mt-kahypar/datastructures/delta_partitioned_graph.h
@@ -251,7 +251,7 @@ class DeltaPartitionedGraph {
     return count;
   }
 
-  HyperedgeWeight moveFromBenefit(const HypernodeID u) const {
+  HyperedgeWeight moveFromPenalty(const HypernodeID u) const {
     ASSERT(_pg);
     const PartitionID part_id = partID(u);
     const HyperedgeWeight* incident_weight_delta_u =
@@ -261,7 +261,7 @@ class DeltaPartitionedGraph {
     return -incident_weight_u;
   }
 
-  HyperedgeWeight moveToPenalty(const HypernodeID u, const PartitionID p) const {
+  HyperedgeWeight moveToBenefit(const HypernodeID u, const PartitionID p) const {
     ASSERT(_pg);
     ASSERT(p != kInvalidPartition && p < _k);
     const HyperedgeWeight* incident_weight_delta_p =
@@ -275,11 +275,11 @@ class DeltaPartitionedGraph {
     unused(from);
     ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
     ASSERT(from != to, "The gain computation doesn't work for from = to");
-    return moveFromBenefit(u) - moveToPenalty(u, to);
+    return moveFromPenalty(u) - moveToBenefit(u, to);
   }
 
-  void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& penalty_aggregator) {
-    _pg->initializeGainCacheEntry(u, penalty_aggregator);
+  void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& benefit_aggregator) {
+    _pg->initializeGainCacheEntry(u, benefit_aggregator);
   }
 
   // ! Clears all deltas applied to the partitioned hypergraph

--- a/mt-kahypar/datastructures/delta_partitioned_hypergraph.h
+++ b/mt-kahypar/datastructures/delta_partitioned_hypergraph.h
@@ -72,8 +72,7 @@ class DeltaPartitionedHypergraph {
     _part_weights_delta(0, 0),
     _part_ids_delta(),
     _pins_in_part_delta(),
-    _move_to_penalty_delta(),
-    _move_from_benefit_delta() {}
+    _gain_cache_delta() {}
 
   DeltaPartitionedHypergraph(const Context& context) :
     _k(context.partition.k),
@@ -81,13 +80,11 @@ class DeltaPartitionedHypergraph {
     _part_weights_delta(context.partition.k, 0),
     _part_ids_delta(),
     _pins_in_part_delta(),
-    _move_to_penalty_delta(),
-    _move_from_benefit_delta() {
+    _gain_cache_delta() {
       const bool top_level = context.type == kahypar::ContextType::main;
       _part_ids_delta.initialize(MAP_SIZE_SMALL);
       _pins_in_part_delta.initialize(MAP_SIZE_LARGE);
-      _move_from_benefit_delta.initialize(top_level ? MAP_SIZE_LARGE : MAP_SIZE_MOVE_DELTA);
-      _move_to_penalty_delta.initialize(top_level ? MAP_SIZE_LARGE : MAP_SIZE_MOVE_DELTA);
+      _gain_cache_delta.initialize(top_level ? MAP_SIZE_LARGE : MAP_SIZE_MOVE_DELTA);
     }
 
   DeltaPartitionedHypergraph(const DeltaPartitionedHypergraph&) = delete;
@@ -210,23 +207,23 @@ class DeltaPartitionedHypergraph {
     if (pin_count_in_from_part_after == 1) {
       for (HypernodeID u : pins(he)) {
         if (partID(u) == from) {
-          _move_from_benefit_delta[u] += we;
+          _gain_cache_delta[benefit_index(u)] += we;
         }
       }
     } else if (pin_count_in_from_part_after == 0) {
       for (HypernodeID u : pins(he)) {
-        _move_to_penalty_delta[penalty_index(u, from)] += we;
+        _gain_cache_delta[penalty_index(u, from)] -= we;
       }
     }
 
     if (pin_count_in_to_part_after == 1) {
       for (HypernodeID u : pins(he)) {
-        _move_to_penalty_delta[penalty_index(u, to)] -= we;
+        _gain_cache_delta[penalty_index(u, to)] += we;
       }
     } else if (pin_count_in_to_part_after == 2) {
       for (HypernodeID u : pins(he)) {
         if (partID(u) == to) {
-          _move_from_benefit_delta[u] -= we;
+          _gain_cache_delta[benefit_index(u)] -= we;
         }
       }
     }
@@ -261,7 +258,7 @@ class DeltaPartitionedHypergraph {
   HyperedgeWeight moveFromBenefit(const HypernodeID u) const {
     ASSERT(_phg);
     const HyperedgeWeight* move_from_benefit_delta =
-      _move_from_benefit_delta.get_if_contained(u);
+      _gain_cache_delta.get_if_contained(benefit_index(u));
     return _phg->moveFromBenefit(u) + ( move_from_benefit_delta ? *move_from_benefit_delta : 0 );
   }
 
@@ -271,7 +268,7 @@ class DeltaPartitionedHypergraph {
     ASSERT(_phg);
     ASSERT(p != kInvalidPartition && p < _k);
     const HyperedgeWeight* move_to_penalty_delta =
-      _move_to_penalty_delta.get_if_contained(u * _k + p);
+      _gain_cache_delta.get_if_contained(penalty_index(u, p));
     return _phg->moveToPenalty(u, p) + ( move_to_penalty_delta ? *move_to_penalty_delta : 0 );
   }
 
@@ -279,7 +276,7 @@ class DeltaPartitionedHypergraph {
     unused(from);
     ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
     ASSERT(from != to, "The gain computation doesn't work for from = to");
-    return moveFromBenefit(u) - moveToPenalty(u, to);
+    return moveFromBenefit(u) + moveToPenalty(u, to);
   }
 
   void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& penalty_aggregator) {
@@ -293,8 +290,7 @@ class DeltaPartitionedHypergraph {
     // Constant Time
     _part_ids_delta.clear();
     _pins_in_part_delta.clear();
-    _move_to_penalty_delta.clear();
-    _move_from_benefit_delta.clear();
+    _gain_cache_delta.clear();
   }
 
   void dropMemory() {
@@ -302,15 +298,13 @@ class DeltaPartitionedHypergraph {
       _memory_dropped = true;
       _part_ids_delta.freeInternalData();
       _pins_in_part_delta.freeInternalData();
-      _move_to_penalty_delta.freeInternalData();
-      _move_from_benefit_delta.freeInternalData();
+      _gain_cache_delta.freeInternalData();
     }
   }
 
   size_t combinedMemoryConsumption() const {
     return _pins_in_part_delta.size_in_bytes()
-           + _move_from_benefit_delta.size_in_bytes()
-           + _move_to_penalty_delta.size_in_bytes()
+           + _gain_cache_delta.size_in_bytes()
            + _part_ids_delta.size_in_bytes();
   }
 
@@ -328,17 +322,20 @@ class DeltaPartitionedHypergraph {
     part_ids_node->updateSize(_part_ids_delta.size_in_bytes());
     utils::MemoryTreeNode* pins_in_part_node = delta_phg_node->addChild("Delta Pins In Part");
     pins_in_part_node->updateSize(_pins_in_part_delta.size_in_bytes());
-    utils::MemoryTreeNode* move_from_benefit_node = delta_phg_node->addChild("Delta Move From Benefit");
-    move_from_benefit_node->updateSize(_move_from_benefit_delta.size_in_bytes());
-    utils::MemoryTreeNode* move_to_penalty_node = delta_phg_node->addChild("Delta Move To Penalty");
-    move_to_penalty_node->updateSize(_move_to_penalty_delta.size_in_bytes());
+    utils::MemoryTreeNode* gain_cache_delta_node = delta_phg_node->addChild("Delta Gain Cache");
+    gain_cache_delta_node->updateSize(_gain_cache_delta.size_in_bytes());
   }
 
  private:
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
+  size_t benefit_index(const HypernodeID u) const {
+    return size_t(u) * ( _k + 1 );
+  }
+
+  MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
   size_t penalty_index(const HypernodeID u, const PartitionID p) const {
-    return size_t(u) * _k + p;
+    return size_t(u) * ( _k + 1 ) + p + 1;
   }
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
@@ -371,13 +368,9 @@ class DeltaPartitionedHypergraph {
   // ! relative to the _pins_in_part member in '_phg'
   DynamicFlatMap<size_t, int32_t> _pins_in_part_delta;
 
-  // ! Stores the delta of each locally touched move to penalty entry
-  // ! relative to the _move_to_penalty member in '_phg'
-  DynamicFlatMap<size_t, HyperedgeWeight> _move_to_penalty_delta;
-
-  // ! Stores the delta of each locally touched move from benefit entry
-  // ! relative to the _move_from_benefit member in '_phg'
-  DynamicFlatMap<HypernodeID, HyperedgeWeight> _move_from_benefit_delta;
+  // ! Stores the delta of each locally touched gain cache entry
+  // ! relative to the gain cache in '_phg'
+  DynamicFlatMap<size_t, HyperedgeWeight> _gain_cache_delta;
 };
 
 } // namespace ds

--- a/mt-kahypar/datastructures/partitioned_graph.h
+++ b/mt-kahypar/datastructures/partitioned_graph.h
@@ -579,12 +579,12 @@ private:
 
   HyperedgeWeight moveFromPenalty(const HypernodeID u) const {
     ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
-    return -_incident_weight_in_part[incident_weight_index(u, partID(u))].load(std::memory_order_relaxed);
+    return _incident_weight_in_part[incident_weight_index(u, partID(u))].load(std::memory_order_relaxed);
   }
 
   HyperedgeWeight moveToBenefit(const HypernodeID u, PartitionID p) const {
     ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
-    return -_incident_weight_in_part[incident_weight_index(u, p)].load(std::memory_order_relaxed);
+    return _incident_weight_in_part[incident_weight_index(u, p)].load(std::memory_order_relaxed);
   }
 
   HyperedgeWeight incidentWeightInPart(const HypernodeID u, PartitionID p) const {
@@ -611,7 +611,7 @@ private:
     ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
     ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
     ASSERT(from != to, "The gain computation doesn't work for from = to");
-    return moveFromPenalty(u) - moveToBenefit(u, to);
+    return moveToBenefit(u, to) - moveFromPenalty(u);
   }
 
   // ! Initializes the partition of the hypergraph, if block ids are assigned with
@@ -701,7 +701,7 @@ private:
     HyperedgeWeight w = 0;
     for (HyperedgeID e : incidentEdges(u)) {
       if (!isSinglePin(e) && partID(edgeTarget(e)) == part_id) {
-        w -= edgeWeight(e);
+        w += edgeWeight(e);
       }
     }
     return w;
@@ -713,7 +713,7 @@ private:
     HyperedgeWeight w = 0;
     for (HyperedgeID e : incidentEdges(u)) {
       if (!isSinglePin(e) && partID(edgeTarget(e)) == p) {
-        w -= edgeWeight(e);
+        w += edgeWeight(e);
       }
     }
     return w;

--- a/mt-kahypar/datastructures/partitioned_hypergraph.h
+++ b/mt-kahypar/datastructures/partitioned_hypergraph.h
@@ -362,19 +362,17 @@ private:
             // substract edge weight.
             for ( const HypernodeID& pin : pins(he) ) {
               if ( pin != v && partID(pin) == block ) {
-                _gain_cache[benefit_index(pin)].sub_fetch(edge_weight, std::memory_order_relaxed);
+                _gain_cache[penalty_index(pin)].add_fetch(edge_weight, std::memory_order_relaxed);
                 break;
               }
             }
           }
 
+          _gain_cache[penalty_index(v)].add_fetch(edge_weight, std::memory_order_relaxed);
           // For all blocks contained in the connectivity set of hyperedge he
-          // we increase the the move_to_penalty for vertex v by w(e) =>
-          // move_to_penalty is than w(I(v)) - move_to_penalty(v, p) for a
-          // block p
-          _gain_cache[benefit_index(v)].sub_fetch(edge_weight, std::memory_order_relaxed);
+          // we increase the move_to_benefit for vertex v by w(e)
           for ( const PartitionID block : _connectivity_set.connectivitySet(he) ) {
-            _gain_cache[penalty_index(v, block)].add_fetch(
+            _gain_cache[benefit_index(v, block)].add_fetch(
               edge_weight, std::memory_order_relaxed);
           }
         }
@@ -386,23 +384,23 @@ private:
           const PartitionID block = partID(u);
           const HyperedgeWeight edge_weight = edgeWeight(he);
           // Since u is no longer incident to hyperedge he its contribution for decreasing
-          // the connectivity of he is shifted to vertex v => b(u) -= w(e), b(v) += w(e).
+          // the connectivity of he is shifted to vertex v
           if ( pinCountInPart(he, block) == 1 ) {
-            _gain_cache[benefit_index(u)].sub_fetch(edge_weight, std::memory_order_relaxed);
-            _gain_cache[benefit_index(v)].add_fetch(edge_weight, std::memory_order_relaxed);
+            _gain_cache[penalty_index(u)].add_fetch(edge_weight, std::memory_order_relaxed);
+            _gain_cache[penalty_index(v)].sub_fetch(edge_weight, std::memory_order_relaxed);
           }
 
+          _gain_cache[penalty_index(u)].sub_fetch(
+            edge_weight, std::memory_order_relaxed);
+          _gain_cache[penalty_index(v)].add_fetch(
+            edge_weight, std::memory_order_relaxed);
           // For all blocks contained in the connectivity set of hyperedge he
-          // we decrease the the move_to_penalty for vertex u and increase it for
-          // vertex v by w(e)
-          _gain_cache[benefit_index(u)].add_fetch(
-            edge_weight, std::memory_order_relaxed);
-          _gain_cache[benefit_index(v)].sub_fetch(
-            edge_weight, std::memory_order_relaxed);
+          // we increase the move_to_benefit for vertex v by w(e) and decrease
+          // it for vertex u by w(e)
           for ( const PartitionID block : _connectivity_set.connectivitySet(he) ) {
-            _gain_cache[penalty_index(u, block)].sub_fetch(
+            _gain_cache[benefit_index(u, block)].sub_fetch(
               edge_weight, std::memory_order_relaxed);
-            _gain_cache[penalty_index(v, block)].add_fetch(
+            _gain_cache[benefit_index(v, block)].add_fetch(
               edge_weight, std::memory_order_relaxed);
           }
         }
@@ -472,7 +470,7 @@ private:
         _pins_in_part.setPinCountInPart(he, block_of_single_pin, 1);
 
         if ( _is_gain_cache_initialized ) {
-          _gain_cache[penalty_index(
+          _gain_cache[benefit_index(
             single_vertex_of_he, block_of_single_pin)].add_fetch(
               edgeWeight(he), std::memory_order_relaxed);
         }
@@ -528,7 +526,6 @@ private:
 
   // ! Changes the block id of vertex u from block 'from' to block 'to'
   // ! Returns true, if move of vertex u to corresponding block succeeds.
-
   template<typename SuccessFunc, typename DeltaFunc>
   bool changeNodePart(const HypernodeID u,
                       PartitionID from,
@@ -636,14 +633,39 @@ private:
     return _pins_in_part.pinCountInPart(e, p);
   }
 
-  HyperedgeWeight moveFromBenefit(const HypernodeID u) const {
+  /**
+   * In the following, we define functions to derive the benefit and penalty term
+   * decribed in our publications. However, we swapped the naming of both (the benefit term
+   * is now the penalty term and vice versa) due to refactoring of the gain cache.
+   */
+
+  // ! The move from penalty term stores weight of all incident edges of u for which
+  // ! we cannot reduce their connecitivity when u is moved out of its block.
+  // ! More formally, p(u) := w({ e \in I(u) | pin_count(e, partID(u)) > 1 })
+  HyperedgeWeight moveFromPenalty(const HypernodeID u) const {
     //ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
-    return _gain_cache[benefit_index(u)].load(std::memory_order_relaxed);
+    return _gain_cache[penalty_index(u)].load(std::memory_order_relaxed);
   }
 
-  HyperedgeWeight moveToPenalty(const HypernodeID u, PartitionID p) const {
+  // ! The move to benefit term stores the weight of all incident edges of u
+  // ! for which we do not increase the connecitivity when we move u to block p.
+  // ! More formally, b(u, p) := w({ e \in I(u) | pin_count(e, p) >= 1 })
+  HyperedgeWeight moveToBenefit(const HypernodeID u, PartitionID p) const {
     //ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
-    return _gain_cache[penalty_index(u, p)].load(std::memory_order_relaxed);
+    return _gain_cache[benefit_index(u, p)].load(std::memory_order_relaxed);
+  }
+
+  // ! The gain of moving a node u from its current block to a target block to can
+  // ! be expressed as g(u, to) = b(u, to) - p(u), which is the weight of
+  // ! all incident edges of u for which we do not increase their connectivity if moved
+  // ! to block to minus the weight of all incident edges of u for which we cannot reduce
+  // ! their connectivity if u is moved out of its current block.
+  HyperedgeWeight km1Gain(const HypernodeID u, PartitionID from, PartitionID to) const {
+    unused(from);
+    //ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
+    ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
+    ASSERT(from != to, "The gain computation doesn't work for from = to");
+    return moveToBenefit(u, to) - moveFromPenalty(u);
   }
 
   void allocateGainTableIfNecessary() {
@@ -653,35 +675,37 @@ private:
     }
   }
 
-  void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& penalty_aggregator) {
-    PartitionID pu = partID(u);
-    Gain benefit = 0, incident_edges_weight = 0;
-    for (HyperedgeID e : incidentEdges(u)) {
-      HyperedgeWeight ew = edgeWeight(e);
-      if (pinCountInPart(e, pu) == 1) {
-        benefit += ew;
-      }
-      for (PartitionID i : connectivitySet(e)) {
-        penalty_aggregator[i] += ew;
-      }
-      incident_edges_weight += ew;
-    }
 
-    _gain_cache[benefit_index(u)].store(
-      benefit - incident_edges_weight, std::memory_order_relaxed);
-    for (PartitionID i = 0; i < _k; ++i) {
-      _gain_cache[penalty_index(u, i)].store(
-        penalty_aggregator[i], std::memory_order_relaxed);
-      penalty_aggregator[i] = 0;
+  // ! The move from penalty term stores weight of all incident edges of u for which
+  // ! we cannot reduce their connecitivity when u is moved out of its block.
+  // ! More formally, p(u) := w({ e \in I(u) | pin_count(e, partID(u)) > 1 })
+  HyperedgeWeight moveFromPenaltyRecomputed(const HypernodeID u) const {
+    const PartitionID p = partID(u);
+    HyperedgeWeight b = 0;
+    for (HyperedgeID e : incidentEdges(u)) {
+      if (pinCountInPart(e, p) > 1) {
+        b += edgeWeight(e);
+      }
     }
+    return b;
   }
 
-  HyperedgeWeight km1Gain(const HypernodeID u, PartitionID from, PartitionID to) const {
-    unused(from);
-    //ASSERT(_is_gain_cache_initialized, "Gain cache is not initialized");
-    ASSERT(from == partID(u), "While gain computation works for from != partID(u), such a query makes no sense");
-    ASSERT(from != to, "The gain computation doesn't work for from = to");
-    return moveFromBenefit(u) + moveToPenalty(u, to);
+  void recomputeMoveFromPenalty(const HypernodeID u) {
+    _gain_cache[penalty_index(u)].store(moveFromPenaltyRecomputed(u), std::memory_order_relaxed);
+  }
+
+  // ! Only for testing
+  // ! The move to benefit term stores the weight of all incident edges of u
+  // ! for which we do not increase the connecitivity when we move u to block p.
+  // ! More formally, b(u, p) := w({ e \in I(u) | pin_count(e, p) >= 1 })
+  HyperedgeWeight moveToBenefitRecomputed(const HypernodeID u, PartitionID p) const {
+    HyperedgeWeight w = 0;
+    for (HyperedgeID e : incidentEdges(u)) {
+      if (pinCountInPart(e, p) >= 1) {
+        w += edgeWeight(e);
+      }
+    }
+    return w;
   }
 
   // ! Initializes the partition of the hypergraph, if block ids are assigned with
@@ -698,6 +722,26 @@ private:
     return _is_gain_cache_initialized;
   }
 
+  void initializeGainCacheEntry(const HypernodeID u, vec<Gain>& benefit_aggregator) {
+    PartitionID pu = partID(u);
+    Gain penalty = 0;
+    for (const HyperedgeID& e : incidentEdges(u)) {
+      HyperedgeWeight ew = edgeWeight(e);
+      if (pinCountInPart(e, pu) > 1) {
+        penalty += ew;
+      }
+      for (const PartitionID& i : connectivitySet(e)) {
+        benefit_aggregator[i] += ew;
+      }
+    }
+
+    _gain_cache[penalty_index(u)].store(penalty, std::memory_order_relaxed);
+    for (PartitionID i = 0; i < _k; ++i) {
+      _gain_cache[benefit_index(u, i)].store(benefit_aggregator[i], std::memory_order_relaxed);
+      benefit_aggregator[i] = 0;
+    }
+  }
+
   // ! Initialize gain cache
   // ! NOTE: Requires that pin counts are already initialized and reflect the
   // ! current state of the partition
@@ -711,50 +755,45 @@ private:
     auto aggregate_contribution_of_he_for_vertex =
       [&](const PartitionID block_of_u,
           const HyperedgeID he,
-          HyperedgeWeight& l_move_from_benefit,
-          HyperedgeWeight& incident_edges_weight,
-          vec<HyperedgeWeight>& l_move_to_penalty) {
+          HyperedgeWeight& l_move_from_penalty,
+          vec<HyperedgeWeight>& l_move_to_benefit) {
       HyperedgeWeight edge_weight = edgeWeight(he);
-      if (pinCountInPart(he, block_of_u) == 1) {
-        l_move_from_benefit += edge_weight;
+      if (pinCountInPart(he, block_of_u) > 1) {
+        l_move_from_penalty += edge_weight;
       }
 
       for (const PartitionID block : connectivitySet(he)) {
-        l_move_to_penalty[block] += edge_weight;
+        l_move_to_benefit[block] += edge_weight;
       }
-      incident_edges_weight += edge_weight;
     };
 
 
 
     // Gain calculation consist of two stages
-    //  1. Compute gain of all low degree vertices sequential (with a parallel for over all vertices)
-    //  2. Compute gain of all high degree vertices parallel (with a sequential for over all high degree vertices)
-    tbb::enumerable_thread_specific< vec<HyperedgeWeight> > ets_mtp(_k, 0);
+    //  1. Compute gain of all low degree vertices sequential (iterating over all vertices in parallel)
+    //  2. Compute gain of all high degree vertices parallel (iterating over all high degree vertices sequentially)
+    tbb::enumerable_thread_specific< vec<HyperedgeWeight> > ets_mtb(_k, 0);
     std::mutex high_degree_vertex_mutex;
     parallel::scalable_vector<HypernodeID> high_degree_vertices;
 
-    // Compute gain of all low degree vertices sequential (parallel for over all vertices)
+    // Compute gain of all low degree vertices sequential (iterating over all vertices in parallel)
     tbb::parallel_for(tbb::blocked_range<HypernodeID>(HypernodeID(0), initialNumNodes()),
       [&](tbb::blocked_range<HypernodeID>& r) {
-        vec<HyperedgeWeight>& l_move_to_penalty = ets_mtp.local();
+        vec<HyperedgeWeight>& l_move_to_benefit = ets_mtb.local();
         for (HypernodeID u = r.begin(); u < r.end(); ++u) {
           if ( nodeIsEnabled(u)) {
             if ( nodeDegree(u) <= HIGH_DEGREE_THRESHOLD) {
               const PartitionID from = partID(u);
-              HyperedgeWeight incident_edges_weight = 0;
-              HyperedgeWeight l_move_from_benefit = 0;
+              HyperedgeWeight l_move_from_penalty = 0;
               for (HyperedgeID he : incidentEdges(u)) {
                 aggregate_contribution_of_he_for_vertex(from, he,
-                  l_move_from_benefit, incident_edges_weight, l_move_to_penalty);
+                  l_move_from_penalty, l_move_to_benefit);
               }
 
-              _gain_cache[benefit_index(u)].store(
-                l_move_from_benefit - incident_edges_weight, std::memory_order_relaxed);
+              _gain_cache[penalty_index(u)].store(l_move_from_penalty, std::memory_order_relaxed);
               for (PartitionID p = 0; p < _k; ++p) {
-                _gain_cache[penalty_index(u,p)].store(
-                  l_move_to_penalty[p], std::memory_order_relaxed);
-                l_move_to_penalty[p] = 0;
+                _gain_cache[benefit_index(u,p)].store(l_move_to_benefit[p], std::memory_order_relaxed);
+                l_move_to_benefit[p] = 0;
               }
             } else {
               // Collect high degree vertex for subsequent parallel gain computation
@@ -765,21 +804,19 @@ private:
         }
       });
 
-    // Compute gain of all high degree vertices parallel (sequential for over all high degree vertices)
+    // Compute gain of all high degree vertices parallel (iterating over all high degree vertices sequentially)
     for ( const HypernodeID& u : high_degree_vertices ) {
-      tbb::enumerable_thread_specific<HyperedgeWeight> ets_mfb(0);
-      tbb::enumerable_thread_specific<HyperedgeWeight> ets_iew(0);
+      tbb::enumerable_thread_specific<HyperedgeWeight> ets_mfp(0);
       const PartitionID from = partID(u);
       const HypernodeID degree_of_u = _hg->nodeDegree(u);
       tbb::parallel_for(tbb::blocked_range<HypernodeID>(ID(0), degree_of_u),
         [&](tbb::blocked_range<HypernodeID>& r) {
-        vec<HyperedgeWeight>& l_move_to_penalty = ets_mtp.local();
-        HyperedgeWeight& l_move_from_benefit = ets_mfb.local();
-        HyperedgeWeight& l_incident_edges_weight = ets_iew.local();
+        vec<HyperedgeWeight>& l_move_to_benefit = ets_mtb.local();
+        HyperedgeWeight& l_move_from_penalty = ets_mfp.local();
         size_t current_pos = r.begin();
         for ( const HyperedgeID& he : _hg->incident_nets_of(u, r.begin()) ) {
           aggregate_contribution_of_he_for_vertex(from, he,
-            l_move_from_benefit, l_incident_edges_weight, l_move_to_penalty);
+            l_move_from_penalty, l_move_to_benefit);
           ++current_pos;
           if ( current_pos == r.end() ) {
             break;
@@ -788,16 +825,15 @@ private:
       });
 
       // Aggregate thread locals to compute overall gain of the high degree vertex
-      const HyperedgeWeight benefit_term = ets_mfb.combine(std::plus<HyperedgeWeight>());
-      const HyperedgeWeight incident_edges_weight = ets_iew.combine(std::plus<HyperedgeWeight>());
-      _gain_cache[benefit_index(u)].store(benefit_term - incident_edges_weight, std::memory_order_relaxed);
+      const HyperedgeWeight penalty_term = ets_mfp.combine(std::plus<HyperedgeWeight>());
+      _gain_cache[penalty_index(u)].store(penalty_term, std::memory_order_relaxed);
       for (PartitionID p = 0; p < _k; ++p) {
-        HyperedgeWeight move_to_penalty = 0;
-        for ( auto& l_move_to_penalty : ets_mtp ) {
-          move_to_penalty += l_move_to_penalty[p];
-          l_move_to_penalty[p] = 0;
+        HyperedgeWeight move_to_benefit = 0;
+        for ( auto& l_move_to_benefit : ets_mtb ) {
+          move_to_benefit += l_move_to_benefit[p];
+          l_move_to_benefit[p] = 0;
         }
-        _gain_cache[penalty_index(u, p)].store(move_to_penalty, std::memory_order_relaxed);
+        _gain_cache[benefit_index(u, p)].store(move_to_benefit, std::memory_order_relaxed);
       }
     }
 
@@ -835,33 +871,6 @@ private:
   }
 
   // ! Only for testing
-  HyperedgeWeight moveFromBenefitRecomputed(const HypernodeID u) const {
-    const PartitionID p = partID(u);
-    HyperedgeWeight b = 0;
-    for (HyperedgeID e : incidentEdges(u)) {
-      if (pinCountInPart(e, p) > 1) {
-        b -= edgeWeight(e);
-      }
-    }
-    return b;
-  }
-
-  // ! Only for testing
-  HyperedgeWeight moveToPenaltyRecomputed(const HypernodeID u, PartitionID p) const {
-    HyperedgeWeight w = 0;
-    for (HyperedgeID e : incidentEdges(u)) {
-      if (pinCountInPart(e, p) > 0) {
-        w += edgeWeight(e);
-      }
-    }
-    return w;
-  }
-
-  void recomputeMoveFromBenefit(const HypernodeID u) {
-    _gain_cache[benefit_index(u)].store(moveFromBenefitRecomputed(u), std::memory_order_relaxed);
-  }
-
-  // ! Only for testing
   bool checkTrackedPartitionInformation() {
     bool success = true;
 
@@ -887,10 +896,10 @@ private:
 
     if ( _is_gain_cache_initialized ) {
       for (HypernodeID u : nodes()) {
-        if ( moveFromBenefit(u) != moveFromBenefitRecomputed(u) ) {
+        if ( moveFromPenalty(u) != moveFromPenaltyRecomputed(u) ) {
           LOG << "Move from benefit of hypernode" << u << "=>" <<
-              "Expected:" << V(moveFromBenefitRecomputed(u)) << ", " <<
-              "Actual:" <<  V(moveFromBenefit(u));
+              "Expected:" << V(moveFromPenaltyRecomputed(u)) << ", " <<
+              "Actual:" <<  V(moveFromPenalty(u));
           for ( const HyperedgeID& e : incidentEdges(u) ) {
             LOG << V(u) << V(partID(u)) << V(e) << V(edgeSize(e)) << V(edgeWeight(e)) << V(pinCountInPart(e, partID(u)));
           }
@@ -899,10 +908,10 @@ private:
 
         for (PartitionID i = 0; i < k(); ++i) {
           if (partID(u) != i) {
-            if ( moveToPenalty(u, i) != moveToPenaltyRecomputed(u, i) ) {
+            if ( moveToBenefit(u, i) != moveToBenefitRecomputed(u, i) ) {
               LOG << "Move to penalty of hypernode" << u << "in block" << i << "=>" <<
-                  "Expected:" << V(moveToPenaltyRecomputed(u, i)) << ", " <<
-                  "Actual:" <<  V(moveToPenalty(u, i));
+                  "Expected:" << V(moveToBenefitRecomputed(u, i)) << ", " <<
+                  "Actual:" <<  V(moveToBenefit(u, i));
               success = false;
             }
           }
@@ -1026,26 +1035,26 @@ private:
       for (const HypernodeID& u : pins(he)) {
         nodeGainAssertions(u, from);
         if (partID(u) == from) {
-          _gain_cache[benefit_index(u)].fetch_add(we, std::memory_order_relaxed);
+          _gain_cache[penalty_index(u)].fetch_sub(we, std::memory_order_relaxed);
         }
       }
     } else if (pin_count_in_from_part_after == 0) {
       for (const HypernodeID& u : pins(he)) {
         nodeGainAssertions(u, from);
-        _gain_cache[penalty_index(u, from)].fetch_sub(we, std::memory_order_relaxed);
+        _gain_cache[benefit_index(u, from)].fetch_sub(we, std::memory_order_relaxed);
       }
     }
 
     if (pin_count_in_to_part_after == 1) {
       for (const HypernodeID& u : pins(he)) {
         nodeGainAssertions(u, to);
-        _gain_cache[penalty_index(u, to)].fetch_add(we, std::memory_order_relaxed);
+        _gain_cache[benefit_index(u, to)].fetch_add(we, std::memory_order_relaxed);
       }
     } else if (pin_count_in_to_part_after == 2) {
       for (const HypernodeID& u : pins(he)) {
         nodeGainAssertions(u, to);
         if (partID(u) == to) {
-          _gain_cache[benefit_index(u)].fetch_sub(we, std::memory_order_relaxed);
+          _gain_cache[penalty_index(u)].fetch_add(we, std::memory_order_relaxed);
         }
       }
     }
@@ -1054,12 +1063,12 @@ private:
  private:
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
-  size_t benefit_index(const HypernodeID u) const {
+  size_t penalty_index(const HypernodeID u) const {
     return size_t(u) * ( _k + 1 );
   }
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
-  size_t penalty_index(const HypernodeID u, const PartitionID p) const {
+  size_t benefit_index(const HypernodeID u, const PartitionID p) const {
     return size_t(u) * ( _k + 1 )  + p + 1;
   }
 
@@ -1130,7 +1139,7 @@ private:
     ASSERT(u < initialNumNodes(), "Hypernode" << u << "does not exist");
     ASSERT(nodeIsEnabled(u), "Hypernode" << u << "is disabled");
     ASSERT(p != kInvalidPartition && p < _k);
-    ASSERT(penalty_index(u, p) < _gain_cache.size());
+    ASSERT(benefit_index(u, p) < _gain_cache.size());
   }
 
   // ! Updates pin count in part using a spinlock.
@@ -1195,12 +1204,12 @@ private:
   // ! For each hyperedge, _connectivity_set stores the set of blocks that the hyperedge spans
   ConnectivitySets _connectivity_set;
 
-  // ! For each node u, the gain cache stores k + 1 entries.
-  // ! The first entry stores the benefit term b(u) (weight of all incident hyperedges where u is the last remaining
-  // ! pin in its block) minus the weight of all incident hyperedges of u (w(I(u))).
-  // ! The remaining k entries stores for each block V_i the penalty term p(u, V_i) that stores the weight
-  // ! of all incident hyperedges of u which contains pins of block V_i
-  // ! The gain of moving a node u to block V_i can then be computed as b(u) - w(I(u)) + p(u, V_i).
+  // ! The gain of moving a node u to from its current block V_i to a target block V_j
+  // ! can be expressed as follows for the connectivity metric
+  // ! g(u, V_j) := w({ e \in I(u) | pin_count(e, V_j) >= 1 }) - w({ e \in I(u) | pin_count(e, V_i) > 1 })
+  // !            = b(u, V_j) - p(u)
+  // ! We call b(u, V_j) the benefit term and p(u) the penalty term. Our gain cache stores and maintains these
+  // ! entries for each node and block. Thus, the gain cache stores k + 1 entries per node.
   Array< CAtomic<HyperedgeWeight> > _gain_cache;
 
   // ! In order to update the pin count of a hyperedge thread-safe, a thread must acquire

--- a/mt-kahypar/partition/refinement/flows/scheduler.cpp
+++ b/mt-kahypar/partition/refinement/flows/scheduler.cpp
@@ -187,7 +187,7 @@ bool FlowRefinementScheduler::refineImpl(
          phg.isGainCacheInitialized() ) {
     phg.doParallelForAllNodes([&](const HypernodeID& hn) {
       if ( _was_moved[hn] ) {
-        phg.recomputeMoveFromBenefit(hn);
+        phg.recomputeMoveFromPenalty(hn);
         _was_moved[hn] = uint8_t(false);
       }
     });

--- a/mt-kahypar/partition/refinement/fm/global_rollback.cpp
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.cpp
@@ -191,9 +191,9 @@ namespace mt_kahypar {
     });
 
     if (update_gain_cache) {
-      // recompute moveFromBenefit values since they are potentially invalid
+      // recompute moveFromPenalty values since they are potentially invalid
       tbb::parallel_for(MoveID(0), numMoves, [&](const MoveID i) {
-        phg.recomputeMoveFromBenefit(move_order[i].node);
+        phg.recomputeMoveFromPenalty(move_order[i].node);
       });
     }
 
@@ -364,7 +364,7 @@ namespace mt_kahypar {
 
     if (update_gain_cache) {
       tbb::parallel_for(0U, numMoves, [&](const MoveID i) {
-        phg.recomputeMoveFromBenefit(move_order[i].node);
+        phg.recomputeMoveFromPenalty(move_order[i].node);
       });
     }
 
@@ -382,7 +382,7 @@ namespace mt_kahypar {
     auto recompute_move_from_benefits = [&] {
       if constexpr (update_gain_cache) {
         for (MoveID localMoveID = 0; localMoveID < sharedData.moveTracker.numPerformedMoves(); ++localMoveID) {
-          phg.recomputeMoveFromBenefit(move_order[localMoveID].node);
+          phg.recomputeMoveFromPenalty(move_order[localMoveID].node);
         }
       }
     };
@@ -414,8 +414,8 @@ namespace mt_kahypar {
 
       if constexpr (update_gain_cache) {
         const Gain gain_from_cache = phg.km1Gain(m.node, m.from, m.to); unused(gain_from_cache);
-        ASSERT(phg.moveFromBenefit(m.node) == phg.moveFromBenefitRecomputed(m.node));
-        ASSERT(phg.moveToPenalty(m.node, m.to) == phg.moveToPenaltyRecomputed(m.node, m.to));
+        ASSERT(phg.moveFromPenalty(m.node) == phg.moveFromPenaltyRecomputed(m.node));
+        ASSERT(phg.moveToBenefit(m.node, m.to) == phg.moveToBenefitRecomputed(m.node, m.to));
         ASSERT(gain == gain_from_cache);
       }
 

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
@@ -189,13 +189,13 @@ private:
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;
-    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::max();
+    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::min();
     HypernodeWeight best_to_weight = from_weight - wu;
     for (PartitionID i = 0; i < phg.k(); ++i) {
       if (i != from) {
         const HypernodeWeight to_weight = phg.partWeight(i);
         const HyperedgeWeight penalty = phg.moveToPenalty(u, i);
-        if ( ( penalty < to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
+        if ( ( penalty > to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
              to_weight + wu <= context.partition.max_part_weights[i] ) {
           to_penalty = penalty;
           to = i;
@@ -203,7 +203,7 @@ private:
         }
       }
     }
-    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) - to_penalty
+    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) + to_penalty
                                               : std::numeric_limits<HyperedgeWeight>::min();
     return std::make_pair(to, gain);
   }
@@ -216,13 +216,13 @@ private:
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;
-    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::max();
+    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::min();
     HypernodeWeight best_to_weight = from_weight - wu;
     for (PartitionID i : parts) {
       if (i != from && i != kInvalidPartition) {
         const HypernodeWeight to_weight = phg.partWeight(i);
         const HyperedgeWeight penalty = phg.moveToPenalty(u, i);
-        if ( ( penalty < to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
+        if ( ( penalty > to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
              to_weight + wu <= context.partition.max_part_weights[i] ) {
           to_penalty = penalty;
           to = i;
@@ -230,7 +230,7 @@ private:
         }
       }
     }
-    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) - to_penalty
+    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) + to_penalty
                                               : std::numeric_limits<HyperedgeWeight>::min();
     return std::make_pair(to, gain);
   }

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
@@ -80,11 +80,11 @@ public:
     PartitionID newTarget = kInvalidPartition;
 
     if (phg.k() < 4 || designatedTargetV == move.from || designatedTargetV == move.to) {
-      // moveToPenalty of designatedTargetV is affected.
+      // moveToBenefit of designatedTargetV is affected.
       // and may now be greater than that of other blocks --> recompute full
       std::tie(newTarget, gain) = computeBestTargetBlock(phg, v, pv);
     } else {
-      // moveToPenalty of designatedTargetV is not affected.
+      // moveToBenefit of designatedTargetV is not affected.
       // only move.from and move.to may be better
       std::tie(newTarget, gain) = bestOfThree(phg, v, pv, { designatedTargetV, move.from, move.to });
     }
@@ -189,21 +189,21 @@ private:
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;
-    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::min();
+    HyperedgeWeight to_benefit = std::numeric_limits<HyperedgeWeight>::min();
     HypernodeWeight best_to_weight = from_weight - wu;
     for (PartitionID i = 0; i < phg.k(); ++i) {
       if (i != from) {
         const HypernodeWeight to_weight = phg.partWeight(i);
-        const HyperedgeWeight penalty = phg.moveToPenalty(u, i);
-        if ( ( penalty > to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
+        const HyperedgeWeight penalty = phg.moveToBenefit(u, i);
+        if ( ( penalty > to_benefit || ( penalty == to_benefit && to_weight < best_to_weight ) ) &&
              to_weight + wu <= context.partition.max_part_weights[i] ) {
-          to_penalty = penalty;
+          to_benefit = penalty;
           to = i;
           best_to_weight = to_weight;
         }
       }
     }
-    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) + to_penalty
+    const Gain gain = to != kInvalidPartition ? to_benefit - phg.moveFromPenalty(u)
                                               : std::numeric_limits<HyperedgeWeight>::min();
     return std::make_pair(to, gain);
   }
@@ -216,21 +216,21 @@ private:
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;
-    HyperedgeWeight to_penalty = std::numeric_limits<HyperedgeWeight>::min();
+    HyperedgeWeight to_benefit = std::numeric_limits<HyperedgeWeight>::min();
     HypernodeWeight best_to_weight = from_weight - wu;
     for (PartitionID i : parts) {
       if (i != from && i != kInvalidPartition) {
         const HypernodeWeight to_weight = phg.partWeight(i);
-        const HyperedgeWeight penalty = phg.moveToPenalty(u, i);
-        if ( ( penalty > to_penalty || ( penalty == to_penalty && to_weight < best_to_weight ) ) &&
+        const HyperedgeWeight penalty = phg.moveToBenefit(u, i);
+        if ( ( penalty > to_benefit || ( penalty == to_benefit && to_weight < best_to_weight ) ) &&
              to_weight + wu <= context.partition.max_part_weights[i] ) {
-          to_penalty = penalty;
+          to_benefit = penalty;
           to = i;
           best_to_weight = to_weight;
         }
       }
     }
-    const Gain gain = to != kInvalidPartition ? phg.moveFromBenefit(u) + to_penalty
+    const Gain gain = to != kInvalidPartition ? to_benefit - phg.moveFromPenalty(u)
                                               : std::numeric_limits<HyperedgeWeight>::min();
     return std::make_pair(to, gain);
   }

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_delta_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_delta_strategy.h
@@ -139,12 +139,12 @@ namespace mt_kahypar {
         vertexPQs[i].decreaseKey(u, vertexPQs[i].getKey(u) - edge_weight);
       };
 
-      // gain = moveFromBenefit - moveToPenalty
+      // gain = moveToBenefit - moveFromPenalty
 
       if (pin_count_in_from_part_after == 1) {
         for (HypernodeID u : phg.pins(he)) {
           if (phg.partID(u) == from && in_search(u)) {
-            // move from benefit increased --> gain increased
+            // move to benefit increased --> gain increased
             for (PartitionID i = 0; i < k; ++i) {
               if (i != from) {
                 increase(u, i);
@@ -154,7 +154,7 @@ namespace mt_kahypar {
         }
       } else if (pin_count_in_from_part_after == 0) {
         for (HypernodeID u : phg.pins(he)) {
-          // moveToPenalty increased --> gain decreased
+          // moveToBenefit increased --> gain decreased
           if (in_search(u)) {
             decrease(u, from);
           }
@@ -163,7 +163,7 @@ namespace mt_kahypar {
 
       if (pin_count_in_to_part_after == 1) {
         for (HypernodeID u : phg.pins(he)) {
-          // moveToPenalty decreased --> gain increased
+          // moveToBenefit decreased --> gain increased
           if (in_search(u))  {
             increase(u, to);
           }

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -143,7 +143,7 @@ namespace mt_kahypar {
            hypergraph.isGainCacheInitialized() ) {
       auto recompute = [&](size_t j) {
         if ( _active_node_was_moved[j] ) {
-          hypergraph.recomputeMoveFromBenefit(_active_nodes[j]);
+          hypergraph.recomputeMoveFromPenalty(_active_nodes[j]);
           _active_node_was_moved[j] = uint8_t(false);
         }
       };

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -97,7 +97,6 @@ namespace mt_kahypar {
   bool LabelPropagationRefiner<GainPolicy>::labelPropagationRound(
                               PartitionedHypergraph& hypergraph,
                               NextActiveNodes& next_active_nodes) {
-
     _visited_he.reset();
     _next_active.reset();
     // This function is passed as lambda to the changeNodePart function and used

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -98,6 +98,7 @@ class LabelPropagationRefiner final : public IRefiner {
 
         Gain delta_before = _gain.localDelta();
         bool changed_part = changeNodePart(hypergraph, hn, from, to, objective_delta);
+        is_moved = true;
         if (changed_part) {
           // In case the move to block 'to' was successful, we verify that the "real" gain
           // of the move is either equal to our computed gain or if not, still improves
@@ -125,7 +126,6 @@ class LabelPropagationRefiner final : public IRefiner {
             if ( _next_active.compare_and_set_to_true(hn) ) {
               next_active_nodes.stream(hn);
             }
-            is_moved = true;
           } else {
             DBG << "Revert move of hypernode" << hn << "from block" << from << "to block" << to
                 << "( Expected Gain:" << best_move.gain << ", Real Gain:" << move_delta << ")";

--- a/mt-kahypar/partition/registries/register_memory_pool.cpp
+++ b/mt-kahypar/partition/registries/register_memory_pool.cpp
@@ -117,11 +117,9 @@ namespace mt_kahypar {
                                   ds::ConnectivitySets::num_elements(num_hyperedges, context.partition.k),
                                   sizeof(ds::ConnectivitySets::UnsafeBlock));
         if ( context.refinement.fm.algorithm != FMAlgorithm::do_nothing ) {
-          pool.register_memory_chunk("Refinement", "move_to_penalty",
+          pool.register_memory_chunk("Refinement", "gain_cache",
                                     static_cast<size_t>(num_hypernodes) * ( context.partition.k + 1 ),
                                     sizeof(CAtomic<HyperedgeWeight>));
-          pool.register_memory_chunk("Refinement", "move_from_penalty",
-                                    num_hypernodes, sizeof(CAtomic<HyperedgeWeight>));
         }
         pool.register_memory_chunk("Refinement", "pin_count_update_ownership",
                                   num_hyperedges, sizeof(SpinLock));

--- a/tests/datastructures/delta_partitioned_graph_test.cc
+++ b/tests/datastructures/delta_partitioned_graph_test.cc
@@ -75,7 +75,7 @@ class ADeltaPartitionedGraph : public Test {
       if (block != delta_phg.partID(hn)) {
         ASSERT_EQ(expected_penalties[block], delta_phg.km1Gain(hn, delta_phg.partID(hn), block)) << V(hn) << "; " << V(block);
       } else {
-        ASSERT_EQ(delta_phg.moveToPenalty(hn, block), delta_phg.moveFromBenefit(hn)) << V(hn) << "; " << V(block);
+        ASSERT_EQ(delta_phg.moveToBenefit(hn, block), delta_phg.moveFromPenalty(hn)) << V(hn) << "; " << V(block);
       }
     }
   }

--- a/tests/datastructures/delta_partitioned_hypergraph_test.cc
+++ b/tests/datastructures/delta_partitioned_hypergraph_test.cc
@@ -68,11 +68,11 @@ class ADeltaPartitionedHypergraph : public Test {
     }
   }
 
-  void verifyMoveToPenalty(const HypernodeID hn,
+  void verifymoveToBenefit(const HypernodeID hn,
                            const std::vector<HypernodeID>& expected_penalties) {
     ASSERT(expected_penalties.size() == static_cast<size_t>(phg.k()));
     for (PartitionID block = 0; block < 3; ++block) {
-      ASSERT_EQ(expected_penalties[block], delta_phg.moveToPenalty(hn, block)) << V(hn) << V(block);
+      ASSERT_EQ(expected_penalties[block], delta_phg.moveToBenefit(hn, block)) << V(hn) << V(block);
     }
   }
 
@@ -89,24 +89,24 @@ TEST_F(ADeltaPartitionedHypergraph, VerifiesInitialPinCounts) {
   verifyPinCounts(3, { 1, 0, 2 });
 }
 
-TEST_F(ADeltaPartitionedHypergraph, VerifyInitialMoveFromBenefits) {
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(1));
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(2));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(5));
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(6));
+TEST_F(ADeltaPartitionedHypergraph, VerifyInitialmoveFromPenaltys) {
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(0));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(1));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(2));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(3));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(4));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(5));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(6));
 }
 
 TEST_F(ADeltaPartitionedHypergraph, VerifyInitialMoveToPenalties) {
-  verifyMoveToPenalty(0, { 2, 1, 0 });
-  verifyMoveToPenalty(1, { 1, 1, 0 });
-  verifyMoveToPenalty(2, { 2, 0, 1 });
-  verifyMoveToPenalty(3, { 1, 2, 1 });
-  verifyMoveToPenalty(4, { 1, 2, 1 });
-  verifyMoveToPenalty(5, { 1, 0, 1 });
-  verifyMoveToPenalty(6, { 1, 1, 2 });
+  verifymoveToBenefit(0, { 2, 1, 0 });
+  verifymoveToBenefit(1, { 1, 1, 0 });
+  verifymoveToBenefit(2, { 2, 0, 1 });
+  verifymoveToBenefit(3, { 1, 2, 1 });
+  verifymoveToBenefit(4, { 1, 2, 1 });
+  verifymoveToBenefit(5, { 1, 0, 1 });
+  verifymoveToBenefit(6, { 1, 1, 2 });
 }
 TEST_F(ADeltaPartitionedHypergraph, MovesAVertex1) {
   delta_phg.changeNodePartWithGainCacheUpdate(1, 0, 1, 1000);
@@ -117,14 +117,14 @@ TEST_F(ADeltaPartitionedHypergraph, MovesAVertex1) {
   verifyPinCounts(1, { 1, 3, 0 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(0));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(3));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(4));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(0, { 2, 1, 0 });
-  verifyMoveToPenalty(3, { 1, 2, 1 });
-  verifyMoveToPenalty(4, { 1, 2, 1 });
+  verifymoveToBenefit(0, { 2, 1, 0 });
+  verifymoveToBenefit(3, { 1, 2, 1 });
+  verifymoveToBenefit(4, { 1, 2, 1 });
 }
 
 TEST_F(ADeltaPartitionedHypergraph, MovesAVertex2) {
@@ -137,16 +137,16 @@ TEST_F(ADeltaPartitionedHypergraph, MovesAVertex2) {
   verifyPinCounts(3, { 1, 1, 1 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(2));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(5));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(2));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(3));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(4));
+  ASSERT_EQ(0, delta_phg.moveFromPenalty(5));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(2, { 2, 1, 1 });
-  verifyMoveToPenalty(3, { 1, 2, 0 });
-  verifyMoveToPenalty(4, { 1, 2, 0 });
-  verifyMoveToPenalty(5, { 1, 1, 1 });
+  verifymoveToBenefit(2, { 2, 1, 1 });
+  verifymoveToBenefit(3, { 1, 2, 0 });
+  verifymoveToBenefit(4, { 1, 2, 0 });
+  verifymoveToBenefit(5, { 1, 1, 1 });
 }
 
 TEST_F(ADeltaPartitionedHypergraph, MovesSeveralVertices) {
@@ -167,19 +167,19 @@ TEST_F(ADeltaPartitionedHypergraph, MovesSeveralVertices) {
   verifyPinCounts(3, { 0, 3, 0 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(-1, delta_phg.moveFromBenefit(1));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(0));
+  ASSERT_EQ(1, delta_phg.moveFromPenalty(1));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(3));
+  ASSERT_EQ(2, delta_phg.moveFromPenalty(4));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(0, { 2, 2, 0 });
-  verifyMoveToPenalty(1, { 1, 1, 0 });
-  verifyMoveToPenalty(2, { 1, 2, 0 });
-  verifyMoveToPenalty(3, { 1, 2, 0 });
-  verifyMoveToPenalty(4, { 1, 2, 0 });
-  verifyMoveToPenalty(5, { 0, 1, 0 });
-  verifyMoveToPenalty(6, { 0, 2, 0 });
+  verifymoveToBenefit(0, { 2, 2, 0 });
+  verifymoveToBenefit(1, { 1, 1, 0 });
+  verifymoveToBenefit(2, { 1, 2, 0 });
+  verifymoveToBenefit(3, { 1, 2, 0 });
+  verifymoveToBenefit(4, { 1, 2, 0 });
+  verifymoveToBenefit(5, { 0, 1, 0 });
+  verifymoveToBenefit(6, { 0, 2, 0 });
 }
 
 } // namespace ds

--- a/tests/datastructures/delta_partitioned_hypergraph_test.cc
+++ b/tests/datastructures/delta_partitioned_hypergraph_test.cc
@@ -90,23 +90,23 @@ TEST_F(ADeltaPartitionedHypergraph, VerifiesInitialPinCounts) {
 }
 
 TEST_F(ADeltaPartitionedHypergraph, VerifyInitialMoveFromBenefits) {
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(1));
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(2));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(4));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(5));
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(6));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(0));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(1));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(2));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(5));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(6));
 }
 
 TEST_F(ADeltaPartitionedHypergraph, VerifyInitialMoveToPenalties) {
-  verifyMoveToPenalty(0, { 0, 1, 2 });
-  verifyMoveToPenalty(1, { 0, 0, 1 });
-  verifyMoveToPenalty(2, { 0, 2, 1 });
-  verifyMoveToPenalty(3, { 1, 0, 1 });
-  verifyMoveToPenalty(4, { 1, 0, 1 });
-  verifyMoveToPenalty(5, { 0, 1, 0 });
-  verifyMoveToPenalty(6, { 1, 1, 0 });
+  verifyMoveToPenalty(0, { 2, 1, 0 });
+  verifyMoveToPenalty(1, { 1, 1, 0 });
+  verifyMoveToPenalty(2, { 2, 0, 1 });
+  verifyMoveToPenalty(3, { 1, 2, 1 });
+  verifyMoveToPenalty(4, { 1, 2, 1 });
+  verifyMoveToPenalty(5, { 1, 0, 1 });
+  verifyMoveToPenalty(6, { 1, 1, 2 });
 }
 TEST_F(ADeltaPartitionedHypergraph, MovesAVertex1) {
   delta_phg.changeNodePartWithGainCacheUpdate(1, 0, 1, 1000);
@@ -117,14 +117,14 @@ TEST_F(ADeltaPartitionedHypergraph, MovesAVertex1) {
   verifyPinCounts(1, { 1, 3, 0 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(0));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(0, { 0, 1, 2 });
-  verifyMoveToPenalty(3, { 1, 0, 1 });
-  verifyMoveToPenalty(4, { 1, 0, 1 });
+  verifyMoveToPenalty(0, { 2, 1, 0 });
+  verifyMoveToPenalty(3, { 1, 2, 1 });
+  verifyMoveToPenalty(4, { 1, 2, 1 });
 }
 
 TEST_F(ADeltaPartitionedHypergraph, MovesAVertex2) {
@@ -137,16 +137,16 @@ TEST_F(ADeltaPartitionedHypergraph, MovesAVertex2) {
   verifyPinCounts(3, { 1, 1, 1 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(2));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(4));
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(5));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(2));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(0, delta_phg.moveFromBenefit(5));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(2, { 0, 1, 1 });
-  verifyMoveToPenalty(3, { 1, 0, 2 });
-  verifyMoveToPenalty(4, { 1, 0, 2 });
-  verifyMoveToPenalty(5, { 0, 0, 0 });
+  verifyMoveToPenalty(2, { 2, 1, 1 });
+  verifyMoveToPenalty(3, { 1, 2, 0 });
+  verifyMoveToPenalty(4, { 1, 2, 0 });
+  verifyMoveToPenalty(5, { 1, 1, 1 });
 }
 
 TEST_F(ADeltaPartitionedHypergraph, MovesSeveralVertices) {
@@ -167,19 +167,19 @@ TEST_F(ADeltaPartitionedHypergraph, MovesSeveralVertices) {
   verifyPinCounts(3, { 0, 3, 0 });
 
   // Verify Move From Benefit
-  ASSERT_EQ(1, delta_phg.moveFromBenefit(0));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(1));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(3));
-  ASSERT_EQ(0, delta_phg.moveFromBenefit(4));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(0));
+  ASSERT_EQ(-1, delta_phg.moveFromBenefit(1));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(3));
+  ASSERT_EQ(-2, delta_phg.moveFromBenefit(4));
 
   // Verify Move To Penalty
-  verifyMoveToPenalty(0, { 0, 0, 2 });
-  verifyMoveToPenalty(1, { 0, 0, 1 });
-  verifyMoveToPenalty(2, { 1, 0, 2 });
-  verifyMoveToPenalty(3, { 1, 0, 2 });
-  verifyMoveToPenalty(4, { 1, 0, 2 });
-  verifyMoveToPenalty(5, { 1, 0, 1 });
-  verifyMoveToPenalty(6, { 2, 0, 2 });
+  verifyMoveToPenalty(0, { 2, 2, 0 });
+  verifyMoveToPenalty(1, { 1, 1, 0 });
+  verifyMoveToPenalty(2, { 1, 2, 0 });
+  verifyMoveToPenalty(3, { 1, 2, 0 });
+  verifyMoveToPenalty(4, { 1, 2, 0 });
+  verifyMoveToPenalty(5, { 0, 1, 0 });
+  verifyMoveToPenalty(6, { 0, 2, 0 });
 }
 
 } // namespace ds

--- a/tests/datastructures/dynamic_partitioned_hypergraph_test.cc
+++ b/tests/datastructures/dynamic_partitioned_hypergraph_test.cc
@@ -222,14 +222,14 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyIfWeRestoreSingle
   auto removed_hyperedges = hypergraph.removeSinglePinAndParallelHyperedges();
 
   initializePartition();
-    partitioned_hypergraph.initializeGainCache();
-  ASSERT_EQ(1, partitioned_hypergraph.moveFromBenefit(0));
+  partitioned_hypergraph.initializeGainCache();
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(0));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
   partitioned_hypergraph.restoreSinglePinAndParallelNets(removed_hyperedges);
-  ASSERT_EQ(2, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(0));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
   verifyAllKm1GainValues();
 }
 
@@ -246,19 +246,19 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyIfWeRestoreSingle
 
   initializePartition();
     partitioned_hypergraph.initializeGainCache();
-  ASSERT_EQ(2, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(2, partitioned_hypergraph.moveFromBenefit(6));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(6));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
   partitioned_hypergraph.restoreSinglePinAndParallelNets(removed_hyperedges);
-  ASSERT_EQ(3, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(3, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(3, partitioned_hypergraph.moveFromBenefit(6));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(3, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(6));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
   verifyAllKm1GainValues();
 }
 
@@ -325,11 +325,11 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyAfterUncontractio
   initializePartition();
     partitioned_hypergraph.initializeGainCache();
   partitioned_hypergraph.uncontract(hierarchy.back().back());
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
+  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(0));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(1, partitioned_hypergraph.moveFromBenefit(2));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(2, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(2, 1));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(2, 2));
   verifyAllKm1GainValues();
 }
@@ -347,7 +347,7 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyAfterUncontractio
   VersionedBatchVector hierarchy = hypergraph.createBatchUncontractionHierarchy(2);
 
   initializePartition();
-    partitioned_hypergraph.initializeGainCache();
+  partitioned_hypergraph.initializeGainCache();
 
   while ( !hierarchy.empty() ) {
     BatchVector& batches = hierarchy.back();
@@ -359,27 +359,27 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyAfterUncontractio
     hierarchy.pop_back();
   }
 
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 1));
+  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(1, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(1, 2));
-  ASSERT_EQ(1, partitioned_hypergraph.moveFromBenefit(2));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(2, 1));
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(1, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(1, 2));
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(2, 1));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(2, 2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(3));
+  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(3));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(3, 0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(3, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(4));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(3, 1));
+  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(4));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(4, 0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(4, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(5));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(5, 0));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(5, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(6));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(4, 1));
+  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(5));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(5, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(5, 1));
+  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(6));
   ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
   verifyAllKm1GainValues();
 }
 

--- a/tests/datastructures/dynamic_partitioned_hypergraph_test.cc
+++ b/tests/datastructures/dynamic_partitioned_hypergraph_test.cc
@@ -223,13 +223,13 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyIfWeRestoreSingle
 
   initializePartition();
   partitioned_hypergraph.initializeGainCache();
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 2));
   partitioned_hypergraph.restoreSinglePinAndParallelNets(removed_hyperedges);
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 2));
   verifyAllKm1GainValues();
 }
 
@@ -246,19 +246,19 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyIfWeRestoreSingle
 
   initializePartition();
     partitioned_hypergraph.initializeGainCache();
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(6));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToBenefit(0, 2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromPenalty(6));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToBenefit(6, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(6, 1));
   partitioned_hypergraph.restoreSinglePinAndParallelNets(removed_hyperedges);
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveFromBenefit(6));
-  ASSERT_EQ(2, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToBenefit(0, 2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveFromPenalty(6));
+  ASSERT_EQ(2, partitioned_hypergraph.moveToBenefit(6, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(6, 1));
   verifyAllKm1GainValues();
 }
 
@@ -325,12 +325,12 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyAfterUncontractio
   initializePartition();
     partitioned_hypergraph.initializeGainCache();
   partitioned_hypergraph.uncontract(hierarchy.back().back());
-  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(2, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(2, 2));
+  ASSERT_EQ(2, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(0, 2));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(2, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(2, 2));
   verifyAllKm1GainValues();
 }
 
@@ -359,27 +359,27 @@ TEST_F(ADynamicPartitionedHypergraph, UpdatesGainCacheCorrectlyAfterUncontractio
     hierarchy.pop_back();
   }
 
-  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(0, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(0, 2));
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(1));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(1, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(1, 2));
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(2));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(2, 1));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(2, 2));
-  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(3));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(3, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(3, 1));
-  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(4));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(4, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(4, 1));
-  ASSERT_EQ(-1, partitioned_hypergraph.moveFromBenefit(5));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(5, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(5, 1));
-  ASSERT_EQ(-2, partitioned_hypergraph.moveFromBenefit(6));
-  ASSERT_EQ(1, partitioned_hypergraph.moveToPenalty(6, 0));
-  ASSERT_EQ(0, partitioned_hypergraph.moveToPenalty(6, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveFromPenalty(0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(0, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(0, 2));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(1));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(1, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(1, 2));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(2));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(2, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(2, 2));
+  ASSERT_EQ(2, partitioned_hypergraph.moveFromPenalty(3));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(3, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(3, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveFromPenalty(4));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(4, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(4, 1));
+  ASSERT_EQ(1, partitioned_hypergraph.moveFromPenalty(5));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(5, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(5, 1));
+  ASSERT_EQ(2, partitioned_hypergraph.moveFromPenalty(6));
+  ASSERT_EQ(1, partitioned_hypergraph.moveToBenefit(6, 0));
+  ASSERT_EQ(0, partitioned_hypergraph.moveToBenefit(6, 1));
   verifyAllKm1GainValues();
 }
 

--- a/tests/datastructures/gain_updates_test.cc
+++ b/tests/datastructures/gain_updates_test.cc
@@ -55,8 +55,8 @@ TEST(GainUpdates, Example1) {
 
     phg.initializeGainCache();
   ASSERT_EQ(phg.km1Gain(0, phg.partID(0), 1), -1);
-  ASSERT_EQ(phg.moveFromBenefit(0), 1);
-  ASSERT_EQ(phg.moveToPenalty(0, 1), 2);
+  ASSERT_EQ(phg.moveFromBenefit(0), -2);
+  ASSERT_EQ(phg.moveToPenalty(0, 1), 1);
 
   ASSERT_EQ(phg.km1Gain(2, phg.partID(2), 0), -1);
 

--- a/tests/datastructures/gain_updates_test.cc
+++ b/tests/datastructures/gain_updates_test.cc
@@ -55,8 +55,8 @@ TEST(GainUpdates, Example1) {
 
     phg.initializeGainCache();
   ASSERT_EQ(phg.km1Gain(0, phg.partID(0), 1), -1);
-  ASSERT_EQ(phg.moveFromBenefit(0), -2);
-  ASSERT_EQ(phg.moveToPenalty(0, 1), 1);
+  ASSERT_EQ(phg.moveFromPenalty(0), 2);
+  ASSERT_EQ(phg.moveToBenefit(0, 1), 1);
 
   ASSERT_EQ(phg.km1Gain(2, phg.partID(2), 0), -1);
 
@@ -68,7 +68,7 @@ TEST(GainUpdates, Example1) {
 
     phg.changeNodePartWithGainCacheUpdate(8, 0, 1);
 
-  phg.recomputeMoveFromBenefit(8);  // nodes are allowed to move once before moveFromBenefit must be recomputed
+  phg.recomputeMoveFromPenalty(8);  // nodes are allowed to move once before moveFromPenalty must be recomputed
   ASSERT_EQ(phg.km1Gain(8, 1, 0), 2);
 
   ASSERT_EQ(phg.km1Gain(6, 0, 1), 0);

--- a/tests/partition/refinement/rebalance_test.cc
+++ b/tests/partition/refinement/rebalance_test.cc
@@ -79,7 +79,7 @@ TEST(RebalanceTests, FindsMoves) {
 
   for (Move& m : moves_to_empty_blocks) {
     ASSERT_EQ(phg.km1Gain(m.node, m.from, m.to), m.gain);
-    Gain recomputed_gain = phg.moveFromBenefitRecomputed(m.node) + phg.moveToPenaltyRecomputed(m.node, m.to);
+    Gain recomputed_gain = phg.moveToBenefitRecomputed(m.node, m.to) - phg.moveFromPenaltyRecomputed(m.node);
     if (recomputed_gain == 0) {
       ASSERT_TRUE([&]() {
         for (HyperedgeID e : phg.incidentEdges(m.node)) {

--- a/tests/partition/refinement/rebalance_test.cc
+++ b/tests/partition/refinement/rebalance_test.cc
@@ -79,7 +79,7 @@ TEST(RebalanceTests, FindsMoves) {
 
   for (Move& m : moves_to_empty_blocks) {
     ASSERT_EQ(phg.km1Gain(m.node, m.from, m.to), m.gain);
-    Gain recomputed_gain = phg.moveFromBenefitRecomputed(m.node) - phg.moveToPenaltyRecomputed(m.node, m.to);
+    Gain recomputed_gain = phg.moveFromBenefitRecomputed(m.node) + phg.moveToPenaltyRecomputed(m.node, m.to);
     if (recomputed_gain == 0) {
       ASSERT_TRUE([&]() {
         for (HyperedgeID e : phg.incidentEdges(m.node)) {


### PR DESCRIPTION
The gain of a node move is g(u,V_j) = b(u) - w(I(u)) + p(u,V_j). Before this change, we stored the w(I(u)) and p(u,V_j) terms interleaved in one array and the b(u) terms seperately. Thus, the gain cache used k + 2 entries per node. In this change, we store all entries in one array and additionally store b(u) - w(i(u)) in one memory location instead of storing both seperately. This reduces the memory consumption of the gain cache from k + 2 to k + 1 entries per node. 