### PR TITLE
Use portable "cmake --build" command in custom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,13 +315,14 @@ add_subdirectory(tests)
 add_subdirectory(mt-kahypar)
 
 add_custom_target(MtKaHyPar
-  COMMAND $(MAKE) MtKaHyParDefault
-  COMMAND $(MAKE) MtKaHyParQuality
-  COMMAND $(MAKE) MtKaHyParGraph
-  COMMAND $(MAKE) MtKaHyParGraphQuality
-  COMMAND $(MAKE) MtKaHyParWrapper)
+  COMMAND ${CMAKE_COMMAND} --build . --target MtKaHyParDefault
+  COMMAND ${CMAKE_COMMAND} --build . --target MtKaHyParQuality
+  COMMAND ${CMAKE_COMMAND} --build . --target MtKaHyParGraph
+  COMMAND ${CMAKE_COMMAND} --build . --target MtKaHyParGraphQuality
+  COMMAND ${CMAKE_COMMAND} --build . --target MtKaHyParWrapper)
 
 add_custom_target(mt_kahypar_tests
-  COMMAND $(MAKE) mt_kahypar_fast_tests
-  COMMAND $(MAKE) mt_kahypar_strong_tests
-  COMMAND $(MAKE) mt_kahypar_graph_tests)
+  COMMAND ${CMAKE_COMMAND} --build . --target mt_kahypar_fast_tests
+  COMMAND ${CMAKE_COMMAND} --build . --target mt_kahypar_strong_tests
+  COMMAND ${CMAKE_COMMAND} --build . --target mt_kahypar_graph_tests)
+


### PR DESCRIPTION
The `$(MAKE)` in the custom target leads to problems when building with ninja:
```
CMake Error:
  Running

   '/usr/bin/ninja-build' '-C' '/home/sebastian/git/mt-kahypar/build' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:164: bad $-escape (literal $ must be written as $$)
    COMMAND = cd /home/sebastian/git/mt-kahypar/build && $(MAKE) MtKaHyPar...
                                                         ^ near here
```

This PR changes it to the more portable `cmake --build` command which selects the appropriate build command.