### PR TITLE
Performance improvements for coarsening on (large irregular) graphs

### DIFF
--- a/mt-kahypar/datastructures/array.h
+++ b/mt-kahypar/datastructures/array.h
@@ -300,6 +300,13 @@ class Array {
     assign(size, init_value, assign_parallel);
   }
 
+  void resizeNoAssign(const size_type size) {
+    if ( _data || _underlying_data ) {
+      throw SystemException("Memory of vector already allocated");
+    }
+    allocate_data(size);
+  }
+
   void resize(const std::string& group,
               const std::string& key,
               const size_type size,

--- a/mt-kahypar/datastructures/concurrent_bucket_map.h
+++ b/mt-kahypar/datastructures/concurrent_bucket_map.h
@@ -74,12 +74,6 @@ class ConcurrentBucketMap {
     _spin_locks(_num_buckets),
     _buckets(_num_buckets) { }
 
-  explicit ConcurrentBucketMap(size_t bucket_factor) :
-    _num_buckets(align_to_next_power_of_two(bucket_factor * std::thread::hardware_concurrency())),
-    _mod_mask(_num_buckets - 1),
-    _spin_locks(_num_buckets),
-    _buckets(_num_buckets) { }
-
   ConcurrentBucketMap(const ConcurrentBucketMap&) = delete;
   ConcurrentBucketMap & operator= (const ConcurrentBucketMap &) = delete;
 

--- a/mt-kahypar/datastructures/concurrent_bucket_map.h
+++ b/mt-kahypar/datastructures/concurrent_bucket_map.h
@@ -74,6 +74,12 @@ class ConcurrentBucketMap {
     _spin_locks(_num_buckets),
     _buckets(_num_buckets) { }
 
+  explicit ConcurrentBucketMap(size_t bucket_factor) :
+    _num_buckets(align_to_next_power_of_two(bucket_factor * std::thread::hardware_concurrency())),
+    _mod_mask(_num_buckets - 1),
+    _spin_locks(_num_buckets),
+    _buckets(_num_buckets) { }
+
   ConcurrentBucketMap(const ConcurrentBucketMap&) = delete;
   ConcurrentBucketMap & operator= (const ConcurrentBucketMap &) = delete;
 

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -350,8 +350,8 @@ namespace mt_kahypar::ds {
     tbb::parallel_invoke([&] {
       // Copy edges
       edge_id_mapping.assign(_num_edges / 2, 0);
-      hypergraph._edges.resize(coarsened_num_edges);
-      hypergraph._unique_edge_ids.resize(coarsened_num_edges);
+      hypergraph._edges.resizeNoAssign(coarsened_num_edges);
+      hypergraph._unique_edge_ids.resizeNoAssign(coarsened_num_edges);
       tbb::parallel_for(ID(0), coarsened_num_nodes, [&](const HyperedgeID& coarse_node) {
         const HyperedgeID tmp_edges_start = tmp_nodes[coarse_node].firstEntry();
         const HyperedgeID edges_start = degree_mapping[coarse_node];

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -347,7 +347,7 @@ namespace mt_kahypar::ds {
           edge_id_mapping[tmp_edge.getID()] = UL(1);
         };
 
-        if (degree_mapping.value(coarse_node) > HIGH_DEGREE_CONTRACTION_THRESHOLD) {
+        if (degree_mapping.value(coarse_node) > HIGH_DEGREE_CONTRACTION_THRESHOLD / 8) {
           tbb::parallel_for(ID(0), degree_mapping.value(coarse_node), handle_edge);
         } else {
           for (size_t index = 0; index < degree_mapping.value(coarse_node); ++index) {

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -34,6 +34,7 @@
 #include "mt-kahypar/utils/memory_tree.h"
 
 #include <tbb/parallel_reduce.h>
+#include <tbb/parallel_sort.h>
 
 
 namespace mt_kahypar::ds {
@@ -46,7 +47,7 @@ namespace mt_kahypar::ds {
    *
    * \param communities Community structure that should be contracted
    */
-  StaticGraph StaticGraph::contract(parallel::scalable_vector<HypernodeID>& communities, bool /*deterministic*/) {
+  StaticGraph StaticGraph::contract(parallel::scalable_vector<HypernodeID>& communities, bool deterministic) {
     ASSERT(communities.size() == _num_nodes);
 
     // helper function that is used in multiple places for edge deduplication
@@ -261,7 +262,7 @@ namespace mt_kahypar::ds {
         const size_t num_chunks = std::thread::hardware_concurrency();
         const size_t chunk_size = (size_of_range + num_chunks - 1) / num_chunks;
         tbb::parallel_for(UL(0), num_chunks, [&](const size_t chunk_id) {
-          const size_t start = incident_edges_start + chunk_id * chunk_size;
+          const size_t start = std::min(incident_edges_start + chunk_id * chunk_size, incident_edges_end);
           const size_t end = std::min(incident_edges_start + (chunk_id + 1) * chunk_size, incident_edges_end);
           // First, we apply a deduplication step to the thread-local range. The reason is that on large irregular
           // graphs, extremely large clusters (thousands of nodes) can be created during coarsening. In this case,
@@ -293,6 +294,14 @@ namespace mt_kahypar::ds {
           tmp_edges[i].invalidate();
         });
         node_sizes[coarse_node] = contracted_size;
+
+        if (deterministic) {
+          // sort for determinism
+          tbb::parallel_sort(tmp_edges.begin() + incident_edges_start, tmp_edges.begin() + incident_edges_pos.load(),
+            [](const TmpEdgeInformation& e1, const TmpEdgeInformation& e2) {
+              return e1._target < e2._target;
+            });
+        }
       }
     }
 

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -49,6 +49,58 @@ namespace mt_kahypar::ds {
   StaticGraph StaticGraph::contract(parallel::scalable_vector<HypernodeID>& communities, bool /*deterministic*/) {
     ASSERT(communities.size() == _num_nodes);
 
+    // helper function that is used in multiple places for edge deduplication
+    auto deduplicate_tmp_edges = [](TmpEdgeInformation* edge_start, TmpEdgeInformation* edge_end) {
+      ASSERT(std::distance(edge_start, edge_end) >= 0);
+      std::sort(edge_start, edge_end,
+                [](const TmpEdgeInformation& e1, const TmpEdgeInformation& e2) {
+                  return e1._target < e2._target;
+                });
+
+      // Deduplicate, aggregate weights and calculate minimum unique id
+      //
+      // <-- deduplicated --> <-- already processed --> <-- to be processed --> <-- invalid edges -->
+      //                    ^                         ^
+      // valid_edge_index ---        tmp_edge_index ---
+      size_t valid_edge_index = 0;
+      size_t tmp_edge_index = 1;
+      while (tmp_edge_index < static_cast<size_t>(std::distance(edge_start, edge_end)) && edge_start[tmp_edge_index].isValid()) {
+        HEAVY_COARSENING_ASSERT(
+          [&](){
+            size_t i = 0;
+            for (; i <= valid_edge_index; ++i) {
+              if (!edge_start[i].isValid()) {
+                return false;
+              } else if ((i + 1 <= valid_edge_index) &&
+                edge_start[i].getTarget() >= edge_start[i + 1].getTarget()) {
+                return false;
+              }
+            }
+            for (; i < tmp_edge_index; ++i) {
+              if (edge_start[i].isValid()) {
+                return false;
+              }
+            }
+            return true;
+          }(),
+          "Invariant violated while deduplicating incident edges!"
+        );
+
+        TmpEdgeInformation& valid_edge = edge_start[valid_edge_index];
+        TmpEdgeInformation& next_edge = edge_start[tmp_edge_index];
+        if (valid_edge.getTarget() == next_edge.getTarget()) {
+          valid_edge.addWeight(next_edge.getWeight());
+          valid_edge.updateID(next_edge.getID());
+          next_edge.invalidate();
+        } else {
+          std::swap(edge_start[++valid_edge_index], next_edge);
+        }
+        ++tmp_edge_index;
+      }
+      const bool is_non_empty = (std::distance(edge_start, edge_end) > 0) && edge_start[0].isValid();
+      return is_non_empty ? (valid_edge_index + 1) : 0;
+    };
+
     if ( !_tmp_contraction_buffer ) {
       allocateTmpContractionBuffer();
     }
@@ -173,61 +225,13 @@ namespace mt_kahypar::ds {
     parallel::scalable_vector<HypernodeID> high_degree_vertices;
     std::mutex high_degree_vertex_mutex;
     tbb::parallel_for(ID(0), coarsened_num_nodes, [&](const HypernodeID& coarse_node) {
-      // Remove duplicates
       const size_t incident_edges_start = tmp_incident_edges_prefix_sum[coarse_node];
       const size_t incident_edges_end = tmp_incident_edges_prefix_sum[coarse_node + 1];
       const size_t tmp_degree = incident_edges_end - incident_edges_start;
       if (tmp_degree <= HIGH_DEGREE_CONTRACTION_THRESHOLD) {
-        std::sort(tmp_edges.begin() + incident_edges_start, tmp_edges.begin() + incident_edges_end,
-                  [](const TmpEdgeInformation& e1, const TmpEdgeInformation& e2) {
-                    return e1._target < e2._target;
-                  });
-
-        // Deduplicate, aggregate weights and calculate minimum unique id
-        //
-        // <-- deduplicated --> <-- already processed --> <-- to be processed --> <-- invalid edges -->
-        //                    ^                         ^
-        // valid_edge_index ---        tmp_edge_index ---
-        size_t valid_edge_index = incident_edges_start;
-        size_t tmp_edge_index = incident_edges_start + 1;
-        while (tmp_edge_index < incident_edges_end && tmp_edges[tmp_edge_index].isValid()) {
-          HEAVY_COARSENING_ASSERT(
-            [&](){
-              size_t i = incident_edges_start;
-              for (; i <= valid_edge_index; ++i) {
-                if (!tmp_edges[i].isValid()) {
-                  return false;
-                } else if ((i + 1 <= valid_edge_index) &&
-                  tmp_edges[i].getTarget() >= tmp_edges[i + 1].getTarget()) {
-                  return false;
-                }
-              }
-              for (; i < tmp_edge_index; ++i) {
-                if (tmp_edges[i].isValid()) {
-                  return false;
-                }
-              }
-              return true;
-            }(),
-            "Invariant violated while deduplicating incident edges!"
-          );
-
-          TmpEdgeInformation& valid_edge = tmp_edges[valid_edge_index];
-          TmpEdgeInformation& next_edge = tmp_edges[tmp_edge_index];
-          if (next_edge.isValid()) {
-            if (valid_edge.getTarget() == next_edge.getTarget()) {
-              valid_edge.addWeight(next_edge.getWeight());
-              valid_edge.updateID(next_edge.getID());
-              next_edge.invalidate();
-            } else {
-              std::swap(tmp_edges[++valid_edge_index], next_edge);
-            }
-            ++tmp_edge_index;
-          }
-        }
-        const bool is_non_empty = (incident_edges_start < incident_edges_end) && tmp_edges[valid_edge_index].isValid();
-        const HyperedgeID contracted_size = is_non_empty ? (valid_edge_index - incident_edges_start + 1) : 0;
-        node_sizes[coarse_node] = contracted_size;
+        // if the degree is small enough, we directly deduplicate the edges
+        node_sizes[coarse_node] = deduplicate_tmp_edges(tmp_edges.data() + incident_edges_start,
+                                                        tmp_edges.data() + incident_edges_end);
       } else {
         std::lock_guard<std::mutex> lock(high_degree_vertex_mutex);
         high_degree_vertices.push_back(coarse_node);
@@ -251,62 +255,33 @@ namespace mt_kahypar::ds {
       for ( const HypernodeID& coarse_node : high_degree_vertices ) {
         const size_t incident_edges_start = tmp_incident_edges_prefix_sum[coarse_node];
         const size_t incident_edges_end = tmp_incident_edges_prefix_sum[coarse_node + 1];
+        const size_t size_of_range = incident_edges_end - incident_edges_start;
 
         // Insert incident edges into concurrent bucket map
-        tbb::parallel_for(incident_edges_start, incident_edges_end, [&](const size_t pos) {
-          const TmpEdgeInformation& edge = tmp_edges[pos];
-          if (edge.isValid()) {
+        const size_t num_chunks = std::thread::hardware_concurrency();
+        const size_t chunk_size = (size_of_range + num_chunks - 1) / num_chunks;
+        tbb::parallel_for(UL(0), num_chunks, [&](const size_t chunk_id) {
+          const size_t start = incident_edges_start + chunk_id * chunk_size;
+          const size_t end = std::min(incident_edges_start + (chunk_id + 1) * chunk_size, incident_edges_end);
+          // First, we apply a deduplication step to the thread-local range. The reason is that on large irregular
+          // graphs, extremely large clusters (thousands of nodes) can be created during coarsening. In this case,
+          // there can be thousands of edges with the same target, which creates a massive imbalance and thus high
+          // contention in the bucket map if we insert them directly. The local deduplication avoids this problem
+          // by ensuring that each edge appears at most t times.
+          const HyperedgeID local_degree = deduplicate_tmp_edges(tmp_edges.data() + start, tmp_edges.data() + end);
+          for (size_t pos = start; pos < start + local_degree; ++pos) {
+            const TmpEdgeInformation& edge = tmp_edges[pos];
+            ASSERT(edge.isValid());
             incident_edges_map.insert(edge.getTarget(), TmpEdgeInformation(edge));
           }
-        });
+        }, tbb::static_partitioner());
 
-        // Process each bucket in parallel and remove duplicates
+        // Process each bucket in parallel and deduplicate the edges
         std::atomic<size_t> incident_edges_pos(incident_edges_start);
         tbb::parallel_for(UL(0), incident_edges_map.numBuckets(), [&](const size_t bucket) {
           auto& incident_edges_bucket = incident_edges_map.getBucket(bucket);
-          std::sort(incident_edges_bucket.begin(), incident_edges_bucket.end(),
-                    [](const TmpEdgeInformation& e1, const TmpEdgeInformation& e2) {
-                      return e1._target < e2._target;
-                    });
-          size_t valid_edge_index = 0;
-          size_t tmp_edge_index = 1;
-          while (tmp_edge_index < incident_edges_bucket.size() && incident_edges_bucket[tmp_edge_index].isValid()) {
-            HEAVY_COARSENING_ASSERT(
-              [&](){
-                size_t i = 0;
-                for (; i <= valid_edge_index; ++i) {
-                  if (!incident_edges_bucket[i].isValid()) {
-                    return false;
-                  } else if ((i + 1 <= valid_edge_index) &&
-                    incident_edges_bucket[i].getTarget() >= incident_edges_bucket[i + 1].getTarget()) {
-                    return false;
-                  }
-                }
-                for (; i < tmp_edge_index; ++i) {
-                  if (incident_edges_bucket[i].isValid()) {
-                    return false;
-                  }
-                }
-                return true;
-              }(),
-              "Invariant violated while deduplicating incident edges!"
-            );
-
-            TmpEdgeInformation& valid_edge = incident_edges_bucket[valid_edge_index];
-            TmpEdgeInformation& next_edge = incident_edges_bucket[tmp_edge_index];
-            if (next_edge.isValid()) {
-              if (valid_edge.getTarget() == next_edge.getTarget()) {
-                valid_edge.addWeight(next_edge.getWeight());
-                valid_edge.updateID(next_edge.getID());
-                next_edge.invalidate();
-              } else {
-                std::swap(incident_edges_bucket[++valid_edge_index], next_edge);
-              }
-              ++tmp_edge_index;
-            }
-          }
-          const bool is_non_empty = !incident_edges_bucket.empty() && incident_edges_bucket[0].isValid();
-          const HyperedgeID bucket_degree = is_non_empty ? (valid_edge_index + 1) : 0;
+          const HyperedgeID bucket_degree = deduplicate_tmp_edges(incident_edges_bucket.data(),
+                                              incident_edges_bucket.data() + incident_edges_bucket.size());
           const size_t tmp_incident_edges_pos = incident_edges_pos.fetch_add(bucket_degree);
           memcpy(tmp_edges.data() + tmp_incident_edges_pos,
                  incident_edges_bucket.data(), sizeof(TmpEdgeInformation) * bucket_degree);

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -393,12 +393,12 @@ namespace mt_kahypar::ds {
     HEAVY_COARSENING_ASSERT(
       [&](){
         parallel::scalable_vector<bool> covered_ids(hypergraph.initialNumEdges() / 2, false);
-        for (HyperedgeID e : edges()) {
+        for (HyperedgeID e : hypergraph.edges()) {
           HyperedgeID id = hypergraph.uniqueEdgeID(e);
           covered_ids.at(id) = true;
           bool success = false;
-          for (HyperedgeID b_edge : hypergraph.incidentEdges(edgeTarget(e))) {
-            if (edgeTarget(b_edge) == edgeSource(e)) {
+          for (HyperedgeID b_edge : hypergraph.incidentEdges(hypergraph.edgeTarget(e))) {
+            if (hypergraph.edgeTarget(b_edge) == hypergraph.edgeSource(e)) {
               if (hypergraph.uniqueEdgeID(b_edge) != id) {
                 return false;
               }

--- a/mt-kahypar/datastructures/static_graph.cpp
+++ b/mt-kahypar/datastructures/static_graph.cpp
@@ -293,11 +293,7 @@ namespace mt_kahypar::ds {
         });
 
         const size_t contracted_size = incident_edges_pos.load() - incident_edges_start;
-        tbb::parallel_for(incident_edges_pos.load(), incident_edges_end, [&](size_t i) {
-          tmp_edges[i].invalidate();
-        });
         node_sizes[coarse_node] = contracted_size;
-
         resulting_ranges.emplace_back(incident_edges_start, incident_edges_pos.load());
       }
 

--- a/mt-kahypar/datastructures/static_graph.h
+++ b/mt-kahypar/datastructures/static_graph.h
@@ -63,8 +63,7 @@ class StaticGraph {
   // out that this become a major sequential bottleneck in presence of high
   // degree vertices. Therefore, all vertices with temporary degree greater
   // than this threshold are contracted with a special procedure.
-  // TODO: what is a good value?
-  static constexpr HyperedgeID HIGH_DEGREE_CONTRACTION_THRESHOLD = ID(100000);
+  static constexpr HyperedgeID HIGH_DEGREE_CONTRACTION_THRESHOLD = ID(350000);
 
   static_assert(std::is_unsigned<HypernodeID>::value, "Node ID must be unsigned");
   static_assert(std::is_unsigned<HyperedgeID>::value, "Hyperedge ID must be unsigned");

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.cpp
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.cpp
@@ -99,7 +99,9 @@ bool DeterministicMultilevelCoarsener<TypeTraits>::coarseningPassImpl() {
   if (num_nodes_before_pass / num_nodes <= _context.coarsening.minimum_shrink_factor) {
     return false;
   }
+  _timer.start_timer("contraction", "Contraction");
   _uncoarseningData.performMultilevelContraction(std::move(clusters), true /* deterministic */, pass_start_time);
+  _timer.stop_timer("contraction");
   return true;
 }
 

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 
 #include "mt-kahypar/utils/exception.h"
+#include "mt-kahypar/partition/conversion.h"
 
 namespace mt_kahypar {
 
@@ -412,6 +413,10 @@ namespace mt_kahypar {
       if ( lp_algo != LabelPropagationAlgorithm::do_nothing && lp_algo != LabelPropagationAlgorithm::deterministic ) {
         initial_partitioning.refinement.label_propagation.algorithm = LabelPropagationAlgorithm::deterministic;
       }
+    }
+
+    if ( partition.instance_type == InstanceType::UNDEFINED ) {
+      partition.instance_type = to_instance_type(partition.file_format);
     }
 
     // Set correct gain policy type

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -41,7 +41,7 @@ struct PartitioningParameters {
   Objective objective = Objective::UNDEFINED;
   GainPolicy gain_policy = GainPolicy::none;
   FileFormat file_format = FileFormat::hMetis;
-  InstanceType instance_type = InstanceType::hypergraph;
+  InstanceType instance_type = InstanceType::UNDEFINED;
   PresetType preset_type = PresetType::UNDEFINED;
   mt_kahypar_partition_type_t partition_type =  NULLPTR_PARTITION;
   double epsilon = std::numeric_limits<double>::max();

--- a/mt-kahypar/partition/preprocessing/community_detection/parallel_louvain.cpp
+++ b/mt-kahypar/partition/preprocessing/community_detection/parallel_louvain.cpp
@@ -44,11 +44,11 @@ namespace mt_kahypar::community_detection {
     timer.stop_timer("local_moving");
 
     if (communities_changed) {
-      timer.start_timer("contraction", "Contraction");
+      timer.start_timer("contraction_cd", "Contraction");
       // Contract Communities
       Graph<Hypergraph> coarse_graph = fine_graph.contract(communities, context.preprocessing.community_detection.low_memory_contraction);
       ASSERT(coarse_graph.totalVolume() == fine_graph.totalVolume());
-      timer.stop_timer("contraction");
+      timer.stop_timer("contraction_cd");
 
       // Recurse on contracted graph
       ds::Clustering coarse_communities = local_moving_contract_recurse(coarse_graph, mlv, context);

--- a/mt-kahypar/partition/refinement/fm/global_rollback.h
+++ b/mt-kahypar/partition/refinement/fm/global_rollback.h
@@ -58,21 +58,10 @@ public:
     }
   }
 
-
   HyperedgeWeight revertToBestPrefix(PartitionedHypergraph& phg,
                                      FMSharedData& sharedData,
-                                     const vec<HypernodeWeight>& partWeights) {
-    std::vector<HypernodeWeight> maxPartWeights = context.partition.perfect_balance_part_weights;
-    if (max_part_weight_scaling == 0.0) {
-      for (PartitionID i = 0; i < context.partition.k; ++i) {
-        maxPartWeights[i] = std::numeric_limits<HypernodeWeight>::max();
-      }
-    } else {
-      for (PartitionID i = 0; i < context.partition.k; ++i) {
-        maxPartWeights[i] *= ( 1.0 + context.partition.epsilon * max_part_weight_scaling );
-      }
-    }
-
+                                     const vec<HypernodeWeight>& partWeights,
+                                     const std::vector<HypernodeWeight>& maxPartWeights) {
     if (context.refinement.fm.rollback_parallel) {
       return revertToBestPrefixParallel(phg, sharedData, partWeights, maxPartWeights);
     } else {

--- a/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h
@@ -59,10 +59,6 @@ class GainCacheStrategy: public IFMStrategy {
   virtual bool isUnconstrainedRoundImpl(size_t) const final {
     return false;
   }
-
-  virtual bool includesUnconstrainedImpl() const final {
-    return false;
-  }
 };
 
 }

--- a/mt-kahypar/partition/refinement/fm/strategies/i_fm_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/i_fm_strategy.h
@@ -85,10 +85,6 @@ class IFMStrategy {
     return isUnconstrainedRoundImpl(round);
   }
 
-  bool includesUnconstrained() const {
-    return includesUnconstrainedImpl();
-  }
-
   void reportImprovement(size_t round, Gain absolute_improvement, double relative_improvement) {
     reportImprovementImpl(round, absolute_improvement, relative_improvement);
   }
@@ -132,8 +128,6 @@ class IFMStrategy {
                              size_t num_tasks, size_t num_seeds, size_t round) = 0;
 
   virtual bool isUnconstrainedRoundImpl(size_t round) const = 0;
-
-  virtual bool includesUnconstrainedImpl() const = 0;
 
   virtual void reportImprovementImpl(size_t, Gain, double) {
     // most strategies don't use this

--- a/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h
@@ -86,10 +86,6 @@ class UnconstrainedStrategy: public IFMStrategy {
     }
   }
 
-  virtual bool includesUnconstrainedImpl() const final {
-    return true;
-  }
-
   virtual void reportImprovementImpl(size_t round, Gain absolute_improvement, double relative_improvement) final {
     if (round == 0) {
       absolute_improvement_first_round = absolute_improvement;

--- a/tests/partition/refinement/rollback_test.cc
+++ b/tests/partition/refinement/rollback_test.cc
@@ -102,7 +102,8 @@ TEST(RollbackTests, GainRecalculationAndRollsbackCorrectly) {
   performMove({0, 1, 5, 0});
 
   vec<HypernodeWeight> dummy_part_weights(k, 0);
-  grb.revertToBestPrefix(phg, sharedData, dummy_part_weights);
+  std::vector<HypernodeWeight> max_part_weights(k, 6);
+  grb.revertToBestPrefix(phg, sharedData, dummy_part_weights, max_part_weights);
   // revert last two moves
   ASSERT_EQ(phg.partID(4), 0);
   ASSERT_EQ(phg.partID(5), 0);


### PR DESCRIPTION
The main purpose of this PR is to fix a performance bottleneck on large irregular graphs, where the contraction step of the coarsening could become quite slow. This is because the old special case handling for high degree nodes was not very effective (it only applied to nodes with a degree similar to the total number of nodes, however, on large graphs special case handling should occur significantly earlier).

Note: Although this would not be necessary, the new high degree node handling still sorts the resulting neighborhood. This seems to noticeably improve cache locality for later accesses. Specifically, I got some significant slowdowns in initial partitioning and/or refinement when I tested without the sorting. We might want to test whether this is also true for hypergraphs (which was somewhat discussed in #162).

In addition, the PR adds specialized code for graphs to `multilevel_vertex_pair_rater` (though the improvement gained here seems to be rather small) and cleans up some code from unconstrained refinement which is not needed anymore.

This gives an overall ~5% speedup on our large irregular graphs, for some instances even speedups in the order of 10-25% (e.g. twitter, uk-2005, indochina-2004 and multiple of the brain graphs).

Total running time on the large irregular graph set for `k \in {2, 4, 16, 64}`:
![running_time_total](https://github.com/kahypar/mt-kahypar/assets/25832380/2fedceaf-2c5d-4c22-a533-5b880eabb8f2)

Coarsening time:
![running_time_coarsening](https://github.com/kahypar/mt-kahypar/assets/25832380/03cfe64a-e1b1-4ccb-a6ad-cbac9b0229d6)

Quality:
![quality](https://github.com/kahypar/mt-kahypar/assets/25832380/f279a154-4495-49e1-a1d5-f21aaabb5743)

Note: Quality has some notable variance, which is caused by the high variance of some of the irregular graphs (specifically recomp). It should actually be identical, since the implementations have almost no functional difference.