### PR TITLE
CMake Options for Disabling Thread Pinning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(KAHYPAR_DOWNLOAD_BOOST
 option(KAHYPAR_DOWNLOAD_TBB
   "Download TBB automatically." OFF)
 
-option(KAHYPAR_ENFORCE_MINMUM_TBB_VERSION
+option(KAHYPAR_ENFORCE_MINIMUM_TBB_VERSION
   "Enforces the minimum required TBB version." ON)
 
 option(KAHYPAR_USE_GCOV
@@ -65,6 +65,9 @@ option(KAHYPAR_CI_BUILD
 option(KAHYPAR_ADD_ADDRESS_SANITIZER
   "Adds address sanitizer to compile options." ON)
 
+  option(KAHYPAR_ENABLE_THREAD_PINNING
+    "Enables thread pinning in Mt-KaHyPar." ON)
+
 if(KAHYPAR_DISABLE_ASSERTIONS)
   add_compile_definitions(KAHYPAR_DISABLE_ASSERTIONS)
 endif(KAHYPAR_DISABLE_ASSERTIONS)
@@ -96,6 +99,10 @@ endif(KAHYPAR_USE_64_BIT_IDS)
 if(KAHYPAR_TRAVIS_BUILD)
   add_compile_definitions(KAHYPAR_TRAVIS_BUILD)
 endif(KAHYPAR_TRAVIS_BUILD)
+
+if(KAHYPAR_ENABLE_THREAD_PINNING)
+  add_compile_definitions(KAHYPAR_ENABLE_THREAD_PINNING)
+endif(KAHYPAR_ENABLE_THREAD_PINNING)
 
 if(KAHYPAR_DOWNLOAD_BOOST)
   execute_process(COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/scripts/download_boost.cmake)

--- a/mt-kahypar/parallel/thread_pinning_observer.h
+++ b/mt-kahypar/parallel/thread_pinning_observer.h
@@ -73,7 +73,12 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
     if ( _cpus.size() == 1 ) {
       _cpus.push_back(HwTopology::instance().get_backup_cpu(_numa_node, _cpus[0]));
     }
-    observe(true);
+
+    #ifdef KAHYPAR_ENABLE_THREAD_PINNING
+    #ifndef KAHYPAR_LIBRARY_MODE
+    observe(true); // Enable thread pinning
+    #endif
+    #endif
   }
 
   // Observer is pinned to the global task arena and is reponsible for
@@ -89,7 +94,12 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
     if ( _cpus.size() == 1 ) {
       _cpus.push_back(HwTopology::instance().get_backup_cpu(0, _cpus[0]));
     }
-    observe(true);
+
+    #ifdef KAHYPAR_ENABLE_THREAD_PINNING
+    #ifndef KAHYPAR_LIBRARY_MODE
+    observe(true); // Enable thread pinning
+    #endif
+    #endif
   }
 
 
@@ -110,7 +120,7 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
     const int slot = tbb::this_task_arena::current_thread_index();
     ASSERT(static_cast<size_t>(slot) < _cpus.size(), V(slot) << V(_cpus.size()));
 
-    if ( slot >= _cpus.size() ) {
+    if ( slot >= static_cast<int>(_cpus.size()) ) {
       ERROR("Thread" << std::this_thread::get_id() << "entered the global task arena"
         << "in a slot that should not exist (Slot =" << slot << ", Max Slots =" <<_cpus.size()
         << ", slots are 0-indexed). This bug only occurs in older versions of TBB."


### PR DESCRIPTION
- CMake Options for disabling thread pinning
- Disabling thread pinning in library interface per default