### PR TITLE
Fix edge cases in unconstrained LP, rebalancer and FM

### DIFF
--- a/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
+++ b/mt-kahypar/partition/refinement/fm/localized_kway_fm_core.cpp
@@ -176,7 +176,7 @@ namespace mt_kahypar {
           }
           delta_gain_cache.deltaGainUpdate(deltaPhg, sync_update);
         });
-        fm_strategy.applyMove(deltaPhg, delta_gain_cache, move, false);
+        fm_strategy.applyMove(deltaPhg, delta_gain_cache, move);
       }
 
       if (moved) {

--- a/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
@@ -232,7 +232,7 @@ private:
                                                       HypernodeID u,
                                                       PartitionID from,
                                                       std::array<PartitionID, 3> parts) {
-
+    // We ignore balance here to avoid recomputations that involve all blocks (see `updateGain` for details)
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;

--- a/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
@@ -42,7 +42,7 @@ namespace mt_kahypar {
    * insertIntoPQ(phg, gain_cache, node)
    * updateGain(phg, gain_cache, node, move)
    * findNextMove(phg, gain_cache, move)
-   * applyMove(phg, gain_cache, move, global)
+   * applyMove(phg, gain_cache, move)
    * reset()
    * deltaGainUpdates(phg, gain_cache, sync_update)
    *
@@ -142,13 +142,7 @@ public:
 
   template<typename PartitionedHypergraph, typename GainCache>
   MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
-  void applyMove(const PartitionedHypergraph&, const GainCache&, Move, bool) {
-    // nothing to do here
-  }
-
-  template<typename PartitionedHypergraph, typename GainCache>
-  MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
-  void revertMove(const PartitionedHypergraph&, const GainCache&, Move, bool) {
+  void applyMove(const PartitionedHypergraph&, const GainCache&, Move) {
     // nothing to do here
   }
 

--- a/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
@@ -74,7 +74,7 @@ public:
                     const HypernodeID v) {
     const PartitionID pv = phg.partID(v);
     ASSERT(pv < context.partition.k);
-    auto [target, gain] = computeBestTargetBlock(phg, gain_cache, v, pv);
+    auto [target, gain] = computeBestTargetBlock(phg, gain_cache, v, pv, true);
     ASSERT(target < context.partition.k, V(target) << V(context.partition.k));
     sharedData.targetPart[v] = target;
     vertexPQs[pv].insert(v, gain);  // blockPQ updates are done later, collectively.
@@ -92,10 +92,14 @@ public:
     Gain gain = 0;
     PartitionID newTarget = kInvalidPartition;
 
+    // Note: During gain updates, we ignore the balance constraint for determining the best target block.
+    // This allows to use the optimized `bestOfThree` function for priority updates, which would not always
+    // be valid if balance is included (the best of the three could be overloaded). As soon as the move is
+    // pulled from the PQ, only balanced targets are considered
     if (context.partition.k < 4 || designatedTargetV == move.from || designatedTargetV == move.to) {
       // penalty term of designatedTargetV is affected.
       // and may now be greater than that of other blocks --> recompute full
-      std::tie(newTarget, gain) = computeBestTargetBlock(phg, gain_cache, v, pv);
+      std::tie(newTarget, gain) = computeBestTargetBlock(phg, gain_cache, v, pv, true);
     } else {
       // penalty term of designatedTargetV is not affected.
       // only move.from and move.to may be better
@@ -123,7 +127,7 @@ public:
       const HypernodeID u = vertexPQs[from].top();
       const Gain estimated_gain = vertexPQs[from].topKey();
       ASSERT(estimated_gain == blockPQ.topKey());
-      auto [to, gain] = computeBestTargetBlock(phg, gain_cache, u, phg.partID(u));
+      auto [to, gain] = computeBestTargetBlock(phg, gain_cache, u, phg.partID(u), false);
 
       if (gain >= estimated_gain) { // accept any gain that is at least as good
         m.node = u; m.to = to; m.from = from;
@@ -197,7 +201,8 @@ private:
   std::pair<PartitionID, HyperedgeWeight> computeBestTargetBlock(const PartitionedHypergraph& phg,
                                                                  const GainCache& gain_cache,
                                                                  const HypernodeID u,
-                                                                 const PartitionID from) {
+                                                                 const PartitionID from,
+                                                                 bool ignore_balance) {
     const HypernodeWeight wu = phg.nodeWeight(u);
     const HypernodeWeight from_weight = phg.partWeight(from);
     PartitionID to = kInvalidPartition;
@@ -208,7 +213,7 @@ private:
         const HypernodeWeight to_weight = phg.partWeight(i);
         const HyperedgeWeight penalty = gain_cache.benefitTerm(u, i);
         if ( ( penalty > to_benefit || ( penalty == to_benefit && to_weight < best_to_weight ) ) &&
-             to_weight + wu <= context.partition.max_part_weights[i] ) {
+             (ignore_balance || to_weight + wu <= context.partition.max_part_weights[i]) ) {
           to_benefit = penalty;
           to = i;
           best_to_weight = to_weight;
@@ -237,8 +242,7 @@ private:
       if (i != from && i != kInvalidPartition) {
         const HypernodeWeight to_weight = phg.partWeight(i);
         const HyperedgeWeight penalty = gain_cache.benefitTerm(u, i);
-        if ( ( penalty > to_benefit || ( penalty == to_benefit && to_weight < best_to_weight ) ) &&
-             to_weight + wu <= context.partition.max_part_weights[i] ) {
+        if ( ( penalty > to_benefit || (penalty == to_benefit && to_weight < best_to_weight) ) ) {
           to_benefit = penalty;
           to = i;
           best_to_weight = to_weight;

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -277,10 +277,13 @@ namespace mt_kahypar {
 
     bool was_imbalanced_and_improved_balance = !_old_partition_is_balanced
                                                && current_metrics.imbalance < best_metrics.imbalance;
-    bool is_imbalanced_and_worsened_balance = (!metrics::isBalanced(hypergraph, _context)
-                                              && current_metrics.imbalance > best_metrics.imbalance);
-    if (!was_imbalanced_and_improved_balance
-        && (current_metrics.quality > best_metrics.quality || is_imbalanced_and_worsened_balance)) {
+    // We consider the new partition an improvement if either
+    // (1) the old partiton was imbalanced and balance is improved or
+    // (2) the quality is improved while still being balanced
+    if ( was_imbalanced_and_improved_balance
+         || (current_metrics.quality <= best_metrics.quality && metrics::isBalanced(hypergraph, _context)) ) {
+      return false;
+    } else {
       // rollback and stop LP
       auto noop_obj_fn = [](const SynchronizedEdgeUpdate&) { };
       current_metrics = best_metrics;
@@ -294,7 +297,6 @@ namespace mt_kahypar {
       });
       return true;
     }
-    return false;
   }
 
   template <typename GraphAndGainTypes>

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -60,6 +60,7 @@ class LabelPropagationRefiner final : public IRefiner {
                                    GainCache& gain_cache,
                                    IRebalancer& rb) :
     _might_be_uninitialized(false),
+    _old_partition_is_balanced(true),
     _context(context),
     _gain_cache(gain_cache),
     _current_k(context.partition.k),
@@ -195,6 +196,7 @@ class LabelPropagationRefiner final : public IRefiner {
   }
 
   bool _might_be_uninitialized;
+  bool _old_partition_is_balanced;
   const Context& _context;
   GainCache& _gain_cache;
   PartitionID _current_k;

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -99,14 +99,13 @@ namespace impl {
       }
     }
 
-    Gain gain = std::numeric_limits<Gain>::min();
     if (to != kInvalidPartition) {
-      gain = to_benefit - gain_cache.penaltyTerm(u, phg.partID(u));
+      Gain gain = to_benefit - gain_cache.penaltyTerm(u, phg.partID(u));
+      return std::make_pair(to, transformGain(gain, wu));
     } else {
       // edge case: if u does not fit in any of the three considered blocks we need to check all blocks
       return computeBestTargetBlock(phg, context, gain_cache, u, from);
     }
-    return std::make_pair(to, transformGain(gain, wu));
   }
 
   struct AccessToken {

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -102,6 +102,9 @@ namespace impl {
     Gain gain = std::numeric_limits<Gain>::min();
     if (to != kInvalidPartition) {
       gain = to_benefit - gain_cache.penaltyTerm(u, phg.partID(u));
+    } else {
+      // edge case: if u does not fit in any of the three considered blocks we need to check all blocks
+      return computeBestTargetBlock(phg, context, gain_cache, u, from);
     }
     return std::make_pair(to, transformGain(gain, wu));
   }


### PR DESCRIPTION
This fixes:
- An issue in unconstrained LP where the rollback assumed that rebalancing always succeeds
- Issues related to the `bestOfThree` function used by the rebalancer and FM to update move priorities. The problem is that `bestOfThree` does not work if some of the three blocks are overloaded. If all are overloaded, it could even cause the rebalancer to drop the node completely and thus not rebalancing correctly. For unconstrained FM and the rebalancer, this is solved with a fallback that considers all blocks (which cannot happen too often since the load increases monotonically in these cases). For constrained FM the block weight can fluctuate, thus the new implementation just ignores the balance constraint when updating priorities (balance is ensured when pulling the move from the queue)

Specifically, the combination of the unconstrained LP and rebalancer bug could result in a pathological case with much worse result. Almost all of the improvement comes from fixing this case (red -> blue), as shown here:

![result](https://github.com/kahypar/mt-kahypar/assets/25832380/1f74d2a1-a3ba-49bd-a65c-d6d46ef5d009)

The benchmark set used here contains roughly 50-50 regular and irregular graphs, k is in {32, 64, 128, 256} (as small k are not affected).

On their own, the adjustments to rebalancer and FM bring a tiny improvement (blue -> orange), which is more in the order of statistical noise. I tested two variants for the rebalancer and FM as discussed with @larsgottesbueren and used the one with a tiny bit better results.

Running time seems unaffected.