### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR for the module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project(KaHyPar CXX C)
 set(PROJECT_VENDOR "Tobias Heuer")


### PR DESCRIPTION
The CMake modules path is not set correctly when importing Mt-KaHyPar with CMake's `add_subdirectory(...)` command. This is because `${CMAKE_SOURCE_DIR}` resolves to the root of the parent project.

This MR fixes this by using `${CMAKE_CURRENT_SOURCE_DIR}` instead.