### PR TITLE
CI: Specify Ubuntu version of runner explicitly

### DIFF
--- a/.github/workflows/mt_kahypar_ci.yml
+++ b/.github/workflows/mt_kahypar_ci.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   mt_kahypar_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       BOOST_ROOT : "/usr/local/share/boost/1.72.0"
       CI_ACTIVE : 1
@@ -47,7 +47,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
   mt_kahypar_integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       BOOST_ROOT : "/usr/local/share/boost/1.72.0"
       CI_ACTIVE : 1


### PR DESCRIPTION
This change specifies the runner version explicitly to be `ubuntu-20.04`.

GitHub has changed `ubuntu-latest` to be an alias of `ubuntu-22.04`, which broke the current workflow.
See [their announcement][1].

[1]: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/