### PR TITLE
FM refactoring and compile times reduction

### DIFF
--- a/mt-kahypar/CMakeLists.txt
+++ b/mt-kahypar/CMakeLists.txt
@@ -1,6 +1,6 @@
+add_subdirectory(partition)
 add_subdirectory(datastructures)
 add_subdirectory(io)
-add_subdirectory(partition)
 add_subdirectory(utils)
 
 foreach(modtarget IN LISTS PARTITIONING_SUITE_TARGETS)

--- a/mt-kahypar/definitions.h
+++ b/mt-kahypar/definitions.h
@@ -110,26 +110,12 @@ using TypeTraitsList = kahypar::meta::Typelist<StaticHypergraphTypeTraits
   ENABLE_HIGHEST_QUALITY(template class C<DynamicPartitionedHypergraph>;)        \
   ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(template class C<DynamicPartitionedGraph>;)
 
-#define INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS(C)                            \
-  template class C(StaticHypergraphTypeTraits);                                \
-  ENABLE_GRAPHS(template class C(StaticGraphTypeTraits);)                      \
-  ENABLE_HIGHEST_QUALITY(template class C(DynamicHypergraphTypeTraits);)        \
-  ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(template class C(DynamicGraphTypeTraits);)  \
-  ENABLE_LARGE_K(template class C(LargeKHypergraphTypeTraits);)
-
 #define INSTANTIATE_CLASS_WITH_TYPE_TRAITS(C)                                   \
   template class C<StaticHypergraphTypeTraits>;                                 \
   ENABLE_GRAPHS(template class C<StaticGraphTypeTraits>;)                       \
   ENABLE_HIGHEST_QUALITY(template class C<DynamicHypergraphTypeTraits>;)         \
   ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(template class C<DynamicGraphTypeTraits>;)   \
   ENABLE_LARGE_K(template class C<LargeKHypergraphTypeTraits>;)
-
-#define INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, Other)            \
-  template class C(StaticHypergraphTypeTraits, Other);                                \
-  ENABLE_GRAPHS(template class C(StaticGraphTypeTraits, Other);)                      \
-  ENABLE_HIGHEST_QUALITY(template class C(DynamicHypergraphTypeTraits, Other);)        \
-  ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(template class C(DynamicGraphTypeTraits, Other);)  \
-  ENABLE_LARGE_K(template class C(LargeKHypergraphTypeTraits, Other);)
 
 
 using HighResClockTimepoint = std::chrono::time_point<std::chrono::high_resolution_clock>;

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -406,11 +406,6 @@ namespace mt_kahypar {
              po::value<size_t>((initial_partitioning ? &context.initial_partitioning.refinement.fm.multitry_rounds :
                                 &context.refinement.fm.multitry_rounds))->value_name("<size_t>")->default_value(10),
              "Number of FM rounds within one level of the multilevel hierarchy.")
-            ((initial_partitioning ? "i-r-fm-perform-moves-global" : "r-fm-perform-moves-global"),
-             po::value<bool>((initial_partitioning ? &context.initial_partitioning.refinement.fm.perform_moves_global :
-                              &context.refinement.fm.perform_moves_global))->value_name("<bool>")->default_value(false),
-             "If true, then all moves performed during FM are immediately visible to other searches.\n"
-             "Otherwise, only move sequences that yield an improvement are applied to the global view of the partition.")
             ((initial_partitioning ? "i-r-fm-seed-nodes" : "r-fm-seed-nodes"),
              po::value<size_t>((initial_partitioning ? &context.initial_partitioning.refinement.fm.num_seed_nodes :
                                 &context.refinement.fm.num_seed_nodes))->value_name("<size_t>")->default_value(25),

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -120,7 +120,6 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " sync_lp_use_active_node_set=" << context.refinement.deterministic_refinement.use_active_node_set;
     oss << " fm_algorithm=" << context.refinement.fm.algorithm
         << " fm_multitry_rounds=" << context.refinement.fm.multitry_rounds
-        << " fm_perform_moves_global=" << std::boolalpha << context.refinement.fm.perform_moves_global
         << " fm_rollback_parallel=" << std::boolalpha << context.refinement.fm.rollback_parallel
         << " fm_rollback_sensitive_to_num_moves=" << std::boolalpha << context.refinement.fm.iter_moves_on_recalc
         << " fm_rollback_balance_violation_factor=" << context.refinement.fm.rollback_balance_violation_factor

--- a/mt-kahypar/macros.h
+++ b/mt-kahypar/macros.h
@@ -59,7 +59,7 @@
   template<bool T = EXPR>                   \
   std::enable_if_t<!T, TYPE>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && defined(NDEBUG)
 #define MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE __attribute__ ((always_inline)) inline
 #else
 #define MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE

--- a/mt-kahypar/macros.h
+++ b/mt-kahypar/macros.h
@@ -121,6 +121,9 @@
 
 // In windows unisgned long != size_t
 #define UL(X) (size_t) X
+#ifdef STR
+#undef STR
+#endif
 #define STR(X) std::to_string(X)
 #define STREAM2STR(X) static_cast<std::stringstream>(X).str();
 
@@ -133,6 +136,9 @@
 #define BOLD "\033[1m"
 #define END "\033[0m"
 #define INFO(msg) LOG << CYAN << "[INFO]" << END << msg
+#ifdef WARNING
+#undef WARNING
+#endif
 #define WARNING(msg) LOG << YELLOW << "[WARNING]" << END << msg
 #define ERR(msg) LOG << RED << "[ERROR]" << END << msg; std::exit(-1)
 

--- a/mt-kahypar/partition/CMakeLists.txt
+++ b/mt-kahypar/partition/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(mapping)
 add_subdirectory(registries)
 
 set(PartitionSources
+        deep_multilevel.cpp
         partitioner.cpp
         partitioner_facade.cpp
         multilevel.cpp
@@ -14,7 +15,6 @@ set(PartitionSources
         conversion.cpp
         metrics.cpp
         recursive_bipartitioning.cpp
-        deep_multilevel.cpp
         )
 
 foreach(modtarget IN LISTS PARTITIONING_SUITE_TARGETS)

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
@@ -211,6 +211,10 @@ namespace mt_kahypar {
       improvement_found = false;
       const HyperedgeWeight metric_before = _current_metrics.quality;
 
+      if ( _rebalancer && _context.refinement.rebalancer != RebalancingAlgorithm::do_nothing ) {
+        _rebalancer->initialize(phg);
+      }
+
       if ( _label_propagation && _context.refinement.label_propagation.algorithm != LabelPropagationAlgorithm::do_nothing ) {
         _timer.start_timer("initialize_lp_refiner", "Initialize LP Refiner");
         _label_propagation->initialize(phg);

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
@@ -95,6 +95,9 @@ namespace mt_kahypar {
     // Initialize Refiner
     mt_kahypar_partitioned_hypergraph_t phg =
       utils::partitioned_hg_cast(*_uncoarseningData.partitioned_hg);
+    if ( _rebalancer ) {
+      _rebalancer->initialize(phg);
+    }
     if ( _label_propagation ) {
       _label_propagation->initialize(phg);
     }

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
@@ -36,6 +36,7 @@
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/coarsening/coarsening_commons.h"
 #include "mt-kahypar/datastructures/streaming_vector.h"
+#include "mt-kahypar/utils/progress_bar.h"
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -123,8 +123,10 @@ namespace mt_kahypar {
     str << "    Algorithm:                        " << params.algorithm << std::endl;
     if ( params.algorithm != LabelPropagationAlgorithm::do_nothing ) {
       str << "    Maximum Iterations:               " << params.maximum_iterations << std::endl;
+      str << "    Unconstrained:                    " << std::boolalpha << params.unconstrained << std::endl;
       str << "    Rebalancing:                      " << std::boolalpha << params.rebalancing << std::endl;
       str << "    HE Size Activation Threshold:     " << std::boolalpha << params.hyperedge_size_activation_threshold << std::endl;
+      str << "    Relative Improvement Threshold:   " << params.relative_improvement_threshold << std::endl;
     }
     return str;
   }
@@ -143,6 +145,19 @@ namespace mt_kahypar {
       out << "    Minimum Improvement Factor:       " << params.min_improvement << std::endl;
       out << "    Release Nodes:                    " << std::boolalpha << params.release_nodes << std::endl;
       out << "    Time Limit Factor:                " << params.time_limit_factor << std::endl;
+    }
+    if ( params.algorithm == FMAlgorithm::unconstrained_fm ) {
+      out << "    Unconstrained Rounds:             " << params.unconstrained_rounds << std::endl;
+      out << "    Threshold Border Node Inclusion:  " << params.treshold_border_node_inclusion << std::endl;
+      out << "    Minimum Imbalance Penalty Factor: " << params.imbalance_penalty_min << std::endl;
+      out << "    Maximum Imbalance Penalty Factor: " << params.imbalance_penalty_max << std::endl;
+      out << "    Start Upper Bound for Unc.:       " << params.unconstrained_upper_bound << std::endl;
+      out << "    Final Upper Bound for Unc.:       " << params.unconstrained_upper_bound_min << std::endl;
+      out << "    Unc. Minimum Improvement Factor:  " << params.unconstrained_min_improvement << std::endl;
+      out << "    Activate Unc. Dynamically:        " << std::boolalpha << params.activate_unconstrained_dynamically << std::endl;
+      if ( params.activate_unconstrained_dynamically ) {
+        out << "    Penalty for Activation Test:      " << params.penalty_for_activation_test << std::endl;
+      }
     }
     out << std::flush;
     return out;

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -136,7 +136,6 @@ namespace mt_kahypar {
     out << "    Algorithm:                        " << params.algorithm << std::endl;
     if ( params.algorithm != FMAlgorithm::do_nothing ) {
       out << "    Multitry Rounds:                  " << params.multitry_rounds << std::endl;
-      out << "    Perform Moves Globally:           " << std::boolalpha << params.perform_moves_global << std::endl;
       out << "    Parallel Global Rollbacks:        " << std::boolalpha << params.rollback_parallel << std::endl;
       out << "    Rollback Bal. Violation Factor:   " << params.rollback_balance_violation_factor << std::endl;
       out << "    Num Seed Nodes:                   " << params.num_seed_nodes << std::endl;
@@ -540,7 +539,6 @@ namespace mt_kahypar {
     // initial partitioning -> refinement -> fm
     initial_partitioning.refinement.fm.algorithm = FMAlgorithm::kway_fm;
     initial_partitioning.refinement.fm.multitry_rounds = 5;
-    initial_partitioning.refinement.fm.perform_moves_global = false;
     initial_partitioning.refinement.fm.rollback_parallel = true;
     initial_partitioning.refinement.fm.rollback_balance_violation_factor = 1;
     initial_partitioning.refinement.fm.num_seed_nodes = 25;
@@ -568,7 +566,6 @@ namespace mt_kahypar {
     refinement.fm.algorithm = FMAlgorithm::unconstrained_fm;
     refinement.fm.multitry_rounds = 10;
     refinement.fm.unconstrained_rounds = 8;
-    refinement.fm.perform_moves_global = false;
     refinement.fm.rollback_parallel = true;
     refinement.fm.rollback_balance_violation_factor = 1.0;
     refinement.fm.treshold_border_node_inclusion = 0.7;
@@ -771,7 +768,6 @@ namespace mt_kahypar {
     // initial partitioning -> refinement -> fm
     initial_partitioning.refinement.fm.algorithm = FMAlgorithm::kway_fm;
     initial_partitioning.refinement.fm.multitry_rounds = 5;
-    initial_partitioning.refinement.fm.perform_moves_global = false;
     initial_partitioning.refinement.fm.rollback_parallel = false;
     initial_partitioning.refinement.fm.rollback_balance_violation_factor = 1;
     initial_partitioning.refinement.fm.num_seed_nodes = 5;
@@ -801,7 +797,6 @@ namespace mt_kahypar {
     // refinement -> fm
     refinement.fm.algorithm = FMAlgorithm::kway_fm;
     refinement.fm.multitry_rounds = 10;
-    refinement.fm.perform_moves_global = false;
     refinement.fm.rollback_parallel = false;
     refinement.fm.rollback_balance_violation_factor = 1.25;
     refinement.fm.num_seed_nodes = 5;

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -152,7 +152,6 @@ struct FMParameters {
   double min_improvement = -1.0;
   double time_limit_factor = std::numeric_limits<double>::max();
 
-  bool perform_moves_global = false;
   bool rollback_parallel = true;
   bool iter_moves_on_recalc = false;
   bool shuffle = true;

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -133,9 +133,9 @@ std::ostream & operator<< (std::ostream& str, const CoarseningParameters& params
 struct LabelPropagationParameters {
   LabelPropagationAlgorithm algorithm = LabelPropagationAlgorithm::do_nothing;
   size_t maximum_iterations = 1;
+  bool unconstrained = false;
   bool rebalancing = true;
   bool execute_sequential = false;
-  bool unconstrained = false;
   size_t hyperedge_size_activation_threshold = std::numeric_limits<size_t>::max();
   double relative_improvement_threshold = -1.0;
 };
@@ -159,18 +159,17 @@ struct FMParameters {
   mutable bool obey_minimal_parallelism = false;
   bool release_nodes = true;
 
-  double treshold_border_node_inclusion = 0.75;
-  double unconstrained_upper_bound = 0.0;
-
   // unconstrained
   size_t unconstrained_rounds = 1;
+  double treshold_border_node_inclusion = 0.75;
   double imbalance_penalty_min = 0.2;
   double imbalance_penalty_max = 1.0;
+  double unconstrained_upper_bound = 0.0;
   double unconstrained_upper_bound_min = 0.0;
+  double unconstrained_min_improvement = -1.0;
 
   bool activate_unconstrained_dynamically = false;
   double penalty_for_activation_test = 0.5;
-  double unconstrained_min_improvement = -1.0;
 };
 
 std::ostream& operator<<(std::ostream& out, const FMParameters& params);

--- a/mt-kahypar/partition/factories.h
+++ b/mt-kahypar/partition/factories.h
@@ -88,7 +88,7 @@ using LabelPropagationFactory = kahypar::meta::Factory<LabelPropagationAlgorithm
 using LabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                         LabelPropagationRefiner,
                                         IRefiner,
-                                        kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                        kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using DeterministicLabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                                   DeterministicLabelPropagationRefiner,
@@ -101,7 +101,7 @@ using FMFactory = kahypar::meta::Factory<FMAlgorithm,
 using DefaultFMDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                             MultiTryKWayFM,
                             IRefiner,
-                            kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                            kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using UnconstrainedFMDispatcher = DefaultFMDispatcher;
 
@@ -110,12 +110,12 @@ using FMStrategyFactory = kahypar::meta::Factory<FMAlgorithm, IFMStrategy* (*)(c
 using GainCacheFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                       GainCacheStrategy,
                                       IFMStrategy,
-                                      kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                      kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using UnconstrainedFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                           UnconstrainedStrategy,
                                           IFMStrategy,
-                                          kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                          kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using FlowSchedulerFactory = kahypar::meta::Factory<FlowAlgorithm,
                               IRefiner* (*)(const HypernodeID, const HyperedgeID, const Context&, gain_cache_t)>;
@@ -123,19 +123,19 @@ using FlowSchedulerFactory = kahypar::meta::Factory<FlowAlgorithm,
 using FlowSchedulerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                   FlowRefinementScheduler,
                                   IRefiner,
-                                  kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                  kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using RebalancerFactory = kahypar::meta::Factory<RebalancingAlgorithm, IRebalancer* (*)(HypernodeID, const Context&, gain_cache_t)>;
 
 using SimpleRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                    SimpleRebalancer,
                                    IRebalancer,
-                                   kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                   kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using AdvancedRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                      AdvancedRebalancer,
                                      IRebalancer,
-                                     kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                     kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using FlowRefinementFactory = kahypar::meta::Factory<FlowAlgorithm,
                               IFlowRefiner* (*)(const HyperedgeID, const Context&)>;
@@ -143,5 +143,5 @@ using FlowRefinementFactory = kahypar::meta::Factory<FlowAlgorithm,
 using FlowRefinementDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                   FlowRefiner,
                                   IFlowRefiner,
-                                  kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                  kahypar::meta::Typelist<ValidTraitCombinations>>;
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/factories.h
+++ b/mt-kahypar/partition/factories.h
@@ -32,6 +32,7 @@
 #include "mt-kahypar/definitions.h"
 #include "mt-kahypar/partition/coarsening/i_coarsener.h"
 #include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/refinement/i_rebalancer.h"
 #include "mt-kahypar/partition/refinement/flows/i_flow_refiner.h"
@@ -41,8 +42,12 @@
 
 namespace mt_kahypar {
 
+typedef struct ip_data_container_s ip_data_container_t;
+
 using CoarsenerFactory = kahypar::meta::Factory<CoarseningAlgorithm,
                                                 ICoarsener* (*)(mt_kahypar_hypergraph_t, const Context&, uncoarsening_data_t*)>;
+using InitialPartitionerFactory = kahypar::meta::Factory<InitialPartitioningAlgorithm,
+  IInitialPartitioner* (*)(const InitialPartitioningAlgorithm, ip_data_container_t*, const Context&, const int, const int)>;
 
 using LabelPropagationFactory = kahypar::meta::Factory<LabelPropagationAlgorithm,
                                   IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;

--- a/mt-kahypar/partition/factories.h
+++ b/mt-kahypar/partition/factories.h
@@ -28,120 +28,35 @@
 #pragma once
 
 #include "kahypar-resources/meta/abstract_factory.h"
-#include "kahypar-resources/meta/static_multi_dispatch_factory.h"
-#include "kahypar-resources/meta/typelist.h"
 
 #include "mt-kahypar/definitions.h"
-#ifdef KAHYPAR_ENABLE_HIGHEST_QUALITY_FEATURES
-#include "mt-kahypar/partition/coarsening/nlevel_coarsener.h"
-#endif
-#include "mt-kahypar/partition/coarsening/multilevel_coarsener.h"
-#include "mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h"
 #include "mt-kahypar/partition/coarsening/i_coarsener.h"
-#include "mt-kahypar/partition/coarsening/policies/rating_acceptance_policy.h"
-#include "mt-kahypar/partition/coarsening/policies/rating_heavy_node_penalty_policy.h"
 #include "mt-kahypar/partition/context.h"
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/refinement/i_rebalancer.h"
 #include "mt-kahypar/partition/refinement/flows/i_flow_refiner.h"
-#include "mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h"
-#include "mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h"
 #include "mt-kahypar/partition/refinement/fm/fm_commons.h"
-#include "mt-kahypar/partition/refinement/fm/multitry_kway_fm.h"
 #include "mt-kahypar/partition/refinement/fm/strategies/i_fm_strategy.h"
-#include "mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h"
-#include "mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h"
-#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
-#include "mt-kahypar/partition/refinement/flows/scheduler.h"
-#include "mt-kahypar/partition/refinement/flows/flow_refiner.h"
-#include "mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h"
-#include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
+#include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
 
 namespace mt_kahypar {
 
 using CoarsenerFactory = kahypar::meta::Factory<CoarseningAlgorithm,
                                                 ICoarsener* (*)(mt_kahypar_hypergraph_t, const Context&, uncoarsening_data_t*)>;
 
-using MultilevelCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<MultilevelCoarsener,
-                                                                                ICoarsener,
-                                                                                kahypar::meta::Typelist<TypeTraitsList,
-                                                                                                        RatingScorePolicies,
-                                                                                                        HeavyNodePenaltyPolicies,
-                                                                                                        AcceptancePolicies> >;
-
-using DeterministicCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<DeterministicMultilevelCoarsener,
-                                                                                   ICoarsener,
-                                                                                   kahypar::meta::Typelist<TypeTraitsList>>;
-
-#ifdef KAHYPAR_ENABLE_HIGHEST_QUALITY_FEATURES
-using NLevelCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<NLevelCoarsener,
-                                                                            ICoarsener,
-                                                                            kahypar::meta::Typelist<TypeTraitsList,
-                                                                                                    RatingScorePolicies,
-                                                                                                    HeavyNodePenaltyPolicies,
-                                                                                                    AcceptancePolicies> >;
-#endif
-
 using LabelPropagationFactory = kahypar::meta::Factory<LabelPropagationAlgorithm,
                                   IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;
-
-using LabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                        LabelPropagationRefiner,
-                                        IRefiner,
-                                        kahypar::meta::Typelist<ValidTraitCombinations>>;
-
-using DeterministicLabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                                  DeterministicLabelPropagationRefiner,
-                                                  IRefiner,
-                                                  kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
 
 using FMFactory = kahypar::meta::Factory<FMAlgorithm,
                     IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;
 
-using DefaultFMDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                            MultiTryKWayFM,
-                            IRefiner,
-                            kahypar::meta::Typelist<ValidTraitCombinations>>;
-
-using UnconstrainedFMDispatcher = DefaultFMDispatcher;
-
 using FMStrategyFactory = kahypar::meta::Factory<FMAlgorithm, IFMStrategy* (*)(const Context&, FMSharedData&)>;
-
-using GainCacheFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                      GainCacheStrategy,
-                                      IFMStrategy,
-                                      kahypar::meta::Typelist<ValidTraitCombinations>>;
-
-using UnconstrainedFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                          UnconstrainedStrategy,
-                                          IFMStrategy,
-                                          kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using FlowSchedulerFactory = kahypar::meta::Factory<FlowAlgorithm,
                               IRefiner* (*)(const HypernodeID, const HyperedgeID, const Context&, gain_cache_t)>;
 
-using FlowSchedulerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                  FlowRefinementScheduler,
-                                  IRefiner,
-                                  kahypar::meta::Typelist<ValidTraitCombinations>>;
-
 using RebalancerFactory = kahypar::meta::Factory<RebalancingAlgorithm, IRebalancer* (*)(HypernodeID, const Context&, gain_cache_t)>;
-
-using SimpleRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                   SimpleRebalancer,
-                                   IRebalancer,
-                                   kahypar::meta::Typelist<ValidTraitCombinations>>;
-
-using AdvancedRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                     AdvancedRebalancer,
-                                     IRebalancer,
-                                     kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using FlowRefinementFactory = kahypar::meta::Factory<FlowAlgorithm,
                               IFlowRefiner* (*)(const HyperedgeID, const Context&)>;
-
-using FlowRefinementDispatcher = kahypar::meta::StaticMultiDispatchFactory<
-                                  FlowRefiner,
-                                  IFlowRefiner,
-                                  kahypar::meta::Typelist<ValidTraitCombinations>>;
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/initial_partitioning/initial_partitioning_commons.h
+++ b/mt-kahypar/partition/initial_partitioning/initial_partitioning_commons.h
@@ -32,24 +32,16 @@
 #pragma GCC diagnostic pop
 
 #include "kahypar-resources/datastructure/fast_reset_flag_array.h"
-#include "kahypar-resources/meta/abstract_factory.h"
 
 #include "tbb/enumerable_thread_specific.h"
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
-#include "mt-kahypar/definitions.h"
-#include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
 
 namespace mt_kahypar {
-
-typedef struct ip_data_container_s ip_data_container_t;
 
 using KWayPriorityQueue = kahypar::ds::KWayPriorityQueue<HypernodeID, Gain, std::numeric_limits<Gain>, false>;
 using ThreadLocalKWayPriorityQueue = tbb::enumerable_thread_specific<KWayPriorityQueue>;
 
 using ThreadLocalFastResetFlagArray = tbb::enumerable_thread_specific<kahypar::ds::FastResetFlagArray<> >;
-
-using InitialPartitionerFactory = kahypar::meta::Factory<InitialPartitioningAlgorithm,
-  IInitialPartitioner* (*)(const InitialPartitioningAlgorithm, ip_data_container_t*, const Context&, const int, const int)>;
 
 }

--- a/mt-kahypar/partition/initial_partitioning/initial_partitioning_commons.h
+++ b/mt-kahypar/partition/initial_partitioning/initial_partitioning_commons.h
@@ -31,15 +31,25 @@
 #include "kahypar-resources/datastructure/kway_priority_queue.h"
 #pragma GCC diagnostic pop
 
-#include "tbb/enumerable_thread_specific.h"
-#include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "kahypar-resources/datastructure/fast_reset_flag_array.h"
+#include "kahypar-resources/meta/abstract_factory.h"
+
+#include "tbb/enumerable_thread_specific.h"
+
+#include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
 
 namespace mt_kahypar {
+
+typedef struct ip_data_container_s ip_data_container_t;
 
 using KWayPriorityQueue = kahypar::ds::KWayPriorityQueue<HypernodeID, Gain, std::numeric_limits<Gain>, false>;
 using ThreadLocalKWayPriorityQueue = tbb::enumerable_thread_specific<KWayPriorityQueue>;
 
 using ThreadLocalFastResetFlagArray = tbb::enumerable_thread_specific<kahypar::ds::FastResetFlagArray<> >;
+
+using InitialPartitionerFactory = kahypar::meta::Factory<InitialPartitioningAlgorithm,
+  IInitialPartitioner* (*)(const InitialPartitioningAlgorithm, ip_data_container_t*, const Context&, const int, const int)>;
 
 }

--- a/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
+++ b/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
@@ -714,8 +714,6 @@ class InitialPartitioningDataContainer {
   vec< std::pair<PartitioningResult, vec<PartitionID>>  > _best_partitions;
 };
 
-typedef struct ip_data_container_s ip_data_container_t;
-
 namespace ip {
   template<typename TypeTraits>
   ip_data_container_t* to_pointer(InitialPartitioningDataContainer<TypeTraits>& ip_data) {

--- a/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.cpp
+++ b/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.cpp
@@ -29,7 +29,8 @@
 #include "tbb/task_group.h"
 
 #include "mt-kahypar/definitions.h"
-#include "mt-kahypar/partition/registries/register_initial_partitioning_algorithms.h"
+#include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
+#include "mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h"
 #include "mt-kahypar/utils/cast.h"
 #include "mt-kahypar/utils/exception.h"
 

--- a/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.cpp
+++ b/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.cpp
@@ -29,6 +29,7 @@
 #include "tbb/task_group.h"
 
 #include "mt-kahypar/definitions.h"
+#include "mt-kahypar/partition/factories.h"
 #include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
 #include "mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h"
 #include "mt-kahypar/utils/cast.h"

--- a/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.h
+++ b/mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.h
@@ -30,8 +30,6 @@
 
 #include "include/libmtkahypartypes.h"
 
-#include "mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h"
-
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.cpp
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.cpp
@@ -37,9 +37,8 @@
 
 namespace mt_kahypar {
 
-
-  template<typename TypeTraits, typename GainTypes>
-  bool DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::refineImpl(
+  template<typename CombinedTraits>
+  bool DeterministicLabelPropagationRefiner<CombinedTraits>::refineImpl(
           mt_kahypar_partitioned_hypergraph_t& hypergraph,
           const vec<HypernodeID>&,
           Metrics& best_metrics,
@@ -130,8 +129,8 @@ namespace mt_kahypar {
 /*
  * for configs where we don't know exact gains --> have to trace the overall improvement with attributed gains
  */
-  template<typename TypeTraits, typename GainTypes>
-  Gain DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::performMoveWithAttributedGain(
+  template<typename CombinedTraits>
+  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::performMoveWithAttributedGain(
           PartitionedHypergraph& phg, const Move& m, bool activate_neighbors) {
     Gain attributed_gain = 0;
     auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
@@ -159,9 +158,9 @@ namespace mt_kahypar {
     return attributed_gain;
   }
 
-  template<typename TypeTraits, typename GainTypes>
+  template<typename CombinedTraits>
   template<typename Predicate>
-  Gain DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::applyMovesIf(
+  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesIf(
           PartitionedHypergraph& phg, const vec<Move>& my_moves, size_t end, Predicate&& predicate) {
     auto range = tbb::blocked_range<size_t>(UL(0), end);
     auto accum = [&](const tbb::blocked_range<size_t>& r, const Gain& init) -> Gain {
@@ -199,8 +198,8 @@ namespace mt_kahypar {
     return res;
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  Gain DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::applyMovesSortedByGainAndRevertUnbalanced(PartitionedHypergraph& phg) {
+  template<typename CombinedTraits>
+  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesSortedByGainAndRevertUnbalanced(PartitionedHypergraph& phg) {
     const size_t num_moves = moves.size();
     tbb::parallel_sort(moves.begin(), moves.begin() + num_moves, [](const Move& m1, const Move& m2) {
       return m1.gain > m2.gain || (m1.gain == m2.gain && m1.node < m2.node);
@@ -290,8 +289,8 @@ namespace mt_kahypar {
     return gain;
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  std::pair<Gain, bool> DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::applyMovesByMaximalPrefixesInBlockPairs(PartitionedHypergraph& phg) {
+  template<typename CombinedTraits>
+  std::pair<Gain, bool> DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesByMaximalPrefixesInBlockPairs(PartitionedHypergraph& phg) {
     PartitionID k = current_k;
     PartitionID max_key = k * k;
     auto index = [&](PartitionID b1, PartitionID b2) { return b1 * k + b2; };
@@ -401,8 +400,8 @@ namespace mt_kahypar {
     return std::make_pair(actual_gain, revert_all);
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::findBestPrefixesRecursive(
+  template<typename CombinedTraits>
+  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<CombinedTraits>::findBestPrefixesRecursive(
           size_t p1_begin, size_t p1_end, size_t p2_begin, size_t p2_end,
           size_t p1_invalid, size_t p2_invalid,
           HypernodeWeight lb_p1, HypernodeWeight ub_p2)
@@ -477,8 +476,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<TypeTraits, GainTypes>::findBestPrefixesSequentially(
+  template<typename CombinedTraits>
+  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<CombinedTraits>::findBestPrefixesSequentially(
           size_t p1_begin, size_t p1_end, size_t p2_begin, size_t p2_end, size_t p1_inv, size_t p2_inv,
           HypernodeWeight lb_p1, HypernodeWeight ub_p2)
   {
@@ -507,9 +506,9 @@ namespace mt_kahypar {
   }
 
   namespace {
-    #define DETERMINISTIC_LABEL_PROPAGATION_REFINER(X, Y) DeterministicLabelPropagationRefiner<X, Y>
+    #define DETERMINISTIC_LABEL_PROPAGATION_REFINER(X) DeterministicLabelPropagationRefiner<X>
   }
 
 
-  INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(DETERMINISTIC_LABEL_PROPAGATION_REFINER)
+  INSTANTIATE_CLASS_WITH_VALID_TRAITS(DETERMINISTIC_LABEL_PROPAGATION_REFINER)
 } // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.cpp
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.cpp
@@ -37,8 +37,8 @@
 
 namespace mt_kahypar {
 
-  template<typename CombinedTraits>
-  bool DeterministicLabelPropagationRefiner<CombinedTraits>::refineImpl(
+  template<typename GraphAndGainTypes>
+  bool DeterministicLabelPropagationRefiner<GraphAndGainTypes>::refineImpl(
           mt_kahypar_partitioned_hypergraph_t& hypergraph,
           const vec<HypernodeID>&,
           Metrics& best_metrics,
@@ -129,8 +129,8 @@ namespace mt_kahypar {
 /*
  * for configs where we don't know exact gains --> have to trace the overall improvement with attributed gains
  */
-  template<typename CombinedTraits>
-  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::performMoveWithAttributedGain(
+  template<typename GraphAndGainTypes>
+  Gain DeterministicLabelPropagationRefiner<GraphAndGainTypes>::performMoveWithAttributedGain(
           PartitionedHypergraph& phg, const Move& m, bool activate_neighbors) {
     Gain attributed_gain = 0;
     auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
@@ -158,9 +158,9 @@ namespace mt_kahypar {
     return attributed_gain;
   }
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   template<typename Predicate>
-  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesIf(
+  Gain DeterministicLabelPropagationRefiner<GraphAndGainTypes>::applyMovesIf(
           PartitionedHypergraph& phg, const vec<Move>& my_moves, size_t end, Predicate&& predicate) {
     auto range = tbb::blocked_range<size_t>(UL(0), end);
     auto accum = [&](const tbb::blocked_range<size_t>& r, const Gain& init) -> Gain {
@@ -198,8 +198,8 @@ namespace mt_kahypar {
     return res;
   }
 
-  template<typename CombinedTraits>
-  Gain DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesSortedByGainAndRevertUnbalanced(PartitionedHypergraph& phg) {
+  template<typename GraphAndGainTypes>
+  Gain DeterministicLabelPropagationRefiner<GraphAndGainTypes>::applyMovesSortedByGainAndRevertUnbalanced(PartitionedHypergraph& phg) {
     const size_t num_moves = moves.size();
     tbb::parallel_sort(moves.begin(), moves.begin() + num_moves, [](const Move& m1, const Move& m2) {
       return m1.gain > m2.gain || (m1.gain == m2.gain && m1.node < m2.node);
@@ -289,8 +289,8 @@ namespace mt_kahypar {
     return gain;
   }
 
-  template<typename CombinedTraits>
-  std::pair<Gain, bool> DeterministicLabelPropagationRefiner<CombinedTraits>::applyMovesByMaximalPrefixesInBlockPairs(PartitionedHypergraph& phg) {
+  template<typename GraphAndGainTypes>
+  std::pair<Gain, bool> DeterministicLabelPropagationRefiner<GraphAndGainTypes>::applyMovesByMaximalPrefixesInBlockPairs(PartitionedHypergraph& phg) {
     PartitionID k = current_k;
     PartitionID max_key = k * k;
     auto index = [&](PartitionID b1, PartitionID b2) { return b1 * k + b2; };
@@ -400,8 +400,8 @@ namespace mt_kahypar {
     return std::make_pair(actual_gain, revert_all);
   }
 
-  template<typename CombinedTraits>
-  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<CombinedTraits>::findBestPrefixesRecursive(
+  template<typename GraphAndGainTypes>
+  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<GraphAndGainTypes>::findBestPrefixesRecursive(
           size_t p1_begin, size_t p1_end, size_t p2_begin, size_t p2_end,
           size_t p1_invalid, size_t p2_invalid,
           HypernodeWeight lb_p1, HypernodeWeight ub_p2)
@@ -476,8 +476,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<CombinedTraits>::findBestPrefixesSequentially(
+  template<typename GraphAndGainTypes>
+  std::pair<size_t, size_t> DeterministicLabelPropagationRefiner<GraphAndGainTypes>::findBestPrefixesSequentially(
           size_t p1_begin, size_t p1_end, size_t p2_begin, size_t p2_end, size_t p1_inv, size_t p2_inv,
           HypernodeWeight lb_p1, HypernodeWeight ub_p2)
   {

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h
@@ -38,12 +38,12 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class DeterministicLabelPropagationRefiner final : public IRefiner {
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainComputation = typename GainTypes::GainComputation;
-  using AttributedGains = typename GainTypes::AttributedGains;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainComputation = typename CombinedTraits::GainComputation;
+  using AttributedGains = typename CombinedTraits::AttributedGains;
 
 public:
   explicit DeterministicLabelPropagationRefiner(const HypernodeID num_hypernodes,

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h
@@ -38,12 +38,12 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class DeterministicLabelPropagationRefiner final : public IRefiner {
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainComputation = typename CombinedTraits::GainComputation;
-  using AttributedGains = typename CombinedTraits::AttributedGains;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainComputation = typename GraphAndGainTypes::GainComputation;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
 
 public:
   explicit DeterministicLabelPropagationRefiner(const HypernodeID num_hypernodes,

--- a/mt-kahypar/partition/refinement/flows/flow_refiner.cpp
+++ b/mt-kahypar/partition/refinement/flows/flow_refiner.cpp
@@ -35,8 +35,8 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
-MoveSequence FlowRefiner<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_const_t& hypergraph,
+template<typename GraphAndGainTypes>
+MoveSequence FlowRefiner<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_const_t& hypergraph,
                                                      const Subhypergraph& sub_hg,
                                                      const HighResClockTimepoint& start) {
   const PartitionedHypergraph& phg = utils::cast_const<PartitionedHypergraph>(hypergraph);
@@ -101,8 +101,8 @@ MoveSequence FlowRefiner<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hype
 #define NOW std::chrono::high_resolution_clock::now()
 #define RUNNING_TIME(X) std::chrono::duration<double>(NOW - X).count();
 
-template<typename CombinedTraits>
-bool FlowRefiner<CombinedTraits>::runFlowCutter(const FlowProblem& flow_problem,
+template<typename GraphAndGainTypes>
+bool FlowRefiner<GraphAndGainTypes>::runFlowCutter(const FlowProblem& flow_problem,
                                                 const HighResClockTimepoint& start,
                                                 bool& time_limit_reached) {
   whfc::Node s = flow_problem.source;
@@ -146,8 +146,8 @@ bool FlowRefiner<CombinedTraits>::runFlowCutter(const FlowProblem& flow_problem,
   return result;
 }
 
-template<typename CombinedTraits>
-FlowProblem FlowRefiner<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem FlowRefiner<GraphAndGainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
                                                                  const Subhypergraph& sub_hg) {
   _block_0 = sub_hg.block_0;
   _block_1 = sub_hg.block_1;

--- a/mt-kahypar/partition/refinement/flows/flow_refiner.cpp
+++ b/mt-kahypar/partition/refinement/flows/flow_refiner.cpp
@@ -35,10 +35,10 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
-MoveSequence FlowRefiner<TypeTraits, GainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_const_t& hypergraph,
-                                                            const Subhypergraph& sub_hg,
-                                                            const HighResClockTimepoint& start) {
+template<typename CombinedTraits>
+MoveSequence FlowRefiner<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_const_t& hypergraph,
+                                                     const Subhypergraph& sub_hg,
+                                                     const HighResClockTimepoint& start) {
   const PartitionedHypergraph& phg = utils::cast_const<PartitionedHypergraph>(hypergraph);
   MoveSequence sequence { { }, 0 };
   utils::Timer& timer = utils::Utilities::instance().getTimer(_context.utility_id);
@@ -101,10 +101,10 @@ MoveSequence FlowRefiner<TypeTraits, GainTypes>::refineImpl(mt_kahypar_partition
 #define NOW std::chrono::high_resolution_clock::now()
 #define RUNNING_TIME(X) std::chrono::duration<double>(NOW - X).count();
 
-template<typename TypeTraits, typename GainTypes>
-bool FlowRefiner<TypeTraits, GainTypes>::runFlowCutter(const FlowProblem& flow_problem,
-                                                       const HighResClockTimepoint& start,
-                                                       bool& time_limit_reached) {
+template<typename CombinedTraits>
+bool FlowRefiner<CombinedTraits>::runFlowCutter(const FlowProblem& flow_problem,
+                                                const HighResClockTimepoint& start,
+                                                bool& time_limit_reached) {
   whfc::Node s = flow_problem.source;
   whfc::Node t = flow_problem.sink;
   bool result = false;
@@ -146,9 +146,9 @@ bool FlowRefiner<TypeTraits, GainTypes>::runFlowCutter(const FlowProblem& flow_p
   return result;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem FlowRefiner<TypeTraits, GainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
-                                                                        const Subhypergraph& sub_hg) {
+template<typename CombinedTraits>
+FlowProblem FlowRefiner<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+                                                                 const Subhypergraph& sub_hg) {
   _block_0 = sub_hg.block_0;
   _block_1 = sub_hg.block_1;
   ASSERT(_block_0 != kInvalidPartition && _block_1 != kInvalidPartition);
@@ -173,9 +173,9 @@ FlowProblem FlowRefiner<TypeTraits, GainTypes>::constructFlowHypergraph(const Pa
 }
 
 namespace {
-#define FLOW_REFINER(X, Y) FlowRefiner<X, Y>
+#define FLOW_REFINER(X) FlowRefiner<X>
 }
 
-INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(FLOW_REFINER)
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(FLOW_REFINER)
 
 } // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/flows/flow_refiner.h
+++ b/mt-kahypar/partition/refinement/flows/flow_refiner.h
@@ -45,12 +45,12 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class FlowRefiner final : public IFlowRefiner {
 
   static constexpr bool debug = false;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
 
  public:
   explicit FlowRefiner(const HyperedgeID num_hyperedges,
@@ -128,7 +128,7 @@ class FlowRefiner final : public IFlowRefiner {
   whfc::HyperFlowCutter<whfc::ParallelPushRelabel> _parallel_hfc;
 
   vec<HypernodeID> _whfc_to_node;
-  SequentialConstruction<TypeTraits, GainTypes> _sequential_construction;
-  ParallelConstruction<TypeTraits, GainTypes> _parallel_construction;
+  SequentialConstruction<CombinedTraits> _sequential_construction;
+  ParallelConstruction<CombinedTraits> _parallel_construction;
 };
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/flows/flow_refiner.h
+++ b/mt-kahypar/partition/refinement/flows/flow_refiner.h
@@ -45,12 +45,12 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class FlowRefiner final : public IFlowRefiner {
 
   static constexpr bool debug = false;
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
 
  public:
   explicit FlowRefiner(const HyperedgeID num_hyperedges,
@@ -128,7 +128,7 @@ class FlowRefiner final : public IFlowRefiner {
   whfc::HyperFlowCutter<whfc::ParallelPushRelabel> _parallel_hfc;
 
   vec<HypernodeID> _whfc_to_node;
-  SequentialConstruction<CombinedTraits> _sequential_construction;
-  ParallelConstruction<CombinedTraits> _parallel_construction;
+  SequentialConstruction<GraphAndGainTypes> _sequential_construction;
+  ParallelConstruction<GraphAndGainTypes> _parallel_construction;
 };
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/flows/parallel_construction.cpp
+++ b/mt-kahypar/partition/refinement/flows/parallel_construction.cpp
@@ -36,9 +36,9 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
-typename ParallelConstruction<CombinedTraits>::TmpHyperedge
-ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::get(const size_t he_hash,
+template<typename GraphAndGainTypes>
+typename ParallelConstruction<GraphAndGainTypes>::TmpHyperedge
+ParallelConstruction<GraphAndGainTypes>::DynamicIdenticalNetDetection::get(const size_t he_hash,
                                                                         const vec<whfc::Node>& pins) {
   const size_t bucket_idx = he_hash % _hash_buckets.size();
   if ( __atomic_load_n(&_hash_buckets[bucket_idx].threshold, __ATOMIC_RELAXED) == _threshold ) {
@@ -65,8 +65,8 @@ ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::get(const si
   return TmpHyperedge { 0, std::numeric_limits<size_t>::max(), whfc::invalidHyperedge };
 }
 
-template<typename CombinedTraits>
-void ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::add(const TmpHyperedge& tmp_he) {
+template<typename GraphAndGainTypes>
+void ParallelConstruction<GraphAndGainTypes>::DynamicIdenticalNetDetection::add(const TmpHyperedge& tmp_he) {
   const size_t bucket_idx = tmp_he.hash % _hash_buckets.size();
   uint32_t expected = __atomic_load_n(&_hash_buckets[bucket_idx].threshold, __ATOMIC_RELAXED);
   uint32_t desired = _threshold - 1;
@@ -81,8 +81,8 @@ void ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::add(con
   _hash_buckets[bucket_idx].identical_nets.push_back(ThresholdHyperedge { tmp_he, _threshold });
 }
 
-template<typename CombinedTraits>
-FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem ParallelConstruction<GraphAndGainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
                                                                           const Subhypergraph& sub_hg,
                                                                           const PartitionID block_0,
                                                                           const PartitionID block_1,
@@ -126,8 +126,8 @@ FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const 
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem ParallelConstruction<GraphAndGainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
                                                                           const Subhypergraph& sub_hg,
                                                                           const PartitionID block_0,
                                                                           const PartitionID block_1,
@@ -170,8 +170,8 @@ FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const 
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem ParallelConstruction<CombinedTraits>::constructDefault(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem ParallelConstruction<GraphAndGainTypes>::constructDefault(const PartitionedHypergraph& phg,
                                                                    const Subhypergraph& sub_hg,
                                                                    const PartitionID block_0,
                                                                    const PartitionID block_1,
@@ -334,8 +334,8 @@ FlowProblem ParallelConstruction<CombinedTraits>::constructDefault(const Partiti
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem ParallelConstruction<CombinedTraits>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem ParallelConstruction<GraphAndGainTypes>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
                                                                                 const Subhypergraph& sub_hg,
                                                                                 const PartitionID block_0,
                                                                                 const PartitionID block_1,
@@ -565,8 +565,8 @@ class BFSQueue {
 };
 }
 
-template<typename CombinedTraits>
-void ParallelConstruction<CombinedTraits>::determineDistanceFromCut(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+void ParallelConstruction<GraphAndGainTypes>::determineDistanceFromCut(const PartitionedHypergraph& phg,
                                                                     const whfc::Node source,
                                                                     const whfc::Node sink,
                                                                     const PartitionID block_0,

--- a/mt-kahypar/partition/refinement/flows/parallel_construction.cpp
+++ b/mt-kahypar/partition/refinement/flows/parallel_construction.cpp
@@ -36,10 +36,10 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
-typename ParallelConstruction<TypeTraits, GainTypes>::TmpHyperedge
-ParallelConstruction<TypeTraits, GainTypes>::DynamicIdenticalNetDetection::get(
-  const size_t he_hash, const vec<whfc::Node>& pins) {
+template<typename CombinedTraits>
+typename ParallelConstruction<CombinedTraits>::TmpHyperedge
+ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::get(const size_t he_hash,
+                                                                        const vec<whfc::Node>& pins) {
   const size_t bucket_idx = he_hash % _hash_buckets.size();
   if ( __atomic_load_n(&_hash_buckets[bucket_idx].threshold, __ATOMIC_RELAXED) == _threshold ) {
     // There exists already some hyperedges with the same hash
@@ -65,8 +65,8 @@ ParallelConstruction<TypeTraits, GainTypes>::DynamicIdenticalNetDetection::get(
   return TmpHyperedge { 0, std::numeric_limits<size_t>::max(), whfc::invalidHyperedge };
 }
 
-template<typename TypeTraits, typename GainTypes>
-void ParallelConstruction<TypeTraits, GainTypes>::DynamicIdenticalNetDetection::add(const TmpHyperedge& tmp_he) {
+template<typename CombinedTraits>
+void ParallelConstruction<CombinedTraits>::DynamicIdenticalNetDetection::add(const TmpHyperedge& tmp_he) {
   const size_t bucket_idx = tmp_he.hash % _hash_buckets.size();
   uint32_t expected = __atomic_load_n(&_hash_buckets[bucket_idx].threshold, __ATOMIC_RELAXED);
   uint32_t desired = _threshold - 1;
@@ -81,12 +81,12 @@ void ParallelConstruction<TypeTraits, GainTypes>::DynamicIdenticalNetDetection::
   _hash_buckets[bucket_idx].identical_nets.push_back(ThresholdHyperedge { tmp_he, _threshold });
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
-                                                                                 const Subhypergraph& sub_hg,
-                                                                                 const PartitionID block_0,
-                                                                                 const PartitionID block_1,
-                                                                                 vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+                                                                          const Subhypergraph& sub_hg,
+                                                                          const PartitionID block_0,
+                                                                          const PartitionID block_1,
+                                                                          vec<HypernodeID>& whfc_to_node) {
   FlowProblem flow_problem;
   const double density = static_cast<double>(phg.initialNumEdges()) / phg.initialNumNodes();
   const double avg_he_size = static_cast<double>(phg.initialNumPins()) / phg.initialNumEdges();
@@ -126,13 +126,13 @@ FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructFlowHypergraph
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
-                                                                                 const Subhypergraph& sub_hg,
-                                                                                 const PartitionID block_0,
-                                                                                 const PartitionID block_1,
-                                                                                 vec<HypernodeID>& whfc_to_node,
-                                                                                 const bool default_construction) {
+template<typename CombinedTraits>
+FlowProblem ParallelConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+                                                                          const Subhypergraph& sub_hg,
+                                                                          const PartitionID block_0,
+                                                                          const PartitionID block_1,
+                                                                          vec<HypernodeID>& whfc_to_node,
+                                                                          const bool default_construction) {
   FlowProblem flow_problem;
   if ( default_construction ) {
     // This algorithm iterates over all hyperedges and checks for all pins if
@@ -170,12 +170,12 @@ FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructFlowHypergraph
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructDefault(const PartitionedHypergraph& phg,
-                                                                          const Subhypergraph& sub_hg,
-                                                                          const PartitionID block_0,
-                                                                          const PartitionID block_1,
-                                                                          vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem ParallelConstruction<CombinedTraits>::constructDefault(const PartitionedHypergraph& phg,
+                                                                   const Subhypergraph& sub_hg,
+                                                                   const PartitionID block_0,
+                                                                   const PartitionID block_1,
+                                                                   vec<HypernodeID>& whfc_to_node) {
   ASSERT(block_0 != kInvalidPartition && block_1 != kInvalidPartition);
   FlowProblem flow_problem;
   flow_problem.total_cut = 0;
@@ -334,12 +334,12 @@ FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructDefault(const 
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem ParallelConstruction<TypeTraits, GainTypes>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
-                                                                                       const Subhypergraph& sub_hg,
-                                                                                       const PartitionID block_0,
-                                                                                       const PartitionID block_1,
-                                                                                       vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem ParallelConstruction<CombinedTraits>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
+                                                                                const Subhypergraph& sub_hg,
+                                                                                const PartitionID block_0,
+                                                                                const PartitionID block_1,
+                                                                                vec<HypernodeID>& whfc_to_node) {
   ASSERT(block_0 != kInvalidPartition && block_1 != kInvalidPartition);
   FlowProblem flow_problem;
   flow_problem.total_cut = 0;
@@ -565,13 +565,13 @@ class BFSQueue {
 };
 }
 
-template<typename TypeTraits, typename GainTypes>
-void ParallelConstruction<TypeTraits, GainTypes>::determineDistanceFromCut(const PartitionedHypergraph& phg,
-                                                                           const whfc::Node source,
-                                                                           const whfc::Node sink,
-                                                                           const PartitionID block_0,
-                                                                           const PartitionID block_1,
-                                                                           const vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+void ParallelConstruction<CombinedTraits>::determineDistanceFromCut(const PartitionedHypergraph& phg,
+                                                                    const whfc::Node source,
+                                                                    const whfc::Node sink,
+                                                                    const PartitionID block_0,
+                                                                    const PartitionID block_1,
+                                                                    const vec<HypernodeID>& whfc_to_node) {
   auto& distances = _hfc.cs.border_nodes.distance;
   distances.assign(_flow_hg.numNodes(), whfc::HopDistance(0));
   _visited_hns.resize(_flow_hg.numNodes() + _flow_hg.numHyperedges());
@@ -640,9 +640,9 @@ void ParallelConstruction<TypeTraits, GainTypes>::determineDistanceFromCut(const
 }
 
 namespace {
-#define PARALLEL_CONSTRUCTION(X, Y) ParallelConstruction<X, Y>
+#define PARALLEL_CONSTRUCTION(X) ParallelConstruction<X>
 }
 
-INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(PARALLEL_CONSTRUCTION)
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(PARALLEL_CONSTRUCTION)
 
 } // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/flows/parallel_construction.h
+++ b/mt-kahypar/partition/refinement/flows/parallel_construction.h
@@ -45,15 +45,15 @@ namespace mt_kahypar {
 
 struct FlowProblem;
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class ParallelConstruction {
 
   static constexpr bool debug = false;
 
   static constexpr size_t NUM_CSR_BUCKETS = 1024;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using FlowNetworkConstruction = typename GainTypes::FlowNetworkConstruction;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using FlowNetworkConstruction = typename CombinedTraits::FlowNetworkConstruction;
 
   struct TmpPin {
     HyperedgeID e;

--- a/mt-kahypar/partition/refinement/flows/parallel_construction.h
+++ b/mt-kahypar/partition/refinement/flows/parallel_construction.h
@@ -45,15 +45,15 @@ namespace mt_kahypar {
 
 struct FlowProblem;
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class ParallelConstruction {
 
   static constexpr bool debug = false;
 
   static constexpr size_t NUM_CSR_BUCKETS = 1024;
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using FlowNetworkConstruction = typename CombinedTraits::FlowNetworkConstruction;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using FlowNetworkConstruction = typename GraphAndGainTypes::FlowNetworkConstruction;
 
   struct TmpPin {
     HyperedgeID e;

--- a/mt-kahypar/partition/refinement/flows/scheduler.cpp
+++ b/mt-kahypar/partition/refinement/flows/scheduler.cpp
@@ -35,8 +35,8 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
-void FlowRefinementScheduler<CombinedTraits>::RefinementStats::update_global_stats() {
+template<typename GraphAndGainTypes>
+void FlowRefinementScheduler<GraphAndGainTypes>::RefinementStats::update_global_stats() {
   _stats.update_stat("num_flow_refinements",
     num_refinements.load(std::memory_order_relaxed));
   _stats.update_stat("num_flow_improvement",
@@ -57,8 +57,8 @@ void FlowRefinementScheduler<CombinedTraits>::RefinementStats::update_global_sta
     total_improvement.load(std::memory_order_relaxed));
 }
 
-template<typename CombinedTraits>
-bool FlowRefinementScheduler<CombinedTraits>::refineImpl(
+template<typename GraphAndGainTypes>
+bool FlowRefinementScheduler<GraphAndGainTypes>::refineImpl(
                 mt_kahypar_partitioned_hypergraph_t& hypergraph,
                 const parallel::scalable_vector<HypernodeID>&,
                 Metrics& best_metrics,
@@ -150,8 +150,8 @@ bool FlowRefinementScheduler<CombinedTraits>::refineImpl(
   return overall_delta.load(std::memory_order_relaxed) < 0;
 }
 
-template<typename CombinedTraits>
-void FlowRefinementScheduler<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph)  {
+template<typename GraphAndGainTypes>
+void FlowRefinementScheduler<GraphAndGainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph)  {
   PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
   _phg = &phg;
   resizeDataStructuresForCurrentK();
@@ -175,8 +175,8 @@ void FlowRefinementScheduler<CombinedTraits>::initializeImpl(mt_kahypar_partitio
   _refiner.initialize(max_parallism);
 }
 
-template<typename CombinedTraits>
-void FlowRefinementScheduler<CombinedTraits>::resizeDataStructuresForCurrentK() {
+template<typename GraphAndGainTypes>
+void FlowRefinementScheduler<GraphAndGainTypes>::resizeDataStructuresForCurrentK() {
   if ( _current_k != _context.partition.k ) {
     _current_k = _context.partition.k;
     // Note that in general changing the number of blocks should not resize
@@ -269,8 +269,8 @@ void addCutHyperedgesToQuotientGraph(QuotientGraph<TypeTraits>& quotient_graph,
 
 } // namespace
 
-template<typename CombinedTraits>
-HyperedgeWeight FlowRefinementScheduler<CombinedTraits>::applyMoves(const SearchID search_id, MoveSequence& sequence) {
+template<typename GraphAndGainTypes>
+HyperedgeWeight FlowRefinementScheduler<GraphAndGainTypes>::applyMoves(const SearchID search_id, MoveSequence& sequence) {
   unused(search_id);
   ASSERT(_phg);
 
@@ -359,9 +359,9 @@ HyperedgeWeight FlowRefinementScheduler<CombinedTraits>::applyMoves(const Search
   return improvement;
 }
 
-template<typename CombinedTraits>
-typename FlowRefinementScheduler<CombinedTraits>::PartWeightUpdateResult
-FlowRefinementScheduler<CombinedTraits>::partWeightUpdate(const vec<HypernodeWeight>& part_weight_deltas,
+template<typename GraphAndGainTypes>
+typename FlowRefinementScheduler<GraphAndGainTypes>::PartWeightUpdateResult
+FlowRefinementScheduler<GraphAndGainTypes>::partWeightUpdate(const vec<HypernodeWeight>& part_weight_deltas,
                                                           const bool rollback) {
   const HypernodeWeight multiplier = rollback ? -1 : 1;
   PartWeightUpdateResult res;

--- a/mt-kahypar/partition/refinement/flows/scheduler.h
+++ b/mt-kahypar/partition/refinement/flows/scheduler.h
@@ -54,15 +54,16 @@ namespace {
   }
 }
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class FlowRefinementScheduler final : public IRefiner {
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using AttributedGains = typename GainTypes::AttributedGains;
+  using TypeTraits = typename CombinedTraits::TypeTraits;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using AttributedGains = typename CombinedTraits::AttributedGains;
 
   struct RefinementStats {
     RefinementStats(utils::Stats& stats) :

--- a/mt-kahypar/partition/refinement/flows/scheduler.h
+++ b/mt-kahypar/partition/refinement/flows/scheduler.h
@@ -54,16 +54,16 @@ namespace {
   }
 }
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class FlowRefinementScheduler final : public IRefiner {
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;
 
-  using TypeTraits = typename CombinedTraits::TypeTraits;
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using AttributedGains = typename CombinedTraits::AttributedGains;
+  using TypeTraits = typename GraphAndGainTypes::TypeTraits;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
 
   struct RefinementStats {
     RefinementStats(utils::Stats& stats) :

--- a/mt-kahypar/partition/refinement/flows/sequential_construction.cpp
+++ b/mt-kahypar/partition/refinement/flows/sequential_construction.cpp
@@ -34,8 +34,8 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
-whfc::Hyperedge SequentialConstruction<TypeTraits, GainTypes>::DynamicIdenticalNetDetection::add_if_not_contained(
+template<typename CombinedTraits>
+whfc::Hyperedge SequentialConstruction<CombinedTraits>::DynamicIdenticalNetDetection::add_if_not_contained(
   const whfc::Hyperedge he, const size_t he_hash, const vec<whfc::Node>& pins) {
   const size_t bucket_idx = he_hash % _hash_buckets.size();
   if ( _hash_buckets[bucket_idx].threshold == _threshold ) {
@@ -64,12 +64,12 @@ whfc::Hyperedge SequentialConstruction<TypeTraits, GainTypes>::DynamicIdenticalN
   return whfc::invalidHyperedge;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
-                                                                                   const Subhypergraph& sub_hg,
-                                                                                   const PartitionID block_0,
-                                                                                   const PartitionID block_1,
-                                                                                   vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+                                                                            const Subhypergraph& sub_hg,
+                                                                            const PartitionID block_0,
+                                                                            const PartitionID block_1,
+                                                                            vec<HypernodeID>& whfc_to_node) {
   FlowProblem flow_problem;
   const double density = static_cast<double>(phg.initialNumEdges()) / phg.initialNumNodes();
   const double avg_he_size = static_cast<double>(phg.initialNumPins()) / phg.initialNumEdges();
@@ -109,13 +109,13 @@ FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructFlowHypergra
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
-                                                                                   const Subhypergraph& sub_hg,
-                                                                                   const PartitionID block_0,
-                                                                                   const PartitionID block_1,
-                                                                                   vec<HypernodeID>& whfc_to_node,
-                                                                                   const bool default_construction) {
+template<typename CombinedTraits>
+FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+                                                                            const Subhypergraph& sub_hg,
+                                                                            const PartitionID block_0,
+                                                                            const PartitionID block_1,
+                                                                            vec<HypernodeID>& whfc_to_node,
+                                                                            const bool default_construction) {
   FlowProblem flow_problem;
   if ( default_construction ) {
     // This algorithm iterates over all hyperedges and checks for all pins if
@@ -153,12 +153,12 @@ FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructFlowHypergra
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructDefault(const PartitionedHypergraph& phg,
-                                                                            const Subhypergraph& sub_hg,
-                                                                            const PartitionID block_0,
-                                                                            const PartitionID block_1,
-                                                                            vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem SequentialConstruction<CombinedTraits>::constructDefault(const PartitionedHypergraph& phg,
+                                                                     const Subhypergraph& sub_hg,
+                                                                     const PartitionID block_0,
+                                                                     const PartitionID block_1,
+                                                                     vec<HypernodeID>& whfc_to_node) {
   ASSERT(block_0 != kInvalidPartition && block_1 != kInvalidPartition);
   FlowProblem flow_problem;
   flow_problem.total_cut = 0;
@@ -274,12 +274,12 @@ FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructDefault(cons
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
-                                                                                         const Subhypergraph& sub_hg,
-                                                                                         const PartitionID block_0,
-                                                                                         const PartitionID block_1,
-                                                                                         vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+FlowProblem SequentialConstruction<CombinedTraits>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
+                                                                                  const Subhypergraph& sub_hg,
+                                                                                  const PartitionID block_0,
+                                                                                  const PartitionID block_1,
+                                                                                  vec<HypernodeID>& whfc_to_node) {
   ASSERT(block_0 != kInvalidPartition && block_1 != kInvalidPartition);
   FlowProblem flow_problem;
   flow_problem.total_cut = 0;
@@ -414,13 +414,13 @@ FlowProblem SequentialConstruction<TypeTraits, GainTypes>::constructOptimizedFor
   return flow_problem;
 }
 
-template<typename TypeTraits, typename GainTypes>
-void SequentialConstruction<TypeTraits, GainTypes>::determineDistanceFromCut(const PartitionedHypergraph& phg,
-                                                                             const whfc::Node source,
-                                                                             const whfc::Node sink,
-                                                                             const PartitionID block_0,
-                                                                             const PartitionID block_1,
-                                                                             const vec<HypernodeID>& whfc_to_node) {
+template<typename CombinedTraits>
+void SequentialConstruction<CombinedTraits>::determineDistanceFromCut(const PartitionedHypergraph& phg,
+                                                                      const whfc::Node source,
+                                                                      const whfc::Node sink,
+                                                                      const PartitionID block_0,
+                                                                      const PartitionID block_1,
+                                                                      const vec<HypernodeID>& whfc_to_node) {
   auto& distances = _hfc.cs.border_nodes.distance;
   distances.assign(_flow_hg.numNodes(), whfc::HopDistance(0));
   _visited_hns.resize(_flow_hg.numNodes() + _flow_hg.numHyperedges());
@@ -478,9 +478,9 @@ void SequentialConstruction<TypeTraits, GainTypes>::determineDistanceFromCut(con
 }
 
 namespace {
-#define SEQUENTIAL_CONSTRUCTION(X, Y) SequentialConstruction<X, Y>
+#define SEQUENTIAL_CONSTRUCTION(X) SequentialConstruction<X>
 }
 
-INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(SEQUENTIAL_CONSTRUCTION)
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(SEQUENTIAL_CONSTRUCTION)
 
 } // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/flows/sequential_construction.cpp
+++ b/mt-kahypar/partition/refinement/flows/sequential_construction.cpp
@@ -34,8 +34,8 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
-whfc::Hyperedge SequentialConstruction<CombinedTraits>::DynamicIdenticalNetDetection::add_if_not_contained(
+template<typename GraphAndGainTypes>
+whfc::Hyperedge SequentialConstruction<GraphAndGainTypes>::DynamicIdenticalNetDetection::add_if_not_contained(
   const whfc::Hyperedge he, const size_t he_hash, const vec<whfc::Node>& pins) {
   const size_t bucket_idx = he_hash % _hash_buckets.size();
   if ( _hash_buckets[bucket_idx].threshold == _threshold ) {
@@ -64,8 +64,8 @@ whfc::Hyperedge SequentialConstruction<CombinedTraits>::DynamicIdenticalNetDetec
   return whfc::invalidHyperedge;
 }
 
-template<typename CombinedTraits>
-FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem SequentialConstruction<GraphAndGainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
                                                                             const Subhypergraph& sub_hg,
                                                                             const PartitionID block_0,
                                                                             const PartitionID block_1,
@@ -109,8 +109,8 @@ FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(cons
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem SequentialConstruction<GraphAndGainTypes>::constructFlowHypergraph(const PartitionedHypergraph& phg,
                                                                             const Subhypergraph& sub_hg,
                                                                             const PartitionID block_0,
                                                                             const PartitionID block_1,
@@ -153,8 +153,8 @@ FlowProblem SequentialConstruction<CombinedTraits>::constructFlowHypergraph(cons
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem SequentialConstruction<CombinedTraits>::constructDefault(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem SequentialConstruction<GraphAndGainTypes>::constructDefault(const PartitionedHypergraph& phg,
                                                                      const Subhypergraph& sub_hg,
                                                                      const PartitionID block_0,
                                                                      const PartitionID block_1,
@@ -274,8 +274,8 @@ FlowProblem SequentialConstruction<CombinedTraits>::constructDefault(const Parti
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-FlowProblem SequentialConstruction<CombinedTraits>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+FlowProblem SequentialConstruction<GraphAndGainTypes>::constructOptimizedForLargeHEs(const PartitionedHypergraph& phg,
                                                                                   const Subhypergraph& sub_hg,
                                                                                   const PartitionID block_0,
                                                                                   const PartitionID block_1,
@@ -414,8 +414,8 @@ FlowProblem SequentialConstruction<CombinedTraits>::constructOptimizedForLargeHE
   return flow_problem;
 }
 
-template<typename CombinedTraits>
-void SequentialConstruction<CombinedTraits>::determineDistanceFromCut(const PartitionedHypergraph& phg,
+template<typename GraphAndGainTypes>
+void SequentialConstruction<GraphAndGainTypes>::determineDistanceFromCut(const PartitionedHypergraph& phg,
                                                                       const whfc::Node source,
                                                                       const whfc::Node sink,
                                                                       const PartitionID block_0,

--- a/mt-kahypar/partition/refinement/flows/sequential_construction.h
+++ b/mt-kahypar/partition/refinement/flows/sequential_construction.h
@@ -41,13 +41,13 @@ namespace mt_kahypar {
 
 struct FlowProblem;
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class SequentialConstruction {
 
   static constexpr bool debug = false;
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using FlowNetworkConstruction = typename CombinedTraits::FlowNetworkConstruction;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using FlowNetworkConstruction = typename GraphAndGainTypes::FlowNetworkConstruction;
 
   struct TmpPin {
     HyperedgeID e;

--- a/mt-kahypar/partition/refinement/flows/sequential_construction.h
+++ b/mt-kahypar/partition/refinement/flows/sequential_construction.h
@@ -41,13 +41,13 @@ namespace mt_kahypar {
 
 struct FlowProblem;
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class SequentialConstruction {
 
   static constexpr bool debug = false;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using FlowNetworkConstruction = typename GainTypes::FlowNetworkConstruction;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using FlowNetworkConstruction = typename CombinedTraits::FlowNetworkConstruction;
 
   struct TmpPin {
     HyperedgeID e;

--- a/mt-kahypar/partition/refinement/fm/fm_commons.cpp
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.cpp
@@ -70,11 +70,11 @@ namespace mt_kahypar {
   }
 
 
-  template<typename TypeTraits, typename GainTypes>
-  void UnconstrainedFMData::InitializationHelper<TypeTraits, GainTypes>::initialize(
+  template<typename CombinedTraits>
+  void UnconstrainedFMData::InitializationHelper<CombinedTraits>::initialize(
             UnconstrainedFMData& data, const Context& context,
-            const typename TypeTraits::PartitionedHypergraph& phg,
-            const typename GainTypes::GainCache& gain_cache) {
+            const typename CombinedTraits::PartitionedHypergraph& phg,
+            const typename CombinedTraits::GainCache& gain_cache) {
     auto get_node_stats = [&](const HypernodeID hypernode) {
       // TODO(maas): we might want to save the total incident weight in the hypergraph data structure
       // at some point in the future
@@ -250,8 +250,8 @@ namespace mt_kahypar {
   }
 
   namespace {
-  #define UNCONSTRAINED_FM_INITIALIZATION(X, Y) UnconstrainedFMData::InitializationHelper<X, Y>;
+  #define UNCONSTRAINED_FM_INITIALIZATION(X) UnconstrainedFMData::InitializationHelper<X>
   }
 
-  INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(UNCONSTRAINED_FM_INITIALIZATION)
+  INSTANTIATE_CLASS_WITH_VALID_TRAITS(UNCONSTRAINED_FM_INITIALIZATION)
 }

--- a/mt-kahypar/partition/refinement/fm/fm_commons.cpp
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.cpp
@@ -70,11 +70,11 @@ namespace mt_kahypar {
   }
 
 
-  template<typename CombinedTraits>
-  void UnconstrainedFMData::InitializationHelper<CombinedTraits>::initialize(
+  template<typename GraphAndGainTypes>
+  void UnconstrainedFMData::InitializationHelper<GraphAndGainTypes>::initialize(
             UnconstrainedFMData& data, const Context& context,
-            const typename CombinedTraits::PartitionedHypergraph& phg,
-            const typename CombinedTraits::GainCache& gain_cache) {
+            const typename GraphAndGainTypes::PartitionedHypergraph& phg,
+            const typename GraphAndGainTypes::GainCache& gain_cache) {
     auto get_node_stats = [&](const HypernodeID hypernode) {
       // TODO(maas): we might want to save the total incident weight in the hypergraph data structure
       // at some point in the future

--- a/mt-kahypar/partition/refinement/fm/fm_commons.h
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.h
@@ -155,11 +155,11 @@ class UnconstrainedFMData {
   using BucketID = uint32_t;
   using AtomicBucketID = parallel::IntegralAtomicWrapper<BucketID>;
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   struct InitializationHelper {
     static void initialize(UnconstrainedFMData& data, const Context& context,
-                           const typename CombinedTraits::PartitionedHypergraph& phg,
-                           const typename CombinedTraits::GainCache& gain_cache);
+                           const typename GraphAndGainTypes::PartitionedHypergraph& phg,
+                           const typename GraphAndGainTypes::GainCache& gain_cache);
   };
 
   static constexpr BucketID NUM_BUCKETS = 16;
@@ -175,14 +175,14 @@ class UnconstrainedFMData {
     local_bucket_weights(),
     rebalancing_nodes(num_nodes) { }
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   void initialize(const Context& context,
-                  const typename CombinedTraits::PartitionedHypergraph& phg,
-                  const typename CombinedTraits::GainCache& gain_cache) {
+                  const typename GraphAndGainTypes::PartitionedHypergraph& phg,
+                  const typename GraphAndGainTypes::GainCache& gain_cache) {
     changeNumberOfBlocks(context.partition.k);
     reset();
 
-    InitializationHelper<CombinedTraits>::initialize(*this, context, phg, gain_cache);
+    InitializationHelper<GraphAndGainTypes>::initialize(*this, context, phg, gain_cache);
   }
 
   Gain estimatePenaltyForImbalancedMove(PartitionID to, HypernodeWeight initial_imbalance, HypernodeWeight moved_weight) const;
@@ -207,7 +207,7 @@ class UnconstrainedFMData {
   }
 
  private:
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   friend class InitializationHelper;
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE size_t indexForBucket(PartitionID block, BucketID bucketId) const {

--- a/mt-kahypar/partition/refinement/fm/fm_commons.h
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.h
@@ -155,11 +155,11 @@ class UnconstrainedFMData {
   using BucketID = uint32_t;
   using AtomicBucketID = parallel::IntegralAtomicWrapper<BucketID>;
 
-  template<typename TypeTraits, typename GainTypes>
+  template<typename CombinedTraits>
   struct InitializationHelper {
     static void initialize(UnconstrainedFMData& data, const Context& context,
-                           const typename TypeTraits::PartitionedHypergraph& phg,
-                           const typename GainTypes::GainCache& gain_cache);
+                           const typename CombinedTraits::PartitionedHypergraph& phg,
+                           const typename CombinedTraits::GainCache& gain_cache);
   };
 
   static constexpr BucketID NUM_BUCKETS = 16;
@@ -175,14 +175,14 @@ class UnconstrainedFMData {
     local_bucket_weights(),
     rebalancing_nodes(num_nodes) { }
 
-  template<typename TypeTraits, typename GainTypes>
+  template<typename CombinedTraits>
   void initialize(const Context& context,
-                  const typename TypeTraits::PartitionedHypergraph& phg,
-                  const typename GainTypes::GainCache& gain_cache) {
+                  const typename CombinedTraits::PartitionedHypergraph& phg,
+                  const typename CombinedTraits::GainCache& gain_cache) {
     changeNumberOfBlocks(context.partition.k);
     reset();
 
-    InitializationHelper<TypeTraits, GainTypes>::initialize(*this, context, phg, gain_cache);
+    InitializationHelper<CombinedTraits>::initialize(*this, context, phg, gain_cache);
   }
 
   Gain estimatePenaltyForImbalancedMove(PartitionID to, HypernodeWeight initial_imbalance, HypernodeWeight moved_weight) const;
@@ -207,7 +207,7 @@ class UnconstrainedFMData {
   }
 
  private:
-  template<typename TypeTraits, typename GainTypes>
+  template<typename CombinedTraits>
   friend class InitializationHelper;
 
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE size_t indexForBucket(PartitionID block, BucketID bucketId) const {

--- a/mt-kahypar/partition/refinement/fm/fm_commons.h
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.h
@@ -275,7 +275,6 @@ struct FMSharedData {
   size_t finishedTasksLimit = std::numeric_limits<size_t>::max();
 
   bool release_nodes = true;
-  bool perform_moves_global = true;
 
   FMSharedData(size_t numNodes, size_t numThreads) :
     numberOfNodes(numNodes),

--- a/mt-kahypar/partition/refinement/fm/fm_commons.h
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.h
@@ -325,48 +325,4 @@ struct FMSharedData {
   }
 };
 
-struct FMStats {
-  size_t retries = 0;
-  size_t extractions = 0;
-  size_t pushes = 0;
-  size_t moves = 0;
-  size_t local_reverts = 0;
-  size_t task_queue_reinsertions = 0;
-  size_t best_prefix_mismatch = 0;
-  Gain estimated_improvement = 0;
-
-
-  void clear() {
-    retries = 0;
-    extractions = 0;
-    pushes = 0;
-    moves = 0;
-    local_reverts = 0;
-    task_queue_reinsertions = 0;
-    best_prefix_mismatch = 0;
-    estimated_improvement = 0;
-  }
-
-  void merge(FMStats& other) {
-    other.retries += retries;
-    other.extractions += extractions;
-    other.pushes += pushes;
-    other.moves += moves;
-    other.local_reverts += local_reverts;
-    other.task_queue_reinsertions += task_queue_reinsertions;
-    other.best_prefix_mismatch += best_prefix_mismatch;
-    other.estimated_improvement += estimated_improvement;
-    clear();
-  }
-
-  std::string serialize() const {
-    std::stringstream os;
-    os  << V(retries) << " " << V(extractions) << " " << V(pushes) << " "
-        << V(moves) << " " << V(local_reverts) << " " << V(estimated_improvement) << " "
-        << V(best_prefix_mismatch);
-    return os.str();
-  }
-};
-
-
 }

--- a/mt-kahypar/partition/refinement/fm/global_rollback.cpp
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.cpp
@@ -155,8 +155,8 @@ namespace mt_kahypar {
     }
   };
 
-  template<typename CombinedTraits>
-  HyperedgeWeight GlobalRollback<CombinedTraits>::revertToBestPrefixParallel(
+  template<typename GraphAndGainTypes>
+  HyperedgeWeight GlobalRollback<GraphAndGainTypes>::revertToBestPrefixParallel(
           PartitionedHypergraph& phg, FMSharedData& sharedData,
           const vec<HypernodeWeight>& partWeights, const std::vector<HypernodeWeight>& maxPartWeights) {
     const MoveID numMoves = sharedData.moveTracker.numPerformedMoves();
@@ -192,8 +192,8 @@ namespace mt_kahypar {
     return b.gain;
   }
 
-  template<typename CombinedTraits>
-  void GlobalRollback<CombinedTraits>::recalculateGainForHyperedge(PartitionedHypergraph& phg,
+  template<typename GraphAndGainTypes>
+  void GlobalRollback<GraphAndGainTypes>::recalculateGainForHyperedge(PartitionedHypergraph& phg,
                                                                    FMSharedData& sharedData,
                                                                    const HyperedgeID& e) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
@@ -250,8 +250,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void GlobalRollback<CombinedTraits>::recalculateGainForHyperedgeViaAttributedGains(PartitionedHypergraph& phg,
+  template<typename GraphAndGainTypes>
+  void GlobalRollback<GraphAndGainTypes>::recalculateGainForHyperedgeViaAttributedGains(PartitionedHypergraph& phg,
                                                                                      FMSharedData& sharedData,
                                                                                      const HyperedgeID& e) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
@@ -307,8 +307,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void GlobalRollback<CombinedTraits>::recalculateGainForGraphEdgeViaAttributedGains(PartitionedHypergraph& phg,
+  template<typename GraphAndGainTypes>
+  void GlobalRollback<GraphAndGainTypes>::recalculateGainForGraphEdgeViaAttributedGains(PartitionedHypergraph& phg,
                                                                                      FMSharedData& sharedData,
                                                                                      const HyperedgeID& e) {
     if ( !phg.isSinglePin(e) ) {
@@ -371,8 +371,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void GlobalRollback<CombinedTraits>::recalculateGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
+  template<typename GraphAndGainTypes>
+  void GlobalRollback<GraphAndGainTypes>::recalculateGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
 
     auto recalculate_and_distribute_for_hyperedge = [&](const HyperedgeID e) {
@@ -415,8 +415,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  HyperedgeWeight GlobalRollback<CombinedTraits>::revertToBestPrefixSequential(
+  template<typename GraphAndGainTypes>
+  HyperedgeWeight GlobalRollback<GraphAndGainTypes>::revertToBestPrefixSequential(
     PartitionedHypergraph& phg,
     FMSharedData& sharedData,
     const vec<HypernodeWeight>&,
@@ -495,8 +495,8 @@ namespace mt_kahypar {
   }
 
 
-  template<typename CombinedTraits>
-  bool GlobalRollback<CombinedTraits>::verifyGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
+  template<typename GraphAndGainTypes>
+  bool GlobalRollback<GraphAndGainTypes>::verifyGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
     vec<Move>& move_order = sharedData.moveTracker.moveOrder;
 
     auto recompute_penalty_terms = [&] {

--- a/mt-kahypar/partition/refinement/fm/global_rollback.cpp
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.cpp
@@ -155,8 +155,8 @@ namespace mt_kahypar {
     }
   };
 
-  template<typename TypeTraits, typename GainTypes>
-  HyperedgeWeight GlobalRollback<TypeTraits, GainTypes>::revertToBestPrefixParallel(
+  template<typename CombinedTraits>
+  HyperedgeWeight GlobalRollback<CombinedTraits>::revertToBestPrefixParallel(
           PartitionedHypergraph& phg, FMSharedData& sharedData,
           const vec<HypernodeWeight>& partWeights, const std::vector<HypernodeWeight>& maxPartWeights) {
     const MoveID numMoves = sharedData.moveTracker.numPerformedMoves();
@@ -192,10 +192,10 @@ namespace mt_kahypar {
     return b.gain;
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  void GlobalRollback<TypeTraits, GainTypes>::recalculateGainForHyperedge(PartitionedHypergraph& phg,
-                                                                          FMSharedData& sharedData,
-                                                                          const HyperedgeID& e) {
+  template<typename CombinedTraits>
+  void GlobalRollback<CombinedTraits>::recalculateGainForHyperedge(PartitionedHypergraph& phg,
+                                                                   FMSharedData& sharedData,
+                                                                   const HyperedgeID& e) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
     auto& r = ets_recalc_data.local();
 
@@ -250,10 +250,10 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  void GlobalRollback<TypeTraits, GainTypes>::recalculateGainForHyperedgeViaAttributedGains(PartitionedHypergraph& phg,
-                                                                                            FMSharedData& sharedData,
-                                                                                            const HyperedgeID& e) {
+  template<typename CombinedTraits>
+  void GlobalRollback<CombinedTraits>::recalculateGainForHyperedgeViaAttributedGains(PartitionedHypergraph& phg,
+                                                                                     FMSharedData& sharedData,
+                                                                                     const HyperedgeID& e) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
     ds::Bitset& connectivity_set = phg.deepCopyOfConnectivitySet(e);
     ds::PinCountSnapshot pin_counts(phg.k(), phg.hypergraph().maxEdgeSize());
@@ -307,10 +307,10 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  void GlobalRollback<TypeTraits, GainTypes>::recalculateGainForGraphEdgeViaAttributedGains(PartitionedHypergraph& phg,
-                                                                                            FMSharedData& sharedData,
-                                                                                            const HyperedgeID& e) {
+  template<typename CombinedTraits>
+  void GlobalRollback<CombinedTraits>::recalculateGainForGraphEdgeViaAttributedGains(PartitionedHypergraph& phg,
+                                                                                     FMSharedData& sharedData,
+                                                                                     const HyperedgeID& e) {
     if ( !phg.isSinglePin(e) ) {
       GlobalMoveTracker& tracker = sharedData.moveTracker;
       SynchronizedEdgeUpdate sync_update;
@@ -371,9 +371,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  void GlobalRollback<TypeTraits, GainTypes>::recalculateGains(PartitionedHypergraph& phg,
-                                                               FMSharedData& sharedData) {
+  template<typename CombinedTraits>
+  void GlobalRollback<CombinedTraits>::recalculateGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
     GlobalMoveTracker& tracker = sharedData.moveTracker;
 
     auto recalculate_and_distribute_for_hyperedge = [&](const HyperedgeID e) {
@@ -416,8 +415,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename TypeTraits, typename GainTypes>
-  HyperedgeWeight GlobalRollback<TypeTraits, GainTypes>::revertToBestPrefixSequential(
+  template<typename CombinedTraits>
+  HyperedgeWeight GlobalRollback<CombinedTraits>::revertToBestPrefixSequential(
     PartitionedHypergraph& phg,
     FMSharedData& sharedData,
     const vec<HypernodeWeight>&,
@@ -496,9 +495,8 @@ namespace mt_kahypar {
   }
 
 
-  template<typename TypeTraits, typename GainTypes>
-  bool GlobalRollback<TypeTraits, GainTypes>::verifyGains(PartitionedHypergraph& phg,
-                                                          FMSharedData& sharedData) {
+  template<typename CombinedTraits>
+  bool GlobalRollback<CombinedTraits>::verifyGains(PartitionedHypergraph& phg, FMSharedData& sharedData) {
     vec<Move>& move_order = sharedData.moveTracker.moveOrder;
 
     auto recompute_penalty_terms = [&] {
@@ -557,8 +555,8 @@ namespace mt_kahypar {
   }
 
   namespace {
-  #define GLOBAL_ROLLBACK(X, Y) GlobalRollback<X, Y>
+  #define GLOBAL_ROLLBACK(X) GlobalRollback<X>
   }
 
-  INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(GLOBAL_ROLLBACK)
+  INSTANTIATE_CLASS_WITH_VALID_TRAITS(GLOBAL_ROLLBACK)
 }

--- a/mt-kahypar/partition/refinement/fm/global_rollback.h
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.h
@@ -33,14 +33,14 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class GlobalRollback {
   static constexpr bool enable_heavy_assert = false;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using AttributedGains = typename GainTypes::AttributedGains;
-  using Rollback = typename GainTypes::Rollback;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using AttributedGains = typename CombinedTraits::AttributedGains;
+  using Rollback = typename CombinedTraits::Rollback;
   using RecalculationData = typename Rollback::RecalculationData;
 
 public:

--- a/mt-kahypar/partition/refinement/fm/global_rollback.h
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.h
@@ -33,14 +33,14 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class GlobalRollback {
   static constexpr bool enable_heavy_assert = false;
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using AttributedGains = typename CombinedTraits::AttributedGains;
-  using Rollback = typename CombinedTraits::Rollback;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
+  using Rollback = typename GraphAndGainTypes::Rollback;
   using RecalculationData = typename Rollback::RecalculationData;
 
 public:

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
@@ -52,11 +52,7 @@ namespace mt_kahypar {
       deltaPhg.clear();
       deltaPhg.setPartitionedHypergraph(&phg);
       delta_gain_cache.clear();
-      if ( phg.hasFixedVertices() ) {
-        internalFindMoves<true>(phg, fm_strategy);
-      } else {
-        internalFindMoves<false>(phg, fm_strategy);
-      }
+      internalFindMoves(phg, fm_strategy);
       return true;
     } else {
       return false;
@@ -113,7 +109,7 @@ namespace mt_kahypar {
 
 
   template<typename TypeTraits, typename GainTypes>
-  template<bool has_fixed_vertices, typename DispatchedFMStrategy>
+  template<typename DispatchedFMStrategy>
   void LocalizedKWayFM<TypeTraits, GainTypes>::internalFindMoves(PartitionedHypergraph& phg,
                                                                  DispatchedFMStrategy& fm_strategy) {
     StopRule stopRule(phg.initialNumNodes());
@@ -203,7 +199,12 @@ namespace mt_kahypar {
           break;
         }
 
-        acquireOrUpdateNeighbors<has_fixed_vertices>(deltaPhg, delta_gain_cache, move, fm_strategy);
+        if (phg.hasFixedVertices()) {
+          acquireOrUpdateNeighbors<true>(deltaPhg, delta_gain_cache, move, fm_strategy);
+        } else {
+          acquireOrUpdateNeighbors<false>(deltaPhg, delta_gain_cache, move, fm_strategy);
+        }
+
       }
     }
 

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
@@ -42,13 +42,15 @@ namespace mt_kahypar {
     thisSearch = ++sharedData.nodeTracker.highestActiveSearchID;
 
     HypernodeID seedNode;
-    while (runStats.pushes < numSeeds && sharedData.refinementNodes.try_pop(seedNode, taskID)) {
+    HypernodeID pushes = 0;
+    while (pushes < numSeeds && sharedData.refinementNodes.try_pop(seedNode, taskID)) {
       if (sharedData.nodeTracker.tryAcquireNode(seedNode, thisSearch)) {
         fm_strategy.insertIntoPQ(phg, gain_cache, seedNode);
+        pushes++;
       }
     }
 
-    if (runStats.pushes > 0) {
+    if (pushes > 0) {
       deltaPhg.clear();
       deltaPhg.setPartitionedHypergraph(&phg);
       delta_gain_cache.clear();
@@ -178,7 +180,6 @@ namespace mt_kahypar {
       }
 
       if (moved) {
-        runStats.moves++;
         estimatedImprovement += move.gain;
         localMoves.emplace_back(move, move_id);
         stopRule.update(move.gain);
@@ -220,8 +221,6 @@ namespace mt_kahypar {
     }
 
     fm_strategy.reset();
-    runStats.estimated_improvement = bestImprovement;
-    runStats.merge(stats);
   }
 
 

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
@@ -34,9 +34,9 @@
 
 namespace mt_kahypar {
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   template<typename DispatchedFMStrategy>
-  bool LocalizedKWayFM<CombinedTraits>::findMoves(DispatchedFMStrategy& fm_strategy, PartitionedHypergraph& phg,
+  bool LocalizedKWayFM<GraphAndGainTypes>::findMoves(DispatchedFMStrategy& fm_strategy, PartitionedHypergraph& phg,
                                                   size_t taskID, size_t numSeeds) {
     localMoves.clear();
     thisSearch = ++sharedData.nodeTracker.highestActiveSearchID;
@@ -73,10 +73,10 @@ namespace mt_kahypar {
     return std::make_pair(p, w);
   }
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   template<bool has_fixed_vertices, typename PHG, typename CACHE, typename DispatchedFMStrategy>
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
-  void LocalizedKWayFM<CombinedTraits>::acquireOrUpdateNeighbors(PHG& phg, CACHE& gain_cache, const Move& move,
+  void LocalizedKWayFM<GraphAndGainTypes>::acquireOrUpdateNeighbors(PHG& phg, CACHE& gain_cache, const Move& move,
                                                                  DispatchedFMStrategy& fm_strategy) {
     auto updateOrAcquire = [&](const HypernodeID v) {
       SearchID searchOfV = sharedData.nodeTracker.searchOfNode[v].load(std::memory_order_relaxed);
@@ -119,9 +119,9 @@ namespace mt_kahypar {
   }
 
 
-  template<typename CombinedTraits>
+  template<typename GraphAndGainTypes>
   template<typename DispatchedFMStrategy>
-  void LocalizedKWayFM<CombinedTraits>::internalFindMoves(PartitionedHypergraph& phg,
+  void LocalizedKWayFM<GraphAndGainTypes>::internalFindMoves(PartitionedHypergraph& phg,
                                                           DispatchedFMStrategy& fm_strategy) {
     StopRule stopRule(phg.initialNumNodes());
     Move move;
@@ -225,8 +225,8 @@ namespace mt_kahypar {
   }
 
 
-  template<typename CombinedTraits>
-  void LocalizedKWayFM<CombinedTraits>::changeNumberOfBlocks(const PartitionID new_k) {
+  template<typename GraphAndGainTypes>
+  void LocalizedKWayFM<GraphAndGainTypes>::changeNumberOfBlocks(const PartitionID new_k) {
     deltaPhg.changeNumberOfBlocks(new_k);
     blockPQ.resize(new_k);
     for ( VertexPriorityQueue& pq : vertexPQs ) {
@@ -237,8 +237,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void LocalizedKWayFM<CombinedTraits>::memoryConsumption(utils::MemoryTreeNode *parent) const {
+  template<typename GraphAndGainTypes>
+  void LocalizedKWayFM<GraphAndGainTypes>::memoryConsumption(utils::MemoryTreeNode *parent) const {
     ASSERT(parent);
 
     utils::MemoryTreeNode *localized_fm_node = parent->addChild("Localized k-Way FM");

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -62,7 +62,7 @@ public:
     context(context),
     thisSearch(0),
     deltaPhg(context),
-    neighborDeduplicator(numNodes, 0),
+    neighborDeduplicator(PartitionedHypergraph::is_graph ? 0 : numNodes, 0),
     gain_cache(gainCache),
     delta_gain_cache(gainCache),
     sharedData(sharedData),
@@ -113,7 +113,7 @@ private:
 
   // ! Used after a move. Stores whether a neighbor of the just moved vertex has already been updated.
   vec<HypernodeID> neighborDeduplicator;
-  HypernodeID deduplicationTime = 0;
+  HypernodeID deduplicationTime = 1;
 
   // ! Stores hyperedges whose pins's gains may have changed after vertex move
   vec<HyperedgeID> edgesWithGainChanges;

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -88,24 +88,13 @@ public:
   FMStats stats;
 
 private:
-  template<bool use_delta, bool has_fixed_vertices, typename DispatchedFMStrategy>
+  template<bool has_fixed_vertices, typename DispatchedFMStrategy>
   void internalFindMoves(PartitionedHypergraph& phg, DispatchedFMStrategy& fm_strategy);
 
   template<bool has_fixed_vertices, typename PHG, typename CACHE, typename DispatchedFMStrategy>
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
   void acquireOrUpdateNeighbors(PHG& phg, CACHE& gain_cache, const Move& move, DispatchedFMStrategy& fm_strategy);
 
-
-  // ! Makes moves applied on delta hypergraph visible on the global partitioned hypergraph.
-  template<typename DispatchedFMStrategy>
-  void applyBestLocalPrefixToSharedPartition(PartitionedHypergraph& phg,
-                                             DispatchedFMStrategy& fm_strategy,
-                                             const size_t best_index_locally_observed);
-
-  // ! Rollback to the best improvement found during local search in case we applied moves
-  // ! directly on the global partitioned hypergraph.
-  template<typename DispatchedFMStrategy>
-  void revertToBestLocalPrefix(PartitionedHypergraph& phg, DispatchedFMStrategy& fm_strategy, size_t bestGainIndex);
 
  private:
 

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -88,7 +88,7 @@ public:
   FMStats stats;
 
 private:
-  template<bool has_fixed_vertices, typename DispatchedFMStrategy>
+  template<typename DispatchedFMStrategy>
   void internalFindMoves(PartitionedHypergraph& phg, DispatchedFMStrategy& fm_strategy);
 
   template<bool has_fixed_vertices, typename PHG, typename CACHE, typename DispatchedFMStrategy>

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -50,7 +50,6 @@ public:
   using GainCache = typename GraphAndGainTypes::GainCache;
   using DeltaGainCache = typename GraphAndGainTypes::DeltaGainCache;
   using DeltaPartitionedHypergraph = typename PartitionedHypergraph::template DeltaPartition<DeltaGainCache::requires_connectivity_set>;
-  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
   using BlockPriorityQueue = ds::ExclusiveHandleHeap< ds::MaxHeap<Gain, PartitionID> >;
   using VertexPriorityQueue = ds::MaxHeap<Gain, HypernodeID>;    // these need external handles
 
@@ -75,7 +74,7 @@ public:
 
   template<typename DispatchedFMStrategy>
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE DispatchedFMStrategy initializeDispatchedStrategy() {
-    return DispatchedFMStrategy(context, sharedData, blockPQ, vertexPQs, runStats);
+    return DispatchedFMStrategy(context, sharedData, blockPQ, vertexPQs);
   }
 
   template<typename DispatchedFMStrategy>
@@ -84,8 +83,6 @@ public:
   void memoryConsumption(utils::MemoryTreeNode* parent) const;
 
   void changeNumberOfBlocks(const PartitionID new_k);
-
-  FMStats stats;
 
 private:
   template<typename DispatchedFMStrategy>
@@ -117,8 +114,6 @@ private:
 
   // ! Stores hyperedges whose pins's gains may have changed after vertex move
   vec<HyperedgeID> edgesWithGainChanges;
-
-  FMStats runStats;
 
   GainCache& gain_cache;
 

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -38,19 +38,19 @@
 namespace mt_kahypar {
 
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class LocalizedKWayFM {
 public:
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
 
  private:
   static constexpr size_t MAP_SIZE_LARGE = 16384;
   static constexpr size_t MAP_SIZE_MOVE_DELTA = 8192;
 
-  using GainCache = typename CombinedTraits::GainCache;
-  using DeltaGainCache = typename CombinedTraits::DeltaGainCache;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using DeltaGainCache = typename GraphAndGainTypes::DeltaGainCache;
   using DeltaPartitionedHypergraph = typename PartitionedHypergraph::template DeltaPartition<DeltaGainCache::requires_connectivity_set>;
-  using AttributedGains = typename CombinedTraits::AttributedGains;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
   using BlockPriorityQueue = ds::ExclusiveHandleHeap< ds::MaxHeap<Gain, PartitionID> >;
   using VertexPriorityQueue = ds::MaxHeap<Gain, HypernodeID>;    // these need external handles
 

--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.h
@@ -38,19 +38,19 @@
 namespace mt_kahypar {
 
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class LocalizedKWayFM {
 public:
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
 
  private:
   static constexpr size_t MAP_SIZE_LARGE = 16384;
   static constexpr size_t MAP_SIZE_MOVE_DELTA = 8192;
 
-  using GainCache = typename GainTypes::GainCache;
-  using DeltaGainCache = typename GainTypes::DeltaGainCache;
+  using GainCache = typename CombinedTraits::GainCache;
+  using DeltaGainCache = typename CombinedTraits::DeltaGainCache;
   using DeltaPartitionedHypergraph = typename PartitionedHypergraph::template DeltaPartition<DeltaGainCache::requires_connectivity_set>;
-  using AttributedGains = typename GainTypes::AttributedGains;
+  using AttributedGains = typename CombinedTraits::AttributedGains;
   using BlockPriorityQueue = ds::ExclusiveHandleHeap< ds::MaxHeap<Gain, PartitionID> >;
   using VertexPriorityQueue = ds::MaxHeap<Gain, HypernodeID>;    // these need external handles
 

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -40,8 +40,8 @@
 namespace mt_kahypar {
   using ds::StreamingVector;
 
-  template<typename CombinedTraits>
-  MultiTryKWayFM<CombinedTraits>::MultiTryKWayFM(const HypernodeID num_hypernodes,
+  template<typename GraphAndGainTypes>
+  MultiTryKWayFM<GraphAndGainTypes>::MultiTryKWayFM(const HypernodeID num_hypernodes,
                                                  const HyperedgeID num_hyperedges,
                                                  const Context& c,
                                                  GainCache& gainCache,
@@ -77,8 +77,8 @@ namespace mt_kahypar {
     return max_part_weights;
   }
 
-  template<typename CombinedTraits>
-  bool MultiTryKWayFM<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+  template<typename GraphAndGainTypes>
+  bool MultiTryKWayFM<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                                                   const vec<HypernodeID>& refinement_nodes,
                                                   Metrics& metrics,
                                                   const double time_limit) {
@@ -108,7 +108,7 @@ namespace mt_kahypar {
       const bool is_unconstrained = fm_strategy->isUnconstrainedRound(round);
       if (is_unconstrained) {
         timer.start_timer("initialize_data_unconstrained", "Initialize Data for Unc. FM");
-        sharedData.unconstrained.initialize<CombinedTraits>(context, phg, gain_cache);
+        sharedData.unconstrained.initialize<GraphAndGainTypes>(context, phg, gain_cache);
         timer.stop_timer("initialize_data_unconstrained");
       }
 
@@ -225,8 +225,8 @@ namespace mt_kahypar {
     return overall_improvement > 0;
   }
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::roundInitialization(PartitionedHypergraph& phg,
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::roundInitialization(PartitionedHypergraph& phg,
                                                                   const vec<HypernodeID>& refinement_nodes) {
     // clear border nodes
     sharedData.refinementNodes.clear();
@@ -274,8 +274,8 @@ namespace mt_kahypar {
     sharedData.nodeTracker.requestNewSearches(static_cast<SearchID>(sharedData.refinementNodes.unsafe_size()));
   }
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::interleaveMoveSequenceWithRebalancingMoves(
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::interleaveMoveSequenceWithRebalancingMoves(
                                                             const PartitionedHypergraph& phg,
                                                             const vec<HypernodeWeight>& initialPartWeights,
                                                             const std::vector<HypernodeWeight>& max_part_weights,
@@ -383,8 +383,8 @@ namespace mt_kahypar {
     }, tbb::static_partitioner());
   }
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::insertMovesToBalanceBlock(const PartitionedHypergraph& phg,
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::insertMovesToBalanceBlock(const PartitionedHypergraph& phg,
                                                                         const PartitionID block,
                                                                         const std::vector<HypernodeWeight>& max_part_weights,
                                                                         const vec<vec<Move>>& rebalancing_moves_by_part,
@@ -413,8 +413,8 @@ namespace mt_kahypar {
   }
 
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
     PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
 
     if (!gain_cache.isInitialized()) {
@@ -422,8 +422,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::resizeDataStructuresForCurrentK() {
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::resizeDataStructuresForCurrentK() {
     // If the number of blocks changes, we resize data structures
     // (can happen during deep multilevel partitioning)
     if ( current_k != context.partition.k ) {
@@ -441,8 +441,8 @@ namespace mt_kahypar {
     }
   }
 
-  template<typename CombinedTraits>
-  void MultiTryKWayFM<CombinedTraits>::printMemoryConsumption() {
+  template<typename GraphAndGainTypes>
+  void MultiTryKWayFM<GraphAndGainTypes>::printMemoryConsumption() {
     utils::MemoryTreeNode fm_memory("Multitry k-Way FM", utils::OutputType::MEGABYTE);
 
     for (const auto& fm : ets_fm) {

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -427,8 +427,6 @@ namespace mt_kahypar {
     if (!gain_cache.isInitialized()) {
       gain_cache.initializeGainCache(phg);
     }
-    rebalancer.initialize(hypergraph);
-
     is_initialized = true;
   }
 

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -181,13 +181,9 @@ namespace mt_kahypar {
       HighResClockTimepoint fm_timestamp = std::chrono::high_resolution_clock::now();
       const double elapsed_time = std::chrono::duration<double>(fm_timestamp - fm_start).count();
       if (debug && context.type == ContextType::main) {
-        FMStats stats;
-        for (auto& fm : ets_fm) {
-          fm.stats.merge(stats);
-        }
         LOG << V(round) << V(improvement) << V(metrics::quality(phg, context))
             << V(metrics::imbalance(phg, context)) << V(num_border_nodes) << V(roundImprovementFraction)
-            << V(elapsed_time) << V(current_time_limit) << stats.serialize();
+            << V(elapsed_time) << V(current_time_limit);
       }
 
       // Enforce a time limit (based on k and coarsening time).

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -92,7 +92,6 @@ namespace mt_kahypar {
     size_t consecutive_rounds_with_too_little_improvement = 0;
     enable_light_fm = false;
     sharedData.release_nodes = context.refinement.fm.release_nodes;
-    sharedData.perform_moves_global = context.refinement.fm.perform_moves_global;
     double current_time_limit = time_limit;
     tbb::task_group tg;
     vec<HypernodeWeight> initialPartWeights(size_t(context.partition.k));
@@ -200,7 +199,6 @@ namespace mt_kahypar {
         if ( !enable_light_fm ) {
           DBG << RED << "Multitry FM reached time limit => switch to Light FM Configuration" << END;
           sharedData.release_nodes = false;
-          sharedData.perform_moves_global = true;
           current_time_limit *= 2;
           enable_light_fm = true;
         } else {

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -84,8 +84,6 @@ namespace mt_kahypar {
               Metrics& metrics,
               const double time_limit) {
     PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
-
-    if (!is_initialized) throw std::runtime_error("Call initialize on fm before calling refine");
     resizeDataStructuresForCurrentK();
 
     Gain overall_improvement = 0;
@@ -217,10 +215,6 @@ namespace mt_kahypar {
         && context.type == ContextType::main
         && phg.initialNumNodes() == sharedData.moveTracker.moveOrder.size() /* top level */) {
       printMemoryConsumption();
-    }
-
-    if ( !context.isNLevelPartitioning() ) {
-      is_initialized = false;
     }
 
     metrics.quality -= overall_improvement;
@@ -427,7 +421,6 @@ namespace mt_kahypar {
     if (!gain_cache.isInitialized()) {
       gain_cache.initializeGainCache(phg);
     }
-    is_initialized = true;
   }
 
   template<typename TypeTraits, typename GainTypes>

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
@@ -117,7 +117,6 @@ class MultiTryKWayFM final : public IRefiner {
 
   void resizeDataStructuresForCurrentK();
 
-  bool is_initialized = false;
   bool enable_light_fm = false;
   const HypernodeID initial_num_nodes;
   const Context& context;

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
@@ -40,16 +40,16 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class MultiTryKWayFM final : public IRefiner {
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;
 
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using LocalizedFMSearch = LocalizedKWayFM<CombinedTraits>;
-  using Rollback = GlobalRollback<CombinedTraits>;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using LocalizedFMSearch = LocalizedKWayFM<GraphAndGainTypes>;
+  using Rollback = GlobalRollback<GraphAndGainTypes>;
 
   static_assert(GainCache::TYPE != GainPolicy::none);
 

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
@@ -40,16 +40,16 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class MultiTryKWayFM final : public IRefiner {
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;
 
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using LocalizedFMSearch = LocalizedKWayFM<TypeTraits, GainTypes>;
-  using Rollback = GlobalRollback<TypeTraits, GainTypes>;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using LocalizedFMSearch = LocalizedKWayFM<CombinedTraits>;
+  using Rollback = GlobalRollback<CombinedTraits>;
 
   static_assert(GainCache::TYPE != GainPolicy::none);
 

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
@@ -33,13 +33,13 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class GainCacheStrategy: public IFMStrategy {
   using Base = IFMStrategy;
 
  public:
-  using LocalFM = LocalizedKWayFM<CombinedTraits>;
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using LocalFM = LocalizedKWayFM<GraphAndGainTypes>;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
 
   GainCacheStrategy(const Context& context, FMSharedData& sharedData):
       Base(context, sharedData) { }

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
@@ -33,13 +33,13 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class GainCacheStrategy: public IFMStrategy {
   using Base = IFMStrategy;
 
  public:
-  using LocalFM = LocalizedKWayFM<TypeTraits, GainTypes>;
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using LocalFM = LocalizedKWayFM<CombinedTraits>;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
 
   GainCacheStrategy(const Context& context, FMSharedData& sharedData):
       Base(context, sharedData) { }

--- a/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
@@ -34,14 +34,14 @@
 
 namespace mt_kahypar {
 
-template<typename CombinedTraits>
+template<typename GraphAndGainTypes>
 class UnconstrainedStrategy: public IFMStrategy {
   using Base = IFMStrategy;
   static constexpr bool debug = false;
 
  public:
-  using LocalFM = LocalizedKWayFM<CombinedTraits>;
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using LocalFM = LocalizedKWayFM<GraphAndGainTypes>;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
 
   UnconstrainedStrategy(const Context& context, FMSharedData& sharedData):
       Base(context, sharedData),

--- a/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
@@ -34,14 +34,14 @@
 
 namespace mt_kahypar {
 
-template<typename TypeTraits, typename GainTypes>
+template<typename CombinedTraits>
 class UnconstrainedStrategy: public IFMStrategy {
   using Base = IFMStrategy;
   static constexpr bool debug = false;
 
  public:
-  using LocalFM = LocalizedKWayFM<TypeTraits, GainTypes>;
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using LocalFM = LocalizedKWayFM<CombinedTraits>;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
 
   UnconstrainedStrategy(const Context& context, FMSharedData& sharedData):
       Base(context, sharedData),

--- a/mt-kahypar/partition/refinement/gains/gain_cache_ptr.h
+++ b/mt-kahypar/partition/refinement/gains/gain_cache_ptr.h
@@ -86,7 +86,7 @@ class GainCachePtr {
       #endif
       case GainPolicy::none: break;
     }
-    ERROR("No gain policy set");
+    ERR("No gain policy set");
   }
 
   template<typename Hypergraph, typename F>
@@ -120,7 +120,7 @@ class GainCachePtr {
         default: break;
       }
     }
-    ERROR("No gain policy set");
+    ERR("No gain policy set");
   }
 
   static gain_cache_t constructGainCache(const Context& context) {

--- a/mt-kahypar/partition/refinement/gains/gain_definitions.h
+++ b/mt-kahypar/partition/refinement/gains/gain_definitions.h
@@ -132,8 +132,11 @@ struct SteinerTreeForGraphsTypes : public kahypar::meta::PolicyBase {
 #endif
 #endif
 
-template<typename TypeTraits, typename GainTypes>
+template<typename TypeTraitsT, typename GainTypesT>
 struct CombinedTraits : public kahypar::meta::PolicyBase {
+  using TypeTraits = TypeTraitsT;
+  using GainTypes = GainTypesT;
+
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
 
@@ -187,15 +190,6 @@ using ValidTraitCombinations = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINAT
   ENABLE_HIGHEST_QUALITY(_INSTANTIATE_CLASS_MACRO_FOR_HYPERGRAPH_COMBINATIONS(C, DynamicHypergraphTypeTraits))    \
   ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(_INSTANTIATE_CLASS_MACRO_FOR_GRAPH_COMBINATIONS(C, DynamicGraphTypeTraits))   \
   ENABLE_LARGE_K(_INSTANTIATE_CLASS_MACRO_FOR_HYPERGRAPH_COMBINATIONS(C, LargeKHypergraphTypeTraits))
-
-
-#define INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(C)                                                                 \
-  INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, Km1GainTypes)                                                  \
-  INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, CutGainTypes)                                                  \
-  ENABLE_SOED(INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, SoedGainTypes))                                    \
-  ENABLE_STEINER_TREE(INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, SteinerTreeGainTypes))                     \
-  ENABLE_GRAPHS(INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, CutGainForGraphsTypes))                          \
-  ENABLE_GRAPHS(ENABLE_STEINER_TREE(INSTANTIATE_CLASS_MACRO_WITH_TYPE_TRAITS_AND_OTHER_CLASS(C, SteinerTreeForGraphsTypes)))
 
 
 // functionality for retrieving combined policy of partition type and gain

--- a/mt-kahypar/partition/refinement/gains/gain_definitions.h
+++ b/mt-kahypar/partition/refinement/gains/gain_definitions.h
@@ -133,7 +133,7 @@ struct SteinerTreeForGraphsTypes : public kahypar::meta::PolicyBase {
 #endif
 
 template<typename TypeTraitsT, typename GainTypesT>
-struct CombinedTraits : public kahypar::meta::PolicyBase {
+struct GraphAndGainTypes : public kahypar::meta::PolicyBase {
   using TypeTraits = TypeTraitsT;
   using GainTypes = GainTypesT;
 
@@ -157,31 +157,31 @@ using GainTypes = kahypar::meta::Typelist<Km1GainTypes,
                                           ENABLE_GRAPHS(ENABLE_STEINER_TREE(COMMA SteinerTreeForGraphsTypes))>;
 
 #define _LIST_HYPERGRAPH_COMBINATIONS(TYPE_TRAITS)                                     \
-  CombinedTraits<TYPE_TRAITS, Km1GainTypes>,                                           \
-  CombinedTraits<TYPE_TRAITS, CutGainTypes>                                            \
-  ENABLE_SOED(COMMA CombinedTraits<TYPE_TRAITS COMMA SoedGainTypes>)                   \
-  ENABLE_STEINER_TREE(COMMA CombinedTraits<TYPE_TRAITS COMMA SteinerTreeGainTypes>)
+  GraphAndGainTypes<TYPE_TRAITS, Km1GainTypes>,                                           \
+  GraphAndGainTypes<TYPE_TRAITS, CutGainTypes>                                            \
+  ENABLE_SOED(COMMA GraphAndGainTypes<TYPE_TRAITS COMMA SoedGainTypes>)                   \
+  ENABLE_STEINER_TREE(COMMA GraphAndGainTypes<TYPE_TRAITS COMMA SteinerTreeGainTypes>)
 
 #define _LIST_GRAPH_COMBINATIONS(TYPE_TRAITS)                                             \
-  CombinedTraits<TYPE_TRAITS, CutGainForGraphsTypes>                                      \
-  ENABLE_STEINER_TREE(COMMA CombinedTraits<TYPE_TRAITS COMMA SteinerTreeForGraphsTypes>)
+  GraphAndGainTypes<TYPE_TRAITS, CutGainForGraphsTypes>                                      \
+  ENABLE_STEINER_TREE(COMMA GraphAndGainTypes<TYPE_TRAITS COMMA SteinerTreeForGraphsTypes>)
 
-using ValidTraitCombinations = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINATIONS(StaticHypergraphTypeTraits)
-                                                       ENABLE_GRAPHS(COMMA _LIST_GRAPH_COMBINATIONS(StaticGraphTypeTraits))
-                                                       ENABLE_HIGHEST_QUALITY(COMMA _LIST_HYPERGRAPH_COMBINATIONS(DynamicHypergraphTypeTraits))
-                                                       ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(COMMA _LIST_GRAPH_COMBINATIONS(DynamicGraphTypeTraits))
-                                                       ENABLE_LARGE_K(COMMA _LIST_HYPERGRAPH_COMBINATIONS(LargeKHypergraphTypeTraits))>;
+using GraphAndGainTypesList = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINATIONS(StaticHypergraphTypeTraits)
+                                                      ENABLE_GRAPHS(COMMA _LIST_GRAPH_COMBINATIONS(StaticGraphTypeTraits))
+                                                      ENABLE_HIGHEST_QUALITY(COMMA _LIST_HYPERGRAPH_COMBINATIONS(DynamicHypergraphTypeTraits))
+                                                      ENABLE_HIGHEST_QUALITY_FOR_GRAPHS(COMMA _LIST_GRAPH_COMBINATIONS(DynamicGraphTypeTraits))
+                                                      ENABLE_LARGE_K(COMMA _LIST_HYPERGRAPH_COMBINATIONS(LargeKHypergraphTypeTraits))>;
 
 
 #define _INSTANTIATE_CLASS_MACRO_FOR_HYPERGRAPH_COMBINATIONS(C, TYPE_TRAITS)                  \
-  template class C(CombinedTraits<TYPE_TRAITS COMMA Km1GainTypes>);                                \
-  template class C(CombinedTraits<TYPE_TRAITS COMMA CutGainTypes>);                                \
-  ENABLE_SOED(template class C(CombinedTraits<TYPE_TRAITS COMMA SoedGainTypes>);)                  \
-  ENABLE_STEINER_TREE(template class C(CombinedTraits<TYPE_TRAITS COMMA SteinerTreeGainTypes>);)
+  template class C(GraphAndGainTypes<TYPE_TRAITS COMMA Km1GainTypes>);                                \
+  template class C(GraphAndGainTypes<TYPE_TRAITS COMMA CutGainTypes>);                                \
+  ENABLE_SOED(template class C(GraphAndGainTypes<TYPE_TRAITS COMMA SoedGainTypes>);)                  \
+  ENABLE_STEINER_TREE(template class C(GraphAndGainTypes<TYPE_TRAITS COMMA SteinerTreeGainTypes>);)
 
 #define _INSTANTIATE_CLASS_MACRO_FOR_GRAPH_COMBINATIONS(C, TYPE_TRAITS)                           \
-  template class C(CombinedTraits<TYPE_TRAITS COMMA CutGainForGraphsTypes>);                           \
-  ENABLE_STEINER_TREE(template class C(CombinedTraits<TYPE_TRAITS COMMA SteinerTreeForGraphsTypes>);)
+  template class C(GraphAndGainTypes<TYPE_TRAITS COMMA CutGainForGraphsTypes>);                           \
+  ENABLE_STEINER_TREE(template class C(GraphAndGainTypes<TYPE_TRAITS COMMA SteinerTreeForGraphsTypes>);)
 
 
 #define INSTANTIATE_CLASS_WITH_VALID_TRAITS(C)                                                                    \
@@ -194,7 +194,7 @@ using ValidTraitCombinations = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINAT
 
 // functionality for retrieving combined policy of partition type and gain
 #define _RETURN_COMBINED_POLICY(TYPE_TRAITS, GAIN_TYPES) {      \
-  static CombinedTraits<TYPE_TRAITS, GAIN_TYPES> traits;        \
+  static GraphAndGainTypes<TYPE_TRAITS, GAIN_TYPES> traits;        \
   return traits;                                                \
 }
 

--- a/mt-kahypar/partition/refinement/gains/gain_definitions.h
+++ b/mt-kahypar/partition/refinement/gains/gain_definitions.h
@@ -206,7 +206,7 @@ using ValidTraitCombinations = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINAT
     case GainPolicy::steiner_tree:                                                            \
       ENABLE_STEINER_TREE(_RETURN_COMBINED_POLICY(TYPE_TRAITS, SteinerTreeGainTypes))         \
     default: {                                                                                \
-      ERROR("Invalid gain policy type");                                                      \
+      ERR("Invalid gain policy type");                                                      \
     }                                                                                         \
   }                                                                                           \
 }
@@ -218,7 +218,7 @@ using ValidTraitCombinations = kahypar::meta::Typelist<_LIST_HYPERGRAPH_COMBINAT
     case GainPolicy::steiner_tree_for_graphs:                                                                 \
       ENABLE_STEINER_TREE(ENABLE_GRAPHS(_RETURN_COMBINED_POLICY(TYPE_TRAITS, SteinerTreeForGraphsTypes)))     \
     default: {                                                                                                \
-      ERROR("Invalid gain policy type");                                                                      \
+      ERR("Invalid gain policy type");                                                                      \
     }                                                                                                         \
   }                                                                                                           \
 }

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -39,9 +39,9 @@
 
 namespace mt_kahypar {
 
-  template <typename CombinedTraits>
+  template <typename GraphAndGainTypes>
   template<bool unconstrained, typename F>
-  bool LabelPropagationRefiner<CombinedTraits>::moveVertex(PartitionedHypergraph& hypergraph,
+  bool LabelPropagationRefiner<GraphAndGainTypes>::moveVertex(PartitionedHypergraph& hypergraph,
                                                            const HypernodeID hn,
                                                            NextActiveNodes& next_active_nodes,
                                                            const F& objective_delta) {
@@ -98,8 +98,8 @@ namespace mt_kahypar {
     return is_moved;
   }
 
-  template <typename CombinedTraits>
-  bool LabelPropagationRefiner<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& phg,
+  template <typename GraphAndGainTypes>
+  bool LabelPropagationRefiner<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& phg,
                                                            const vec<HypernodeID>& refinement_nodes,
                                                            Metrics& best_metrics,
                                                            const double)  {
@@ -130,8 +130,8 @@ namespace mt_kahypar {
   }
 
 
-  template <typename CombinedTraits>
-  void LabelPropagationRefiner<CombinedTraits>::labelPropagation(PartitionedHypergraph& hypergraph,
+  template <typename GraphAndGainTypes>
+  void LabelPropagationRefiner<GraphAndGainTypes>::labelPropagation(PartitionedHypergraph& hypergraph,
                                                                  Metrics& best_metrics) {
     NextActiveNodes next_active_nodes;
     vec<Move> rebalance_moves;
@@ -150,8 +150,8 @@ namespace mt_kahypar {
     }
   }
 
-  template <typename CombinedTraits>
-  bool LabelPropagationRefiner<CombinedTraits>::labelPropagationRound(PartitionedHypergraph& hypergraph,
+  template <typename GraphAndGainTypes>
+  bool LabelPropagationRefiner<GraphAndGainTypes>::labelPropagationRound(PartitionedHypergraph& hypergraph,
                                                                       NextActiveNodes& next_active_nodes,
                                                                       Metrics& best_metrics,
                                                                       vec<Move>& rebalance_moves,
@@ -215,9 +215,9 @@ namespace mt_kahypar {
                           _context.refinement.label_propagation.relative_improvement_threshold * old_quality;
   }
 
-  template <typename CombinedTraits>
+  template <typename GraphAndGainTypes>
   template<bool unconstrained>
-  void LabelPropagationRefiner<CombinedTraits>::moveActiveNodes(PartitionedHypergraph& phg,
+  void LabelPropagationRefiner<GraphAndGainTypes>::moveActiveNodes(PartitionedHypergraph& phg,
                                                                 NextActiveNodes& next_active_nodes) {
     // This function is passed as lambda to the changeNodePart function and used
     // to calculate the "real" delta of a move (in terms of the used objective function).
@@ -251,8 +251,8 @@ namespace mt_kahypar {
   }
 
 
-  template <typename CombinedTraits>
-  bool LabelPropagationRefiner<CombinedTraits>::applyRebalancing(PartitionedHypergraph& hypergraph,
+  template <typename GraphAndGainTypes>
+  bool LabelPropagationRefiner<GraphAndGainTypes>::applyRebalancing(PartitionedHypergraph& hypergraph,
                                                                  Metrics& best_metrics,
                                                                  Metrics& current_metrics,
                                                                  vec<Move>& rebalance_moves) {
@@ -294,9 +294,9 @@ namespace mt_kahypar {
     return false;
   }
 
-  template <typename CombinedTraits>
+  template <typename GraphAndGainTypes>
   template<typename F>
-  void LabelPropagationRefiner<CombinedTraits>::forEachMovedNode(F node_fn) {
+  void LabelPropagationRefiner<GraphAndGainTypes>::forEachMovedNode(F node_fn) {
     if ( _context.refinement.label_propagation.execute_sequential ) {
       for (size_t j = 0; j < _active_nodes.size(); j++) {
         if (_active_node_was_moved[j]) {
@@ -312,13 +312,13 @@ namespace mt_kahypar {
     }
   }
 
-  template <typename CombinedTraits>
-  void LabelPropagationRefiner<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
+  template <typename GraphAndGainTypes>
+  void LabelPropagationRefiner<GraphAndGainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
     unused(phg);
   }
 
-  template <typename CombinedTraits>
-  void LabelPropagationRefiner<CombinedTraits>::initializeActiveNodes(PartitionedHypergraph& hypergraph,
+  template <typename GraphAndGainTypes>
+  void LabelPropagationRefiner<GraphAndGainTypes>::initializeActiveNodes(PartitionedHypergraph& hypergraph,
                                                                       const vec<HypernodeID>& refinement_nodes) {
     _active_nodes.clear();
     if ( refinement_nodes.empty() ) {

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -39,12 +39,12 @@
 
 namespace mt_kahypar {
 
-  template <typename TypeTraits, typename GainTypes>
+  template <typename CombinedTraits>
   template<bool unconstrained, typename F>
-  bool LabelPropagationRefiner<TypeTraits, GainTypes>::moveVertex(PartitionedHypergraph& hypergraph,
-                                                                  const HypernodeID hn,
-                                                                  NextActiveNodes& next_active_nodes,
-                                                                  const F& objective_delta) {
+  bool LabelPropagationRefiner<CombinedTraits>::moveVertex(PartitionedHypergraph& hypergraph,
+                                                           const HypernodeID hn,
+                                                           NextActiveNodes& next_active_nodes,
+                                                           const F& objective_delta) {
     bool is_moved = false;
     ASSERT(hn != kInvalidHypernode);
     if ( hypergraph.isBorderNode(hn) && !hypergraph.isFixed(hn) ) {
@@ -98,12 +98,11 @@ namespace mt_kahypar {
     return is_moved;
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  bool LabelPropagationRefiner<TypeTraits, GainTypes>::refineImpl(
-                  mt_kahypar_partitioned_hypergraph_t& phg,
-                  const parallel::scalable_vector<HypernodeID>& refinement_nodes,
-                  Metrics& best_metrics,
-                  const double)  {
+  template <typename CombinedTraits>
+  bool LabelPropagationRefiner<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& phg,
+                                                           const vec<HypernodeID>& refinement_nodes,
+                                                           Metrics& best_metrics,
+                                                           const double)  {
     PartitionedHypergraph& hypergraph = utils::cast<PartitionedHypergraph>(phg);
     resizeDataStructuresForCurrentK();
     _gain.reset();
@@ -131,9 +130,9 @@ namespace mt_kahypar {
   }
 
 
-  template <typename TypeTraits, typename GainTypes>
-  void LabelPropagationRefiner<TypeTraits, GainTypes>::labelPropagation(PartitionedHypergraph& hypergraph,
-                                                                        Metrics& best_metrics) {
+  template <typename CombinedTraits>
+  void LabelPropagationRefiner<CombinedTraits>::labelPropagation(PartitionedHypergraph& hypergraph,
+                                                                 Metrics& best_metrics) {
     NextActiveNodes next_active_nodes;
     vec<Move> rebalance_moves;
     bool should_stop = false;
@@ -151,13 +150,12 @@ namespace mt_kahypar {
     }
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  bool LabelPropagationRefiner<TypeTraits, GainTypes>::labelPropagationRound(
-                              PartitionedHypergraph& hypergraph,
-                              NextActiveNodes& next_active_nodes,
-                              Metrics& best_metrics,
-                              vec<Move>& rebalance_moves,
-                              bool unconstrained_lp) {
+  template <typename CombinedTraits>
+  bool LabelPropagationRefiner<CombinedTraits>::labelPropagationRound(PartitionedHypergraph& hypergraph,
+                                                                      NextActiveNodes& next_active_nodes,
+                                                                      Metrics& best_metrics,
+                                                                      vec<Move>& rebalance_moves,
+                                                                      bool unconstrained_lp) {
     Metrics current_metrics = best_metrics;
     _visited_he.reset();
     _next_active.reset();
@@ -217,10 +215,10 @@ namespace mt_kahypar {
                           _context.refinement.label_propagation.relative_improvement_threshold * old_quality;
   }
 
-  template <typename TypeTraits, typename GainTypes>
+  template <typename CombinedTraits>
   template<bool unconstrained>
-  void LabelPropagationRefiner<TypeTraits, GainTypes>::moveActiveNodes(PartitionedHypergraph& phg,
-                                                                       NextActiveNodes& next_active_nodes) {
+  void LabelPropagationRefiner<CombinedTraits>::moveActiveNodes(PartitionedHypergraph& phg,
+                                                                NextActiveNodes& next_active_nodes) {
     // This function is passed as lambda to the changeNodePart function and used
     // to calculate the "real" delta of a move (in terms of the used objective function).
     auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
@@ -253,11 +251,11 @@ namespace mt_kahypar {
   }
 
 
-  template <typename TypeTraits, typename GainTypes>
-  bool LabelPropagationRefiner<TypeTraits, GainTypes>::applyRebalancing(PartitionedHypergraph& hypergraph,
-                                                                        Metrics& best_metrics,
-                                                                        Metrics& current_metrics,
-                                                                        vec<Move>& rebalance_moves) {
+  template <typename CombinedTraits>
+  bool LabelPropagationRefiner<CombinedTraits>::applyRebalancing(PartitionedHypergraph& hypergraph,
+                                                                 Metrics& best_metrics,
+                                                                 Metrics& current_metrics,
+                                                                 vec<Move>& rebalance_moves) {
     utils::Timer& timer = utils::Utilities::instance().getTimer(_context.utility_id);
     timer.start_timer("rebalance_lp", "Rebalance");
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(hypergraph);
@@ -296,9 +294,9 @@ namespace mt_kahypar {
     return false;
   }
 
-  template <typename TypeTraits, typename GainTypes>
+  template <typename CombinedTraits>
   template<typename F>
-  void LabelPropagationRefiner<TypeTraits, GainTypes>::forEachMovedNode(F node_fn) {
+  void LabelPropagationRefiner<CombinedTraits>::forEachMovedNode(F node_fn) {
     if ( _context.refinement.label_propagation.execute_sequential ) {
       for (size_t j = 0; j < _active_nodes.size(); j++) {
         if (_active_node_was_moved[j]) {
@@ -314,15 +312,14 @@ namespace mt_kahypar {
     }
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  void LabelPropagationRefiner<TypeTraits, GainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
+  template <typename CombinedTraits>
+  void LabelPropagationRefiner<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
     unused(phg);
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  void LabelPropagationRefiner<TypeTraits, GainTypes>::initializeActiveNodes(
-                              PartitionedHypergraph& hypergraph,
-                              const parallel::scalable_vector<HypernodeID>& refinement_nodes) {
+  template <typename CombinedTraits>
+  void LabelPropagationRefiner<CombinedTraits>::initializeActiveNodes(PartitionedHypergraph& hypergraph,
+                                                                      const vec<HypernodeID>& refinement_nodes) {
     _active_nodes.clear();
     if ( refinement_nodes.empty() ) {
       _might_be_uninitialized = false;
@@ -379,9 +376,9 @@ namespace mt_kahypar {
   }
 
   namespace {
-  #define LABEL_PROPAGATION_REFINER(X, Y) LabelPropagationRefiner<X, Y>
+  #define LABEL_PROPAGATION_REFINER(X) LabelPropagationRefiner<X>
   }
 
   // explicitly instantiate so the compiler can generate them when compiling this cpp file
-  INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(LABEL_PROPAGATION_REFINER)
+  INSTANTIATE_CLASS_WITH_VALID_TRAITS(LABEL_PROPAGATION_REFINER)
 }

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -316,7 +316,7 @@ namespace mt_kahypar {
 
   template <typename TypeTraits, typename GainTypes>
   void LabelPropagationRefiner<TypeTraits, GainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
-    _rebalancer.initialize(phg);  // TODO: probably wrong place for this
+    unused(phg);
   }
 
   template <typename TypeTraits, typename GainTypes>

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -40,13 +40,13 @@
 
 
 namespace mt_kahypar {
-template <typename CombinedTraits>
+template <typename GraphAndGainTypes>
 class LabelPropagationRefiner final : public IRefiner {
  private:
-  using Hypergraph = typename CombinedTraits::Hypergraph;
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using GainCalculator = typename CombinedTraits::GainComputation;
+  using Hypergraph = typename GraphAndGainTypes::Hypergraph;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using GainCalculator = typename GraphAndGainTypes::GainComputation;
   using ActiveNodes = parallel::scalable_vector<HypernodeID>;
   using NextActiveNodes = ds::StreamingVector<HypernodeID>;
 

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -40,13 +40,13 @@
 
 
 namespace mt_kahypar {
-template <typename TypeTraits, typename GainTypes>
+template <typename CombinedTraits>
 class LabelPropagationRefiner final : public IRefiner {
  private:
-  using Hypergraph = typename TypeTraits::Hypergraph;
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using GainCalculator = typename GainTypes::GainComputation;
+  using Hypergraph = typename CombinedTraits::Hypergraph;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using GainCalculator = typename CombinedTraits::GainComputation;
   using ActiveNodes = parallel::scalable_vector<HypernodeID>;
   using NextActiveNodes = ds::StreamingVector<HypernodeID>;
 

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -254,8 +254,8 @@ namespace impl {
 } // namespace impl
 
 
-  template <typename TypeTraits, typename GainTypes>
-  void AdvancedRebalancer<TypeTraits, GainTypes>::insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  template <typename CombinedTraits>
+  void AdvancedRebalancer<CombinedTraits>::insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
 
     // init PQs if not done before
@@ -305,8 +305,8 @@ namespace impl {
     }
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  std::pair<int64_t, size_t> AdvancedRebalancer<TypeTraits, GainTypes>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  template <typename CombinedTraits>
+  std::pair<int64_t, size_t> AdvancedRebalancer<CombinedTraits>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
     int64_t attributed_gain = 0;
     size_t global_move_id = 0;
@@ -417,11 +417,11 @@ namespace impl {
     return std::make_pair(attributed_gain, global_move_id);
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  bool AdvancedRebalancer<TypeTraits, GainTypes>::refineInternalParallel(mt_kahypar_partitioned_hypergraph_t& hypergraph,
-                                                                         vec<vec<Move>>* moves_by_part,
-                                                                         vec<Move>* moves_linear,
-                                                                         Metrics& best_metric) {
+  template <typename CombinedTraits>
+  bool AdvancedRebalancer<CombinedTraits>::refineInternalParallel(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                                  vec<vec<Move>>* moves_by_part,
+                                                                  vec<Move>* moves_linear,
+                                                                  Metrics& best_metric) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
 
     if (!_gain_cache.isInitialized()) {
@@ -477,8 +477,8 @@ namespace impl {
   }
 
 
-template <typename TypeTraits, typename GainTypes>
-AdvancedRebalancer<TypeTraits, GainTypes>::AdvancedRebalancer(
+template <typename CombinedTraits>
+AdvancedRebalancer<CombinedTraits>::AdvancedRebalancer(
         HypernodeID num_nodes, const Context& context, GainCache& gain_cache) :
         _context(context),
         _gain_cache(gain_cache),
@@ -490,48 +490,48 @@ AdvancedRebalancer<TypeTraits, GainTypes>::AdvancedRebalancer(
         _pq_id(num_nodes, -1),
         _node_state(num_nodes) { }
 
-template <typename TypeTraits, typename GainTypes>
-AdvancedRebalancer<TypeTraits, GainTypes>::AdvancedRebalancer(
+template <typename CombinedTraits>
+AdvancedRebalancer<CombinedTraits>::AdvancedRebalancer(
         HypernodeID num_nodes, const Context& context, gain_cache_t gain_cache) :
         AdvancedRebalancer(num_nodes, context, GainCachePtr::cast<GainCache>(gain_cache)) { }
 
 
-template <typename TypeTraits, typename GainTypes>
-bool AdvancedRebalancer<TypeTraits, GainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+template <typename CombinedTraits>
+bool AdvancedRebalancer<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                 const vec<HypernodeID>& , Metrics& best_metrics, double) {
   return refineInternalParallel(hypergraph, nullptr, nullptr, best_metrics);
 }
 
-template <typename TypeTraits, typename GainTypes>
-void AdvancedRebalancer<TypeTraits, GainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+template <typename CombinedTraits>
+void AdvancedRebalancer<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
   auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
   unused(phg);
 }
 
-template <typename TypeTraits, typename GainTypes>
-bool AdvancedRebalancer<TypeTraits, GainTypes>::refineAndOutputMovesImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
-                                                                         const vec<HypernodeID>& ,
-                                                                         vec<vec<Move>>& moves_by_part,
-                                                                         Metrics& best_metrics,
-                                                                         const double) {
+template <typename CombinedTraits>
+bool AdvancedRebalancer<CombinedTraits>::refineAndOutputMovesImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                                  const vec<HypernodeID>& ,
+                                                                  vec<vec<Move>>& moves_by_part,
+                                                                  Metrics& best_metrics,
+                                                                  const double) {
   return refineInternalParallel(hypergraph, &moves_by_part, nullptr, best_metrics);
 }
 
-template <typename TypeTraits, typename GainTypes>
-bool AdvancedRebalancer<TypeTraits, GainTypes>::refineAndOutputMovesLinearImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
-                                                                               const vec<HypernodeID>& ,
-                                                                               vec<Move>& moves,
-                                                                               Metrics& best_metrics,
-                                                                               const double) {
+template <typename CombinedTraits>
+bool AdvancedRebalancer<CombinedTraits>::refineAndOutputMovesLinearImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                                        const vec<HypernodeID>& ,
+                                                                        vec<Move>& moves,
+                                                                        Metrics& best_metrics,
+                                                                        const double) {
   return refineInternalParallel(hypergraph, nullptr, &moves, best_metrics);
 }
 
 // explicitly instantiate so the compiler can generate them when compiling this cpp file
 namespace {
-  #define ADVANCED_REBALANCER(X, Y) AdvancedRebalancer<X, Y>
+  #define ADVANCED_REBALANCER(X) AdvancedRebalancer<X>
 }
 
 // explicitly instantiate so the compiler can generate them when compiling this cpp file
-INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(ADVANCED_REBALANCER)
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(ADVANCED_REBALANCER)
 
 }   // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -254,8 +254,8 @@ namespace impl {
 } // namespace impl
 
 
-  template <typename CombinedTraits>
-  void AdvancedRebalancer<CombinedTraits>::insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  template <typename GraphAndGainTypes>
+  void AdvancedRebalancer<GraphAndGainTypes>::insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
 
     // init PQs if not done before
@@ -305,8 +305,8 @@ namespace impl {
     }
   }
 
-  template <typename CombinedTraits>
-  std::pair<int64_t, size_t> AdvancedRebalancer<CombinedTraits>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  template <typename GraphAndGainTypes>
+  std::pair<int64_t, size_t> AdvancedRebalancer<GraphAndGainTypes>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
     int64_t attributed_gain = 0;
     size_t global_move_id = 0;
@@ -417,8 +417,8 @@ namespace impl {
     return std::make_pair(attributed_gain, global_move_id);
   }
 
-  template <typename CombinedTraits>
-  bool AdvancedRebalancer<CombinedTraits>::refineInternalParallel(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+  template <typename GraphAndGainTypes>
+  bool AdvancedRebalancer<GraphAndGainTypes>::refineInternalParallel(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                                                                   vec<vec<Move>>* moves_by_part,
                                                                   vec<Move>* moves_linear,
                                                                   Metrics& best_metric) {
@@ -477,8 +477,8 @@ namespace impl {
   }
 
 
-template <typename CombinedTraits>
-AdvancedRebalancer<CombinedTraits>::AdvancedRebalancer(
+template <typename GraphAndGainTypes>
+AdvancedRebalancer<GraphAndGainTypes>::AdvancedRebalancer(
         HypernodeID num_nodes, const Context& context, GainCache& gain_cache) :
         _context(context),
         _gain_cache(gain_cache),
@@ -490,26 +490,26 @@ AdvancedRebalancer<CombinedTraits>::AdvancedRebalancer(
         _pq_id(num_nodes, -1),
         _node_state(num_nodes) { }
 
-template <typename CombinedTraits>
-AdvancedRebalancer<CombinedTraits>::AdvancedRebalancer(
+template <typename GraphAndGainTypes>
+AdvancedRebalancer<GraphAndGainTypes>::AdvancedRebalancer(
         HypernodeID num_nodes, const Context& context, gain_cache_t gain_cache) :
         AdvancedRebalancer(num_nodes, context, GainCachePtr::cast<GainCache>(gain_cache)) { }
 
 
-template <typename CombinedTraits>
-bool AdvancedRebalancer<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+template <typename GraphAndGainTypes>
+bool AdvancedRebalancer<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                 const vec<HypernodeID>& , Metrics& best_metrics, double) {
   return refineInternalParallel(hypergraph, nullptr, nullptr, best_metrics);
 }
 
-template <typename CombinedTraits>
-void AdvancedRebalancer<CombinedTraits>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+template <typename GraphAndGainTypes>
+void AdvancedRebalancer<GraphAndGainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
   auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
   unused(phg);
 }
 
-template <typename CombinedTraits>
-bool AdvancedRebalancer<CombinedTraits>::refineAndOutputMovesImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+template <typename GraphAndGainTypes>
+bool AdvancedRebalancer<GraphAndGainTypes>::refineAndOutputMovesImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                                                                   const vec<HypernodeID>& ,
                                                                   vec<vec<Move>>& moves_by_part,
                                                                   Metrics& best_metrics,
@@ -517,8 +517,8 @@ bool AdvancedRebalancer<CombinedTraits>::refineAndOutputMovesImpl(mt_kahypar_par
   return refineInternalParallel(hypergraph, &moves_by_part, nullptr, best_metrics);
 }
 
-template <typename CombinedTraits>
-bool AdvancedRebalancer<CombinedTraits>::refineAndOutputMovesLinearImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+template <typename GraphAndGainTypes>
+bool AdvancedRebalancer<GraphAndGainTypes>::refineAndOutputMovesLinearImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                                                                         const vec<HypernodeID>& ,
                                                                         vec<Move>& moves,
                                                                         Metrics& best_metrics,

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
@@ -74,13 +74,13 @@ namespace rebalancer {
 } // namespace rebalancer
 
 
-template <typename CombinedTraits>
+template <typename GraphAndGainTypes>
 class AdvancedRebalancer final : public IRebalancer {
 private:
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using GainCalculator = typename CombinedTraits::GainComputation;
-  using AttributedGains = typename CombinedTraits::AttributedGains;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using GainCalculator = typename GraphAndGainTypes::GainComputation;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
@@ -74,13 +74,13 @@ namespace rebalancer {
 } // namespace rebalancer
 
 
-template <typename TypeTraits, typename GainTypes>
+template <typename CombinedTraits>
 class AdvancedRebalancer final : public IRebalancer {
 private:
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using GainCalculator = typename GainTypes::GainComputation;
-  using AttributedGains = typename GainTypes::AttributedGains;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using GainCalculator = typename CombinedTraits::GainComputation;
+  using AttributedGains = typename CombinedTraits::AttributedGains;
 
   static constexpr bool debug = false;
   static constexpr bool enable_heavy_assert = false;

--- a/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.cpp
@@ -42,11 +42,11 @@
 
 namespace mt_kahypar {
 
-  template <typename TypeTraits, typename GainTypes>
-  bool SimpleRebalancer<TypeTraits, GainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
-                                                           const vec<HypernodeID>&,
-                                                           Metrics& best_metrics,
-                                                           double) {
+  template <typename CombinedTraits>
+  bool SimpleRebalancer<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                    const vec<HypernodeID>&,
+                                                    Metrics& best_metrics,
+                                                    double) {
     PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
     resizeDataStructuresForCurrentK();
     // If partition is imbalanced, rebalancer is activated
@@ -185,8 +185,8 @@ namespace mt_kahypar {
     return improvement;
   }
 
-  template <typename TypeTraits, typename GainTypes>
-  vec<Move> SimpleRebalancer<TypeTraits, GainTypes>::repairEmptyBlocks(PartitionedHypergraph& phg) {
+  template <typename CombinedTraits>
+  vec<Move> SimpleRebalancer<CombinedTraits>::repairEmptyBlocks(PartitionedHypergraph& phg) {
     // First detect if there are any empty blocks.
     const size_t k = size_t(_context.partition.k);
     boost::dynamic_bitset<> is_empty(k);
@@ -291,9 +291,9 @@ namespace mt_kahypar {
 
   // explicitly instantiate so the compiler can generate them when compiling this cpp file
   namespace {
-  #define SIMPLE_REBALANCER(X, Y) SimpleRebalancer<X, Y>
+  #define SIMPLE_REBALANCER(X) SimpleRebalancer<X>
   }
 
   // explicitly instantiate so the compiler can generate them when compiling this cpp file
-  INSTANTIATE_CLASS_WITH_TYPE_TRAITS_AND_GAIN_TYPES(SIMPLE_REBALANCER)
+  INSTANTIATE_CLASS_WITH_VALID_TRAITS(SIMPLE_REBALANCER)
 }

--- a/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.cpp
@@ -42,8 +42,8 @@
 
 namespace mt_kahypar {
 
-  template <typename CombinedTraits>
-  bool SimpleRebalancer<CombinedTraits>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+  template <typename GraphAndGainTypes>
+  bool SimpleRebalancer<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
                                                     const vec<HypernodeID>&,
                                                     Metrics& best_metrics,
                                                     double) {
@@ -185,8 +185,8 @@ namespace mt_kahypar {
     return improvement;
   }
 
-  template <typename CombinedTraits>
-  vec<Move> SimpleRebalancer<CombinedTraits>::repairEmptyBlocks(PartitionedHypergraph& phg) {
+  template <typename GraphAndGainTypes>
+  vec<Move> SimpleRebalancer<GraphAndGainTypes>::repairEmptyBlocks(PartitionedHypergraph& phg) {
     // First detect if there are any empty blocks.
     const size_t k = size_t(_context.partition.k);
     boost::dynamic_bitset<> is_empty(k);

--- a/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h
@@ -39,12 +39,12 @@
 #include "mt-kahypar/utils/cast.h"
 
 namespace mt_kahypar {
-template <typename TypeTraits, typename GainTypes>
+template <typename CombinedTraits>
 class SimpleRebalancer final : public IRebalancer {
  private:
-  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using GainCache = typename GainTypes::GainCache;
-  using GainCalculator = typename GainTypes::GainComputation;
+  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
+  using GainCache = typename CombinedTraits::GainCache;
+  using GainCalculator = typename CombinedTraits::GainComputation;
   using AtomicWeight = parallel::IntegralAtomicWrapper<HypernodeWeight>;
 
   static constexpr bool debug = false;

--- a/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h
@@ -39,12 +39,12 @@
 #include "mt-kahypar/utils/cast.h"
 
 namespace mt_kahypar {
-template <typename CombinedTraits>
+template <typename GraphAndGainTypes>
 class SimpleRebalancer final : public IRebalancer {
  private:
-  using PartitionedHypergraph = typename CombinedTraits::PartitionedHypergraph;
-  using GainCache = typename CombinedTraits::GainCache;
-  using GainCalculator = typename CombinedTraits::GainComputation;
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using GainCalculator = typename GraphAndGainTypes::GainComputation;
   using AtomicWeight = parallel::IntegralAtomicWrapper<HypernodeWeight>;
 
   static constexpr bool debug = false;

--- a/mt-kahypar/partition/registries/CMakeLists.txt
+++ b/mt-kahypar/partition/registries/CMakeLists.txt
@@ -3,6 +3,7 @@ set(RegistrySources
         register_refinement_algorithms.cpp
         register_policies.cpp
         register_coarsening_algorithms.cpp
+        register_initial_partitioning_algorithms.cpp
         )
 
 foreach(modtarget IN LISTS PARTITIONING_SUITE_TARGETS)

--- a/mt-kahypar/partition/registries/register_coarsening_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_coarsening_algorithms.cpp
@@ -26,10 +26,41 @@
  ******************************************************************************/
 
 #include "kahypar-resources/meta/registrar.h"
+#include "kahypar-resources/meta/static_multi_dispatch_factory.h"
+#include "kahypar-resources/meta/typelist.h"
 
+#include "mt-kahypar/definitions.h"
+#ifdef KAHYPAR_ENABLE_HIGHEST_QUALITY_FEATURES
+#include "mt-kahypar/partition/coarsening/nlevel_coarsener.h"
+#endif
+#include "mt-kahypar/partition/coarsening/multilevel_coarsener.h"
+#include "mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h"
+#include "mt-kahypar/partition/coarsening/policies/rating_acceptance_policy.h"
+#include "mt-kahypar/partition/coarsening/policies/rating_heavy_node_penalty_policy.h"
 #include "mt-kahypar/partition/context.h"
 #include "mt-kahypar/partition/factories.h"
 
+
+namespace mt_kahypar {
+using MultilevelCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<MultilevelCoarsener,
+                                                                                ICoarsener,
+                                                                                kahypar::meta::Typelist<TypeTraitsList,
+                                                                                                        RatingScorePolicies,
+                                                                                                        HeavyNodePenaltyPolicies,
+                                                                                                        AcceptancePolicies> >;
+
+using DeterministicCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<DeterministicMultilevelCoarsener,
+                                                                                   ICoarsener,
+                                                                                   kahypar::meta::Typelist<TypeTraitsList>>;
+
+#ifdef KAHYPAR_ENABLE_HIGHEST_QUALITY_FEATURES
+using NLevelCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<NLevelCoarsener,
+                                                                            ICoarsener,
+                                                                            kahypar::meta::Typelist<TypeTraitsList,
+                                                                                                    RatingScorePolicies,
+                                                                                                    HeavyNodePenaltyPolicies,
+                                                                                                    AcceptancePolicies> >;
+#endif
 
 
 #define REGISTER_DISPATCHED_COARSENER(id, dispatcher, ...)                                                    \
@@ -43,7 +74,6 @@
   })
 
 
-namespace mt_kahypar {
 REGISTER_DISPATCHED_COARSENER(CoarseningAlgorithm::multilevel_coarsener,
                               MultilevelCoarsenerDispatcher,
                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(

--- a/mt-kahypar/partition/registries/register_initial_partitioning_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_initial_partitioning_algorithms.cpp
@@ -30,6 +30,7 @@
 #include "kahypar-resources/meta/registrar.h"
 
 #include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/factories.h"
 #include "mt-kahypar/definitions.h"
 #include "mt-kahypar/partition/initial_partitioning/i_initial_partitioner.h"
 #include "mt-kahypar/partition/initial_partitioning/random_initial_partitioner.h"

--- a/mt-kahypar/partition/registries/register_initial_partitioning_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_initial_partitioning_algorithms.cpp
@@ -25,9 +25,6 @@
  * SOFTWARE.
  ******************************************************************************/
 
-#pragma once
-
-#include "kahypar-resources/meta/abstract_factory.h"
 #include "kahypar-resources/meta/static_multi_dispatch_factory.h"
 #include "kahypar-resources/meta/typelist.h"
 #include "kahypar-resources/meta/registrar.h"
@@ -42,10 +39,6 @@
 #include "mt-kahypar/partition/initial_partitioning/policies/gain_computation_policy.h"
 #include "mt-kahypar/partition/initial_partitioning/policies/pq_selection_policy.h"
 
-namespace mt_kahypar {
-using InitialPartitionerFactory = kahypar::meta::Factory<InitialPartitioningAlgorithm,
-  IInitialPartitioner* (*)(const InitialPartitioningAlgorithm, ip_data_container_t*, const Context&, const int, const int)>;
-}
 
 #define REGISTER_DISPATCHED_INITIAL_PARTITIONER(id, dispatcher, ...)                                  \
   static kahypar::meta::Registrar<InitialPartitionerFactory> register_ ## dispatcher(                 \

--- a/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
@@ -152,10 +152,7 @@ kahypar::meta::PolicyBase& getCombinedTraitsPolicy(mt_kahypar_partition_type_t p
 
 REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::label_propagation,
                                LabelPropagationDispatcher,
-                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                context.partition.partition_type),
-                               kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                context.partition.gain_policy));
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::deterministic,
                                DeterministicLabelPropagationDispatcher,
                                kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
@@ -166,58 +163,34 @@ REGISTER_LP_REFINER(LabelPropagationAlgorithm::do_nothing, DoNothingRefiner, 1);
 
 REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::kway_fm,
                                DefaultFMDispatcher,
-                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                context.partition.partition_type),
-                               kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                context.partition.gain_policy));
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::unconstrained_fm,
                                UnconstrainedFMDispatcher,
-                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                context.partition.partition_type),
-                               kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                context.partition.gain_policy));
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FM_REFINER(FMAlgorithm::do_nothing, DoNothingRefiner, 3);
 
 REGISTER_DISPATCHED_FM_STRATEGY(FMAlgorithm::kway_fm,
                                 GainCacheFMStrategyDispatcher,
-                                kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                 context.partition.partition_type),
-                                kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                 context.partition.gain_policy));
+                                getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_FM_STRATEGY(FMAlgorithm::unconstrained_fm,
                                 UnconstrainedFMStrategyDispatcher,
-                                kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                 context.partition.partition_type),
-                                kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                 context.partition.gain_policy));
+                                getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 
 REGISTER_DISPATCHED_FLOW_SCHEDULER(FlowAlgorithm::flow_cutter,
                                    FlowSchedulerDispatcher,
-                                   kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                    context.partition.partition_type),
-                                   kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                     context.partition.gain_policy));
+                                   getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FLOW_SCHEDULER(FlowAlgorithm::do_nothing, DoNothingRefiner, 4);
 
 REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::simple_rebalancer,
                                SimpleRebalancerDispatcher,
-                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                context.partition.partition_type),
-                               kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                context.partition.gain_policy));
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::advanced_rebalancer,
-                                 AdvancedRebalancerDispatcher,
-                                 kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                         context.partition.partition_type),
-                                 kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                         context.partition.gain_policy));
+                               AdvancedRebalancerDispatcher,
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_REBALANCER(RebalancingAlgorithm::do_nothing, DoNothingRefiner, 5);
 
 REGISTER_DISPATCHED_FLOW_REFINER(FlowAlgorithm::flow_cutter,
-                                  FlowRefinementDispatcher,
-                                  kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                   context.partition.partition_type),
-                                  kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                    context.partition.gain_policy));
+                                 FlowRefinementDispatcher,
+                                 getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FLOW_REFINER(FlowAlgorithm::do_nothing, DoNothingFlowRefiner, 6);
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
@@ -55,7 +55,7 @@ using LabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
 using DeterministicLabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                                 DeterministicLabelPropagationRefiner,
                                                 IRefiner,
-                                                kahypar::meta::Typelist<TypeTraitsList, GainTypes>>;
+                                                kahypar::meta::Typelist<ValidTraitCombinations>>;
 
 using DefaultFMDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                             MultiTryKWayFM,
@@ -217,10 +217,7 @@ REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::label_propagation,
                                getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::deterministic,
                                DeterministicLabelPropagationDispatcher,
-                               kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
-                                        context.partition.partition_type),
-                               kahypar::meta::PolicyRegistry<GainPolicy>::getInstance().getPolicy(
-                                        context.partition.gain_policy));
+                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_LP_REFINER(LabelPropagationAlgorithm::do_nothing, DoNothingRefiner, 1);
 
 REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::kway_fm,

--- a/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
@@ -50,49 +50,49 @@ namespace mt_kahypar {
 using LabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                    LabelPropagationRefiner,
                                    IRefiner,
-                                   kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                   kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using DeterministicLabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                                 DeterministicLabelPropagationRefiner,
                                                 IRefiner,
-                                                kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                                kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using DefaultFMDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                             MultiTryKWayFM,
                             IRefiner,
-                            kahypar::meta::Typelist<ValidTraitCombinations>>;
+                            kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using UnconstrainedFMDispatcher = DefaultFMDispatcher;
 
 using GainCacheFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                       GainCacheStrategy,
                                       IFMStrategy,
-                                      kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                      kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using UnconstrainedFMStrategyDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                           UnconstrainedStrategy,
                                           IFMStrategy,
-                                          kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                          kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using FlowSchedulerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                 FlowRefinementScheduler,
                                 IRefiner,
-                                kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using SimpleRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                    SimpleRebalancer,
                                    IRebalancer,
-                                   kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                   kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using AdvancedRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                      AdvancedRebalancer,
                                      IRebalancer,
-                                     kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                     kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using FlowRefinementDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                  FlowRefiner,
                                  IFlowRefiner,
-                                 kahypar::meta::Typelist<ValidTraitCombinations>>;
+                                 kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 
 #define REGISTER_DISPATCHED_LP_REFINER(id, dispatcher, ...)                                            \
@@ -197,7 +197,7 @@ using FlowRefinementDispatcher = kahypar::meta::StaticMultiDispatchFactory<
   })
 
 
-kahypar::meta::PolicyBase& getCombinedTraitsPolicy(mt_kahypar_partition_type_t partition_type, GainPolicy gain_policy) {
+kahypar::meta::PolicyBase& getGraphAndGainTypesPolicy(mt_kahypar_partition_type_t partition_type, GainPolicy gain_policy) {
   switch ( partition_type ) {
     case MULTILEVEL_HYPERGRAPH_PARTITIONING: SWITCH_HYPERGRAPH_GAIN_TYPES(StaticHypergraphTypeTraits, gain_policy);
     case MULTILEVEL_GRAPH_PARTITIONING: SWITCH_GRAPH_GAIN_TYPES(StaticGraphTypeTraits, gain_policy);
@@ -214,42 +214,42 @@ kahypar::meta::PolicyBase& getCombinedTraitsPolicy(mt_kahypar_partition_type_t p
 
 REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::label_propagation,
                                LabelPropagationDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_LP_REFINER(LabelPropagationAlgorithm::deterministic,
                                DeterministicLabelPropagationDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_LP_REFINER(LabelPropagationAlgorithm::do_nothing, DoNothingRefiner, 1);
 
 REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::kway_fm,
                                DefaultFMDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::unconstrained_fm,
                                UnconstrainedFMDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FM_REFINER(FMAlgorithm::do_nothing, DoNothingRefiner, 3);
 
 REGISTER_DISPATCHED_FM_STRATEGY(FMAlgorithm::kway_fm,
                                 GainCacheFMStrategyDispatcher,
-                                getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                                getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_FM_STRATEGY(FMAlgorithm::unconstrained_fm,
                                 UnconstrainedFMStrategyDispatcher,
-                                getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                                getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 
 REGISTER_DISPATCHED_FLOW_SCHEDULER(FlowAlgorithm::flow_cutter,
                                    FlowSchedulerDispatcher,
-                                   getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                                   getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FLOW_SCHEDULER(FlowAlgorithm::do_nothing, DoNothingRefiner, 4);
 
 REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::simple_rebalancer,
                                SimpleRebalancerDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::advanced_rebalancer,
                                AdvancedRebalancerDispatcher,
-                               getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                               getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_REBALANCER(RebalancingAlgorithm::do_nothing, DoNothingRefiner, 5);
 
 REGISTER_DISPATCHED_FLOW_REFINER(FlowAlgorithm::flow_cutter,
                                  FlowRefinementDispatcher,
-                                 getCombinedTraitsPolicy(context.partition.partition_type, context.partition.gain_policy));
+                                 getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
 REGISTER_FLOW_REFINER(FlowAlgorithm::do_nothing, DoNothingFlowRefiner, 6);
 }  // namespace mt_kahypar

--- a/tests/io/context_test.cc.in
+++ b/tests/io/context_test.cc.in
@@ -132,8 +132,6 @@ TEST(AContext, LoadsDefaultPresetCorrectly) {
             expected.initial_partitioning.refinement.fm.min_improvement);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.time_limit_factor,
             expected.initial_partitioning.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.initial_partitioning.refinement.fm.perform_moves_global,
-            expected.initial_partitioning.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.rollback_parallel,
             expected.initial_partitioning.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.iter_moves_on_recalc,
@@ -179,8 +177,6 @@ TEST(AContext, LoadsDefaultPresetCorrectly) {
             expected.refinement.fm.min_improvement);
   ASSERT_EQ(actual.refinement.fm.time_limit_factor,
             expected.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.refinement.fm.perform_moves_global,
-            expected.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.refinement.fm.rollback_parallel,
             expected.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.refinement.fm.iter_moves_on_recalc,
@@ -300,8 +296,6 @@ TEST(AContext, LoadsQualityPresetCorrectly) {
             expected.initial_partitioning.refinement.fm.min_improvement);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.time_limit_factor,
             expected.initial_partitioning.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.initial_partitioning.refinement.fm.perform_moves_global,
-            expected.initial_partitioning.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.rollback_parallel,
             expected.initial_partitioning.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.iter_moves_on_recalc,
@@ -349,8 +343,6 @@ TEST(AContext, LoadsQualityPresetCorrectly) {
             expected.refinement.fm.min_improvement);
   ASSERT_EQ(actual.refinement.fm.time_limit_factor,
             expected.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.refinement.fm.perform_moves_global,
-            expected.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.refinement.fm.rollback_parallel,
             expected.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.refinement.fm.iter_moves_on_recalc,
@@ -645,8 +637,6 @@ TEST(AContext, LoadsHighestQualityPresetCorrectly) {
             expected.initial_partitioning.refinement.fm.min_improvement);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.time_limit_factor,
             expected.initial_partitioning.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.initial_partitioning.refinement.fm.perform_moves_global,
-            expected.initial_partitioning.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.rollback_parallel,
             expected.initial_partitioning.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.initial_partitioning.refinement.fm.iter_moves_on_recalc,
@@ -702,8 +692,6 @@ TEST(AContext, LoadsHighestQualityPresetCorrectly) {
             expected.refinement.fm.min_improvement);
   ASSERT_EQ(actual.refinement.fm.time_limit_factor,
             expected.refinement.fm.time_limit_factor);
-  ASSERT_EQ(actual.refinement.fm.perform_moves_global,
-            expected.refinement.fm.perform_moves_global);
   ASSERT_EQ(actual.refinement.fm.rollback_parallel,
             expected.refinement.fm.rollback_parallel);
   ASSERT_EQ(actual.refinement.fm.iter_moves_on_recalc,

--- a/tests/partition/determinism/determinism_test.cc
+++ b/tests/partition/determinism/determinism_test.cc
@@ -31,9 +31,9 @@
 #include "mt-kahypar/io/hypergraph_factory.h"
 
 #include "mt-kahypar/partition/initial_partitioning/bfs_initial_partitioner.h"
-
 #include "mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h"
 #include "mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
 #include "mt-kahypar/partition/preprocessing/community_detection/parallel_louvain.h"
 #include "mt-kahypar/utils/cast.h"
 
@@ -129,7 +129,7 @@ public:
       }
 
       mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
-      DeterministicLabelPropagationRefiner<TypeTraits, Km1GainTypes> refiner(
+      DeterministicLabelPropagationRefiner<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
         hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), context);
       refiner.initialize(phg);
       vec<HypernodeID> dummy_refinement_nodes;

--- a/tests/partition/initial_partitioning/pool_initial_partitioner_test.cc
+++ b/tests/partition/initial_partitioning/pool_initial_partitioner_test.cc
@@ -33,8 +33,8 @@
 #include "mt-kahypar/definitions.h"
 #include "mt-kahypar/utils/utilities.h"
 #include "mt-kahypar/io/hypergraph_factory.h"
-#include "mt-kahypar/partition/registries/register_initial_partitioning_algorithms.h"
 #include "mt-kahypar/partition/initial_partitioning/pool_initial_partitioner.h"
+#include "mt-kahypar/partition/metrics.h"
 
 using ::testing::Test;
 

--- a/tests/partition/refinement/advanced_rebalancer_test.cc
+++ b/tests/partition/refinement/advanced_rebalancer_test.cc
@@ -57,7 +57,7 @@ class RebalancerTest : public Test {
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
   using HypergraphFactory = typename Hypergraph::Factory;
   using GainCache = typename GainTypes::GainCache;
-  using Km1Rebalancer = AdvancedRebalancer<TypeTraits, GainTypes>;
+  using Rebalancer = AdvancedRebalancer<CombinedTraits<TypeTraits, GainTypes>>;
 
   RebalancerTest() :
           hypergraph(),
@@ -102,7 +102,7 @@ class RebalancerTest : public Test {
     partitioned_hypergraph = PartitionedHypergraph(context.partition.k, hypergraph, parallel_tag_t());
     context.setupPartWeights(hypergraph.totalWeight());
 
-    rebalancer = std::make_unique<Km1Rebalancer>(hypergraph.initialNumNodes(), context, gain_cache);
+    rebalancer = std::make_unique<Rebalancer>(hypergraph.initialNumNodes(), context, gain_cache);
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
     rebalancer->initialize(phg);
   }
@@ -111,7 +111,7 @@ class RebalancerTest : public Test {
   PartitionedHypergraph partitioned_hypergraph;
   Context context;
   GainCache gain_cache;
-  std::unique_ptr<Km1Rebalancer> rebalancer;
+  std::unique_ptr<Rebalancer> rebalancer;
 };
 
 

--- a/tests/partition/refinement/advanced_rebalancer_test.cc
+++ b/tests/partition/refinement/advanced_rebalancer_test.cc
@@ -57,7 +57,7 @@ class RebalancerTest : public Test {
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
   using HypergraphFactory = typename Hypergraph::Factory;
   using GainCache = typename GainTypes::GainCache;
-  using Rebalancer = AdvancedRebalancer<CombinedTraits<TypeTraits, GainTypes>>;
+  using Rebalancer = AdvancedRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>;
 
   RebalancerTest() :
           hypergraph(),

--- a/tests/partition/refinement/flow_construction_test.cc
+++ b/tests/partition/refinement/flow_construction_test.cc
@@ -113,10 +113,10 @@ class AFlowHypergraphConstructor : public Test {
   vec<HypernodeID> whfc_to_node;
 };
 
-typedef ::testing::Types<Config<SequentialConstruction<TypeTraits, Km1GainTypes>, whfc::SequentialPushRelabel, true>,
-                         Config<SequentialConstruction<TypeTraits, Km1GainTypes>, whfc::SequentialPushRelabel, false>,
-                         Config<ParallelConstruction<TypeTraits, Km1GainTypes>, whfc::ParallelPushRelabel, true>,
-                         Config<ParallelConstruction<TypeTraits, Km1GainTypes>, whfc::ParallelPushRelabel, false> > TestConfigs;
+typedef ::testing::Types<Config<SequentialConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, true>,
+                         Config<SequentialConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, false>,
+                         Config<ParallelConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, true>,
+                         Config<ParallelConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, false> > TestConfigs;
 
 TYPED_TEST_CASE(AFlowHypergraphConstructor, TestConfigs);
 

--- a/tests/partition/refinement/flow_construction_test.cc
+++ b/tests/partition/refinement/flow_construction_test.cc
@@ -113,10 +113,10 @@ class AFlowHypergraphConstructor : public Test {
   vec<HypernodeID> whfc_to_node;
 };
 
-typedef ::testing::Types<Config<SequentialConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, true>,
-                         Config<SequentialConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, false>,
-                         Config<ParallelConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, true>,
-                         Config<ParallelConstruction<CombinedTraits<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, false> > TestConfigs;
+typedef ::testing::Types<Config<SequentialConstruction<GraphAndGainTypes<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, true>,
+                         Config<SequentialConstruction<GraphAndGainTypes<TypeTraits, Km1GainTypes>>, whfc::SequentialPushRelabel, false>,
+                         Config<ParallelConstruction<GraphAndGainTypes<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, true>,
+                         Config<ParallelConstruction<GraphAndGainTypes<TypeTraits, Km1GainTypes>>, whfc::ParallelPushRelabel, false> > TestConfigs;
 
 TYPED_TEST_CASE(AFlowHypergraphConstructor, TestConfigs);
 

--- a/tests/partition/refinement/fm_strategy_test.cc
+++ b/tests/partition/refinement/fm_strategy_test.cc
@@ -53,9 +53,8 @@ struct AFMStrategy : public Test {
                                      Km1GainCache& gain_cache,
                                      FMSharedData& sd,
                                      BlockPriorityQueue& blockPQ,
-                                     vec<VertexPriorityQueue>& vertexPQs,
-                                     FMStats& fm_stats) {
-    Strategy strategy(context, sd, blockPQ, vertexPQs, fm_stats);
+                                     vec<VertexPriorityQueue>& vertexPQs) {
+    Strategy strategy(context, sd, blockPQ, vertexPQs);
 
     Move m;
     vec<Gain> gains;
@@ -100,13 +99,10 @@ TYPED_TEST(AFMStrategy, FindNextMove) {
   context.refinement.fm.algorithm = FMAlgorithm::kway_fm;
 
   FMSharedData sd(hg.initialNumNodes(), false);
-  FMStats fm_stats;
-  fm_stats.moves = 1;
-
   BlockPriorityQueue blockPQ(k);
   vec<VertexPriorityQueue> vertexPQs(k, VertexPriorityQueue(sd.vertexPQHandles.data(), sd.numberOfNodes));
 
-  vec<Gain> gains_cached = this->insertAndExtractAllMoves(phg, context, gain_cache, sd, blockPQ, vertexPQs, fm_stats);
+  vec<Gain> gains_cached = this->insertAndExtractAllMoves(phg, context, gain_cache, sd, blockPQ, vertexPQs);
   ASSERT_TRUE(std::is_sorted(gains_cached.begin(), gains_cached.end(), std::greater<Gain>()));
 }
 

--- a/tests/partition/refinement/label_propagation_refiner_test.cc
+++ b/tests/partition/refinement/label_propagation_refiner_test.cc
@@ -46,7 +46,7 @@ template <typename TypeTraitsT, PartitionID k, bool unconstrained>
 struct TestConfig<TypeTraitsT, k, unconstrained, Objective::km1> {
   using TypeTraits = TypeTraitsT;
   using GainTypes = Km1GainTypes;
-  using Refiner = LabelPropagationRefiner<CombinedTraits<TypeTraits, GainTypes>>;
+  using Refiner = LabelPropagationRefiner<GraphAndGainTypes<TypeTraits, GainTypes>>;
   static constexpr PartitionID K = k;
   static constexpr Objective OBJECTIVE = Objective::km1;
   static constexpr LabelPropagationAlgorithm LP_ALGO = LabelPropagationAlgorithm::label_propagation;
@@ -57,7 +57,7 @@ template <typename TypeTraitsT, PartitionID k, bool unconstrained>
 struct TestConfig<TypeTraitsT, k, unconstrained, Objective::cut> {
   using TypeTraits = TypeTraitsT;
   using GainTypes = CutGainTypes;
-  using Refiner = LabelPropagationRefiner<CombinedTraits<TypeTraits, GainTypes>>;
+  using Refiner = LabelPropagationRefiner<GraphAndGainTypes<TypeTraits, GainTypes>>;
   static constexpr PartitionID K = k;
   static constexpr Objective OBJECTIVE = Objective::cut;
   static constexpr LabelPropagationAlgorithm LP_ALGO = LabelPropagationAlgorithm::label_propagation;
@@ -122,7 +122,7 @@ class ALabelPropagationRefiner : public Test {
     context.setupPartWeights(hypergraph.totalWeight());
     initialPartition();
 
-    rebalancer = std::make_unique<AdvancedRebalancer<CombinedTraits<TypeTraits, GainTypes>>>(
+    rebalancer = std::make_unique<AdvancedRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>>(
       hypergraph.initialNumNodes(), context, gain_cache);
     refiner = std::make_unique<Refiner>(
       hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);

--- a/tests/partition/refinement/label_propagation_refiner_test.cc
+++ b/tests/partition/refinement/label_propagation_refiner_test.cc
@@ -46,7 +46,7 @@ template <typename TypeTraitsT, PartitionID k, bool unconstrained>
 struct TestConfig<TypeTraitsT, k, unconstrained, Objective::km1> {
   using TypeTraits = TypeTraitsT;
   using GainTypes = Km1GainTypes;
-  using Refiner = LabelPropagationRefiner<TypeTraits, GainTypes>;
+  using Refiner = LabelPropagationRefiner<CombinedTraits<TypeTraits, GainTypes>>;
   static constexpr PartitionID K = k;
   static constexpr Objective OBJECTIVE = Objective::km1;
   static constexpr LabelPropagationAlgorithm LP_ALGO = LabelPropagationAlgorithm::label_propagation;
@@ -57,7 +57,7 @@ template <typename TypeTraitsT, PartitionID k, bool unconstrained>
 struct TestConfig<TypeTraitsT, k, unconstrained, Objective::cut> {
   using TypeTraits = TypeTraitsT;
   using GainTypes = CutGainTypes;
-  using Refiner = LabelPropagationRefiner<TypeTraits, GainTypes>;
+  using Refiner = LabelPropagationRefiner<CombinedTraits<TypeTraits, GainTypes>>;
   static constexpr PartitionID K = k;
   static constexpr Objective OBJECTIVE = Objective::cut;
   static constexpr LabelPropagationAlgorithm LP_ALGO = LabelPropagationAlgorithm::label_propagation;
@@ -122,7 +122,8 @@ class ALabelPropagationRefiner : public Test {
     context.setupPartWeights(hypergraph.totalWeight());
     initialPartition();
 
-    rebalancer = std::make_unique<AdvancedRebalancer<TypeTraits, GainTypes>>(hypergraph.initialNumNodes(), context, gain_cache);
+    rebalancer = std::make_unique<AdvancedRebalancer<CombinedTraits<TypeTraits, GainTypes>>>(
+      hypergraph.initialNumNodes(), context, gain_cache);
     refiner = std::make_unique<Refiner>(
       hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);

--- a/tests/partition/refinement/multitry_fm_test.cc
+++ b/tests/partition/refinement/multitry_fm_test.cc
@@ -188,7 +188,6 @@ TYPED_TEST(MultiTryFMTest, DoesNotWorsenSolutionQuality) {
 TYPED_TEST(MultiTryFMTest, AlsoWorksWithNonDefaultFeatures) {
   this->context.refinement.fm.obey_minimal_parallelism = true;
   this->context.refinement.fm.rollback_parallel = false;
-  this->context.refinement.fm.perform_moves_global = true;
   HyperedgeWeight objective_before = metrics::quality(this->partitioned_hypergraph, this->context.partition.objective);
   mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
   this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());

--- a/tests/partition/refinement/multitry_fm_test.cc
+++ b/tests/partition/refinement/multitry_fm_test.cc
@@ -54,7 +54,7 @@ class MultiTryFMTest : public Test {
   using TypeTraits = typename Config::TypeTraits;
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using Refiner = MultiTryKWayFM<TypeTraits, Km1GainTypes>;
+  using Refiner = MultiTryKWayFM<CombinedTraits<TypeTraits, Km1GainTypes>>;
 
   MultiTryFMTest() :
           hypergraph(),
@@ -108,7 +108,8 @@ class MultiTryFMTest : public Test {
     context.setupPartWeights(hypergraph.totalWeight());
     initialPartition();
 
-    rebalancer = std::make_unique<AdvancedRebalancer<TypeTraits, Km1GainTypes>>(hypergraph.initialNumNodes(), context, gain_cache);
+    rebalancer = std::make_unique<AdvancedRebalancer<CombinedTraits<TypeTraits, Km1GainTypes>>>(
+      hypergraph.initialNumNodes(), context, gain_cache);
     refiner = std::make_unique<Refiner>(hypergraph.initialNumNodes(),
       hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
@@ -274,7 +275,7 @@ TEST(UnconstrainedFMDataTest, CorrectlyComputesPenalty) {
   gain_cache.initializeGainCache(phg);
 
   UnconstrainedFMData ufm_data(4);
-  ufm_data.initialize<TypeTraits, Km1GainTypes>(context, phg, gain_cache);
+  ufm_data.initialize<CombinedTraits<TypeTraits, Km1GainTypes>>(context, phg, gain_cache);
 
   ASSERT_EQ(0, ufm_data.estimatePenaltyForImbalancedMove(0, -1, -1));
   ASSERT_LE(1.0, ufm_data.estimatePenaltyForImbalancedMove(0, 0, 1));

--- a/tests/partition/refinement/multitry_fm_test.cc
+++ b/tests/partition/refinement/multitry_fm_test.cc
@@ -54,7 +54,7 @@ class MultiTryFMTest : public Test {
   using TypeTraits = typename Config::TypeTraits;
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using Refiner = MultiTryKWayFM<CombinedTraits<TypeTraits, Km1GainTypes>>;
+  using Refiner = MultiTryKWayFM<GraphAndGainTypes<TypeTraits, Km1GainTypes>>;
 
   MultiTryFMTest() :
           hypergraph(),
@@ -108,7 +108,7 @@ class MultiTryFMTest : public Test {
     context.setupPartWeights(hypergraph.totalWeight());
     initialPartition();
 
-    rebalancer = std::make_unique<AdvancedRebalancer<CombinedTraits<TypeTraits, Km1GainTypes>>>(
+    rebalancer = std::make_unique<AdvancedRebalancer<GraphAndGainTypes<TypeTraits, Km1GainTypes>>>(
       hypergraph.initialNumNodes(), context, gain_cache);
     refiner = std::make_unique<Refiner>(hypergraph.initialNumNodes(),
       hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);
@@ -275,7 +275,7 @@ TEST(UnconstrainedFMDataTest, CorrectlyComputesPenalty) {
   gain_cache.initializeGainCache(phg);
 
   UnconstrainedFMData ufm_data(4);
-  ufm_data.initialize<CombinedTraits<TypeTraits, Km1GainTypes>>(context, phg, gain_cache);
+  ufm_data.initialize<GraphAndGainTypes<TypeTraits, Km1GainTypes>>(context, phg, gain_cache);
 
   ASSERT_EQ(0, ufm_data.estimatePenaltyForImbalancedMove(0, -1, -1));
   ASSERT_LE(1.0, ufm_data.estimatePenaltyForImbalancedMove(0, 0, 1));

--- a/tests/partition/refinement/rebalance_test.cc
+++ b/tests/partition/refinement/rebalance_test.cc
@@ -43,7 +43,7 @@ namespace {
   using TypeTraits = StaticHypergraphTypeTraits;
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using Km1Rebalancer = SimpleRebalancer<TypeTraits, Km1GainTypes>;
+  using Km1Rebalancer = SimpleRebalancer<CombinedTraits<TypeTraits, Km1GainTypes>>;
 }
 
 

--- a/tests/partition/refinement/rebalance_test.cc
+++ b/tests/partition/refinement/rebalance_test.cc
@@ -43,7 +43,7 @@ namespace {
   using TypeTraits = StaticHypergraphTypeTraits;
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
-  using Km1Rebalancer = SimpleRebalancer<CombinedTraits<TypeTraits, Km1GainTypes>>;
+  using Km1Rebalancer = SimpleRebalancer<GraphAndGainTypes<TypeTraits, Km1GainTypes>>;
 }
 
 

--- a/tests/partition/refinement/rollback_test.cc
+++ b/tests/partition/refinement/rollback_test.cc
@@ -79,7 +79,7 @@ TEST(RollbackTests, GainRecalculationAndRollsbackCorrectly) {
 
   FMSharedData sharedData(hg.initialNumNodes(), false);
 
-  GlobalRollback<TypeTraits, Km1GainTypes> grb(
+  GlobalRollback<CombinedTraits<TypeTraits, Km1GainTypes>> grb(
     hg.initialNumEdges(), context, gain_cache);
   auto performMove = [&](Move m) {
     if (phg.changeNodePart(gain_cache, m.node, m.from, m.to)) {
@@ -136,7 +136,7 @@ TEST(RollbackTests, GainRecalculation2) {
 
   FMSharedData sharedData(hg.initialNumNodes(), false);
 
-  GlobalRollback<TypeTraits, Km1GainTypes> grb(
+  GlobalRollback<CombinedTraits<TypeTraits, Km1GainTypes>> grb(
     hg.initialNumEdges(), context, gain_cache);
 
   auto performUpdates = [&](Move& m) {

--- a/tests/partition/refinement/rollback_test.cc
+++ b/tests/partition/refinement/rollback_test.cc
@@ -79,7 +79,7 @@ TEST(RollbackTests, GainRecalculationAndRollsbackCorrectly) {
 
   FMSharedData sharedData(hg.initialNumNodes(), false);
 
-  GlobalRollback<CombinedTraits<TypeTraits, Km1GainTypes>> grb(
+  GlobalRollback<GraphAndGainTypes<TypeTraits, Km1GainTypes>> grb(
     hg.initialNumEdges(), context, gain_cache);
   auto performMove = [&](Move m) {
     if (phg.changeNodePart(gain_cache, m.node, m.from, m.to)) {
@@ -136,7 +136,7 @@ TEST(RollbackTests, GainRecalculation2) {
 
   FMSharedData sharedData(hg.initialNumNodes(), false);
 
-  GlobalRollback<CombinedTraits<TypeTraits, Km1GainTypes>> grb(
+  GlobalRollback<GraphAndGainTypes<TypeTraits, Km1GainTypes>> grb(
     hg.initialNumEdges(), context, gain_cache);
 
   auto performUpdates = [&](Move& m) {

--- a/tests/partition/refinement/scheduler_test.cc
+++ b/tests/partition/refinement/scheduler_test.cc
@@ -104,7 +104,7 @@ void verifyPartWeights(const vec<HypernodeWeight> actual_weights,
 
 TEST_F(AFlowRefinementScheduler, MovesOneVertex) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -120,7 +120,7 @@ TEST_F(AFlowRefinementScheduler, MovesOneVertex) {
 
 TEST_F(AFlowRefinementScheduler, MovesVerticesWithIntermediateBalanceViolation) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -138,7 +138,7 @@ TEST_F(AFlowRefinementScheduler, MovesVerticesWithIntermediateBalanceViolation) 
 
 TEST_F(AFlowRefinementScheduler, MovesAVertexThatWorsenSolutionQuality) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -154,7 +154,7 @@ TEST_F(AFlowRefinementScheduler, MovesAVertexThatWorsenSolutionQuality) {
 
 TEST_F(AFlowRefinementScheduler, MovesAVertexThatViolatesBalanceConstraint) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -171,7 +171,7 @@ TEST_F(AFlowRefinementScheduler, MovesAVertexThatViolatesBalanceConstraint) {
 TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrently) {
   context.partition.max_part_weights.assign(2, 5);
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -198,7 +198,7 @@ TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrently) {
 
 TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrentlyWhereOneViolateBalanceConstraint) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -320,7 +320,7 @@ class AFlowRefinementEndToEnd : public Test {
 TEST_F(AFlowRefinementEndToEnd, SmokeTestWithTwoBlocksPerRefiner) {
   const bool debug = false;
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> scheduler(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> scheduler(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
 
   Metrics metrics;
@@ -356,7 +356,7 @@ TEST_F(AFlowRefinementEndToEnd, SmokeTestWithFourBlocksPerRefiner) {
   const bool debug = false;
   FlowRefinerMockControl::instance().max_num_blocks = 4;
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> scheduler(
+  FlowRefinementScheduler<GraphAndGainTypes<TypeTraits, Km1GainTypes>> scheduler(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
 
   Metrics metrics;

--- a/tests/partition/refinement/scheduler_test.cc
+++ b/tests/partition/refinement/scheduler_test.cc
@@ -104,7 +104,7 @@ void verifyPartWeights(const vec<HypernodeWeight> actual_weights,
 
 TEST_F(AFlowRefinementScheduler, MovesOneVertex) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -120,7 +120,7 @@ TEST_F(AFlowRefinementScheduler, MovesOneVertex) {
 
 TEST_F(AFlowRefinementScheduler, MovesVerticesWithIntermediateBalanceViolation) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -138,7 +138,7 @@ TEST_F(AFlowRefinementScheduler, MovesVerticesWithIntermediateBalanceViolation) 
 
 TEST_F(AFlowRefinementScheduler, MovesAVertexThatWorsenSolutionQuality) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -154,7 +154,7 @@ TEST_F(AFlowRefinementScheduler, MovesAVertexThatWorsenSolutionQuality) {
 
 TEST_F(AFlowRefinementScheduler, MovesAVertexThatViolatesBalanceConstraint) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -171,7 +171,7 @@ TEST_F(AFlowRefinementScheduler, MovesAVertexThatViolatesBalanceConstraint) {
 TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrently) {
   context.partition.max_part_weights.assign(2, 5);
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -198,7 +198,7 @@ TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrently) {
 
 TEST_F(AFlowRefinementScheduler, MovesTwoVerticesConcurrentlyWhereOneViolateBalanceConstraint) {
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> refiner(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> refiner(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
   mt_kahypar_partitioned_hypergraph_t partitioned_hg = utils::partitioned_hg_cast(phg);
   refiner.initialize(partitioned_hg);
@@ -320,7 +320,7 @@ class AFlowRefinementEndToEnd : public Test {
 TEST_F(AFlowRefinementEndToEnd, SmokeTestWithTwoBlocksPerRefiner) {
   const bool debug = false;
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> scheduler(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> scheduler(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
 
   Metrics metrics;
@@ -356,7 +356,7 @@ TEST_F(AFlowRefinementEndToEnd, SmokeTestWithFourBlocksPerRefiner) {
   const bool debug = false;
   FlowRefinerMockControl::instance().max_num_blocks = 4;
   Km1GainCache gain_cache;
-  FlowRefinementScheduler<TypeTraits, Km1GainTypes> scheduler(
+  FlowRefinementScheduler<CombinedTraits<TypeTraits, Km1GainTypes>> scheduler(
     hg.initialNumNodes(), hg.initialNumEdges(), context, gain_cache);
 
   Metrics metrics;


### PR DESCRIPTION
- Refactors `localized_kway_fm_core` to reduce compile times and remove code that is not used by our configurations (also introduces a small optimization for graphs)
- Includes several refactoring with the overall goal of reducing compile times. Notably, only valid combinations of graph data structure / gain type are now instantiated
- Includes a few small fixes for previous changes (printing the parameters for unconstrained refinement, fixing some warnings)

Clean build times are ~1.5 times faster on my machine while the compilation time for the slowest files is reduced by a factor of 2-3.