### PR TITLE
MacOS Build

### DIFF
--- a/.github/workflows/master_ci.yml
+++ b/.github/workflows/master_ci.yml
@@ -224,3 +224,33 @@ jobs:
         run: |
           cd build
           ./tests/mt_kahypar_tests
+
+  mt_kahypar_macos_build:
+    name: MacOS Build
+    runs-on: macos-latest
+    env:
+      CI_ACTIVE : 1
+
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v3
+        with:
+         fetch-depth: 1
+
+      - name: Install Dependencies
+        run: |
+          brew install tbb boost hwloc lcov gcovr
+
+      - name: Install Mt-KaHyPar Multilevel Tests
+        run: |
+          git submodule update --init --recursive
+          rm -rf build
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DKAHYPAR_CI_BUILD=ON
+          make -j2 mt_kahypar_tests
+
+      - name: Run Mt-KaHyPar Tests
+        run: |
+          cd build
+          ./tests/mt_kahypar_tests

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ python/tests/os
 python/tests/unittest
 python/tests/*.so
 python/examples/*.so
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROJECT_CONTACT "tobias.heuer@kit.edu")
 set(PROJECT_URL "https://github.com/kittobi1992/mt-kahypar")
 set(PROJECT_DESCRIPTION "Mt-KaHyPar: Multi-Threaded Karlsruhe Hypergraph Partitioning")
 set(PROJECT_VERSION "1.0.0")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # CMake Options
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,12 @@ if(MT_KAHYPAR_VERSION_GIT_REFSPEC)
   configure_file(${PROJECT_SOURCE_DIR}/mt-kahypar/application/git_revision.txt.in ${PROJECT_BINARY_DIR}/mt-kahypar/application/git_head.txt)
 endif(MT_KAHYPAR_VERSION_GIT_REFSPEC)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    set (X86 TRUE)
+else ()
+    set (X86 FALSE)
+endif ()
+
 if(NOT MSVC)
   # Add compile flags
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -Wextra ")
@@ -327,14 +333,17 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Winit-self")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPARANOID ")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
+  if(X86)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
+  endif()
+
   # lld is way faster than ld. If you have it, use it!
   find_program(LLD_BIN lld)
-  if (LLD_BIN)
+  if (LLD_BIN AND X86)
     message(STATUS "Found and will use LLVM linker " ${LLD_BIN})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=lld")
   else()
@@ -348,7 +357,7 @@ if(NOT MSVC)
 
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag(-mcrc32 KAHYPAR_HAS_CRC32)
-  if(KAHYPAR_HAS_CRC32)
+  if(KAHYPAR_HAS_CRC32 AND X86)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcrc32")
   endif()
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Mt-KaHyPar - Multi-Threaded Karlsruhe Graph and Hypergraph Partitioner</h1>
 
-License|Linux & Windows Build|Code Coverage|Zenodo
+License|Linux, MacOS & Windows Build|Code Coverage|Zenodo
 :--:|:--:|:--:|:--:
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)|[![Build Status](https://github.com/kahypar/mt-kahypar/actions/workflows/master_ci.yml/badge.svg)](https://github.com/kahypar/mt-kahypar/actions/workflows/mt_kahypar_ci.yml)|[![codecov](https://codecov.io/gh/kahypar/mt-kahypar/branch/master/graph/badge.svg?token=sNWRRtXZjI)](https://codecov.io/gh/kahypar/mt-kahypar)|[![DOI](https://zenodo.org/badge/205879380.svg)](https://zenodo.org/badge/latestdoi/205879380)
 
@@ -50,7 +50,7 @@ Requirements
 
 The Multi-Threaded Karlsruhe Graph and Hypergraph Partitioning Framework requires:
 
-  - A 64-bit Linux or Windows operating system.
+  - A 64-bit Linux, MacOS, or Windows operating system.
   - A modern, ![C++17](https://img.shields.io/badge/C++-17-blue.svg?style=flat)-ready compiler such as `g++` version 7 or higher, `clang` version 11.0.3 or higher, or `MinGW` compiler on Windows (tested with version 12.1).
  - The [cmake][cmake] build system (>= 3.16).
  - The [Boost - Program Options][Boost.Program_options] library and the boost header files (>= 1.48).
@@ -197,7 +197,7 @@ The C Library Interface
 We provide a simple C-style interface to use Mt-KaHyPar as a library.  The library can be built and installed via
 
 ```sh
-make install.mtkahypar # use sudo (Linux) or run shell as an adminstrator (Windows) to install system-wide
+make install.mtkahypar # use sudo (Linux & MacOS) or run shell as an adminstrator (Windows) to install system-wide
 ```
 
 Note: When installing locally, the build will exit with an error due to missing permissions.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ The following command will install most of the required dependencies on a Ubuntu
 
     sudo apt-get install libtbb-dev libhwloc-dev libboost-program-options-dev
 
+### MacOS
+
+The following command will install most of the required dependencies on a MacOS machine:
+
+    brew install tbb boost hwloc
+
 ### Windows
 
 The following instructions setup the environment used to build Mt-KaHyPar on Windows machines:

--- a/mt-kahypar/datastructures/static_bitset.h
+++ b/mt-kahypar/datastructures/static_bitset.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 #include "mt-kahypar/macros.h"
@@ -102,7 +103,8 @@ class StaticBitset {
       const bool reached_max_id = _current_block_id == _max_block_id;
       // Avoid if statement here
       _current_block_id = (1 - reached_max_id) * ( _current_block_id +
-         utils::lowest_set_bit_64(std::max(b >> ( _current_block_id & MOD_MASK ), UL(1)))) +
+         utils::lowest_set_bit_64(
+           std::max(b >> ( _current_block_id & MOD_MASK ), static_cast<uint64_t>(1)))) +
          reached_max_id * _max_block_id;
     }
 

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -28,11 +28,11 @@
 #include "command_line_options.h"
 
 #include <boost/program_options.hpp>
-#ifdef __linux__
-#include <sys/ioctl.h>
-#elif _WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <process.h>
+#else
+#include <sys/ioctl.h>
 #endif
 
 #include <fstream>

--- a/mt-kahypar/io/hypergraph_io.cpp
+++ b/mt-kahypar/io/hypergraph_io.cpp
@@ -36,7 +36,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#ifdef __linux__
+#if defined(__linux__) or defined(__APPLE__)
 #include <sys/mman.h>
 #include <unistd.h>
 #elif _WIN32
@@ -55,7 +55,7 @@
 
 namespace mt_kahypar::io {
 
-  #ifdef __linux__
+  #if defined(__linux__) or defined(__APPLE__)
   struct FileHandle {
     int fd;
     char* mapped_file;
@@ -130,7 +130,7 @@ namespace mt_kahypar::io {
       if ( handle.mapped_file == NULL ) {
         throw SystemException("Failed to map file to main memory:" + filename);
       }
-    #elif __linux__
+    #elif defined(__linux__) or defined(__APPLE__)
       handle.fd = open(filename.c_str(), O_RDONLY);
       if ( handle.fd < -1 ) {
         throw InvalidInputException("Could not open: " + filename);
@@ -148,7 +148,7 @@ namespace mt_kahypar::io {
   void munmap_file(FileHandle& handle) {
     #ifdef _WIN32
     UnmapViewOfFile(handle.mapped_file);
-    #elif __linux__
+    #elif defined(__linux__) or defined(__APPLE__)
     munmap(handle.mapped_file, handle.length);
     #endif
     handle.closeHandle();

--- a/mt-kahypar/macros.h
+++ b/mt-kahypar/macros.h
@@ -12,8 +12,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ *all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -28,12 +28,13 @@
 
 #include <type_traits>
 
-#if defined(MT_KAHYPAR_LIBRARY_MODE) || !defined(KAHYPAR_ENABLE_THREAD_PINNING)
+#if defined(MT_KAHYPAR_LIBRARY_MODE) ||                                        \
+    !defined(KAHYPAR_ENABLE_THREAD_PINNING) || defined(__APPLE__)
 #include "tbb/task_arena.h"
-// If we use the C or Python interface or thread pinning is disabled, the cpu ID to
-// which the current thread is assigned to is not unique. We therefore use the slot index
-// of the current task arena as unique thread ID. Note that the ID can be negative if
-// the task scheduler is not initialized.
+// If we use the C or Python interface or thread pinning is disabled, the cpu ID
+// to which the current thread is assigned to is not unique. We therefore use
+// the slot index of the current task arena as unique thread ID. Note that the
+// ID can be negative if the task scheduler is not initialized.
 #define THREAD_ID std::max(0, tbb::this_task_arena::current_thread_index())
 #else
 #ifdef __linux__
@@ -47,17 +48,14 @@
 
 #include "kahypar-resources/macros.h"
 
-#define SPECIALIZATION(EXPR, TYPE)          \
-  template<bool T = EXPR>                   \
-  std::enable_if_t<T, TYPE>
+#define SPECIALIZATION(EXPR, TYPE)                                             \
+  template <bool T = EXPR> std::enable_if_t<T, TYPE>
 
-#define TRUE_SPECIALIZATION(EXPR, TYPE)     \
-  template<bool T = EXPR>                   \
-  std::enable_if_t<T, TYPE>
+#define TRUE_SPECIALIZATION(EXPR, TYPE)                                        \
+  template <bool T = EXPR> std::enable_if_t<T, TYPE>
 
-#define FALSE_SPECIALIZATION(EXPR, TYPE)    \
-  template<bool T = EXPR>                   \
-  std::enable_if_t<!T, TYPE>
+#define FALSE_SPECIALIZATION(EXPR, TYPE)                                       \
+  template <bool T = EXPR> std::enable_if_t<!T, TYPE>
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(NDEBUG)
 #define MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE __attribute__ ((always_inline)) inline
@@ -65,59 +63,65 @@
 #define MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
 #endif
 
-#define HEAVY_ASSERT0(cond) \
-  !(enable_heavy_assert) ? (void)0 : [&]() { ASSERT(cond); } ()
-#define HEAVY_ASSERT1(cond, msg) \
-  !(enable_heavy_assert) ? (void)0 : [&]() { ASSERT(cond, msg); } ()
+#define HEAVY_ASSERT0(cond)                                                    \
+  !(enable_heavy_assert) ? (void)0 : [&]() { ASSERT(cond); }()
+#define HEAVY_ASSERT1(cond, msg)                                               \
+  !(enable_heavy_assert) ? (void)0 : [&]() { ASSERT(cond, msg); }()
 
 #ifdef KAHYPAR_ENABLE_HEAVY_PREPROCESSING_ASSERTIONS
-  #define HEAVY_PREPROCESSING_ASSERT_1(cond) ASSERT(cond)
-  #define HEAVY_PREPROCESSING_ASSERT_2(cond, msg) ASSERT(cond, msg)
+#define HEAVY_PREPROCESSING_ASSERT_1(cond) ASSERT(cond)
+#define HEAVY_PREPROCESSING_ASSERT_2(cond, msg) ASSERT(cond, msg)
 #else
-  #define HEAVY_PREPROCESSING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
-  #define HEAVY_PREPROCESSING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
+#define HEAVY_PREPROCESSING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
+#define HEAVY_PREPROCESSING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
 #endif
 
 #ifdef KAHYPAR_ENABLE_HEAVY_COARSENING_ASSERTIONS
-  #define HEAVY_COARSENING_ASSERT_1(cond) ASSERT(cond)
-  #define HEAVY_COARSENING_ASSERT_2(cond, msg) ASSERT(cond, msg)
+#define HEAVY_COARSENING_ASSERT_1(cond) ASSERT(cond)
+#define HEAVY_COARSENING_ASSERT_2(cond, msg) ASSERT(cond, msg)
 #else
-  #define HEAVY_COARSENING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
-  #define HEAVY_COARSENING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
+#define HEAVY_COARSENING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
+#define HEAVY_COARSENING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
 #endif
 
 #ifdef KAHYPAR_ENABLE_HEAVY_INITIAL_PARTITIONING_ASSERTIONS
-  #define HEAVY_INITIAL_PARTITIONING_ASSERT_1(cond) ASSERT(cond)
-  #define HEAVY_INITIAL_PARTITIONING_ASSERT_2(cond, msg) ASSERT(cond, msg)
+#define HEAVY_INITIAL_PARTITIONING_ASSERT_1(cond) ASSERT(cond)
+#define HEAVY_INITIAL_PARTITIONING_ASSERT_2(cond, msg) ASSERT(cond, msg)
 #else
-  #define HEAVY_INITIAL_PARTITIONING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
-  #define HEAVY_INITIAL_PARTITIONING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
+#define HEAVY_INITIAL_PARTITIONING_ASSERT_1(cond) HEAVY_ASSERT0(cond)
+#define HEAVY_INITIAL_PARTITIONING_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
 #endif
 
 #ifdef KAHYPAR_ENABLE_HEAVY_REFINEMENT_ASSERTIONS
-  #define HEAVY_REFINEMENT_ASSERT_1(cond) ASSERT(cond)
-  #define HEAVY_REFINEMENT_ASSERT_2(cond, msg) ASSERT(cond, msg)
+#define HEAVY_REFINEMENT_ASSERT_1(cond) ASSERT(cond)
+#define HEAVY_REFINEMENT_ASSERT_2(cond, msg) ASSERT(cond, msg)
 #else
-  #define HEAVY_REFINEMENT_ASSERT_1(cond) HEAVY_ASSERT0(cond)
-  #define HEAVY_REFINEMENT_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
+#define HEAVY_REFINEMENT_ASSERT_1(cond) HEAVY_ASSERT0(cond)
+#define HEAVY_REFINEMENT_ASSERT_2(cond, msg) HEAVY_ASSERT1(cond, msg)
 #endif
 
-#define HEAVY_ASSERT_(TYPE, N) HEAVY_ ## TYPE ## _ASSERT_ ## N
+#define HEAVY_ASSERT_(TYPE, N) HEAVY_##TYPE##_ASSERT_##N
 #define HEAVY_ASSERT_EVAL(TYPE, N) HEAVY_ASSERT_(TYPE, N)
 
 // Heavy assertions are assertions which increase the complexity of the scope
-// which they are executed in by an polynomial factor. In debug mode you are often only
-// interested in certain phase of the multilevel paradigm. However, when enabling all assertions
-// it can take a while to reach the point which you are really interested in, because heavy assertions
-// radicaly downgrade the performance of the application. Therefore such assertions should be packed
-// in a heavy assertion macro. Heavy assertions can be enabled via cmake flag for specific phase or for
-// specific scope by adding
-// static constexpr bool enable_heavy_assert = false;
-// to the corresponding scope.
-#define HEAVY_PREPROCESSING_ASSERT(...) EXPAND(HEAVY_ASSERT_EVAL(PREPROCESSING, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
-#define HEAVY_COARSENING_ASSERT(...) EXPAND(HEAVY_ASSERT_EVAL(COARSENING, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
-#define HEAVY_INITIAL_PARTITIONING_ASSERT(...) EXPAND(HEAVY_ASSERT_EVAL(INITIAL_PARTITIONING, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
-#define HEAVY_REFINEMENT_ASSERT(...) EXPAND(HEAVY_ASSERT_EVAL(REFINEMENT, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
+// which they are executed in by an polynomial factor. In debug mode you are
+// often only interested in certain phase of the multilevel paradigm. However,
+// when enabling all assertions it can take a while to reach the point which you
+// are really interested in, because heavy assertions radicaly downgrade the
+// performance of the application. Therefore such assertions should be packed in
+// a heavy assertion macro. Heavy assertions can be enabled via cmake flag for
+// specific phase or for specific scope by adding static constexpr bool
+// enable_heavy_assert = false; to the corresponding scope.
+#define HEAVY_PREPROCESSING_ASSERT(...)                                        \
+  EXPAND(HEAVY_ASSERT_EVAL(PREPROCESSING,                                      \
+                           EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
+#define HEAVY_COARSENING_ASSERT(...)                                           \
+  EXPAND(HEAVY_ASSERT_EVAL(COARSENING, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
+#define HEAVY_INITIAL_PARTITIONING_ASSERT(...)                                 \
+  EXPAND(HEAVY_ASSERT_EVAL(INITIAL_PARTITIONING,                               \
+                           EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
+#define HEAVY_REFINEMENT_ASSERT(...)                                           \
+  EXPAND(HEAVY_ASSERT_EVAL(REFINEMENT, EXPAND(NARG(__VA_ARGS__)))(__VA_ARGS__))
 
 // In windows unisgned long != size_t
 #define UL(X) (size_t) X
@@ -140,20 +144,24 @@
 #undef WARNING
 #endif
 #define WARNING(msg) LOG << YELLOW << "[WARNING]" << END << msg
-#define ERR(msg) LOG << RED << "[ERROR]" << END << msg; std::exit(-1)
+#define ERR(msg)                                                               \
+  LOG << RED << "[ERROR]" << END << msg;                                       \
+  std::exit(-1)
 
 #ifdef MT_KAHYPAR_LIBRARY_MODE
-#define ALGO_SWITCH(warning_msg, error_msg, context_variable, alternative_value) \
+#define ALGO_SWITCH(warning_msg, error_msg, context_variable,                  \
+                    alternative_value)                                         \
   ERR(error_msg);
 #else
-#define ALGO_SWITCH(warning_msg, error_msg, context_variable, alternative_value) \
-  WARNING(warning_msg);                                                          \
-  char answer = 'N';                                                             \
-  std::cin >> answer;                                                            \
-  answer = std::toupper(answer);                                                 \
-  if (answer == 'Y') {                                                           \
-    context_variable = alternative_value;                                        \
-  } else {                                                                       \
+#define ALGO_SWITCH(warning_msg, error_msg, context_variable,                  \
+                    alternative_value)                                         \
+  WARNING(warning_msg);                                                        \
+  char answer = 'N';                                                           \
+  std::cin >> answer;                                                          \
+  answer = std::toupper(answer);                                               \
+  if (answer == 'Y') {                                                         \
+    context_variable = alternative_value;                                      \
+  } else {                                                                     \
     ERR(error_msg);                                                            \
   }
 #endif

--- a/mt-kahypar/parallel/memory_pool.h
+++ b/mt-kahypar/parallel/memory_pool.h
@@ -34,7 +34,7 @@
 #include <atomic>
 #include <vector>
 #include <algorithm>
-#ifdef __linux__
+#if defined(__linux__) or defined(__APPLE__)
 #include <unistd.h>
 #elif _WIN32
 #include <sysinfoapi.h>
@@ -592,7 +592,7 @@ class MemoryPoolT {
     _use_round_robin_assignment(true),
     _use_minimum_allocation_size(true),
     _use_unused_memory_chunks(true) {
-    #ifdef __linux__
+    #if defined(__linux__) or defined(__APPLE__)
       _page_size = sysconf(_SC_PAGE_SIZE);
     #elif _WIN32
       SYSTEM_INFO sysInfo;

--- a/mt-kahypar/parallel/stl/zero_allocator.h
+++ b/mt-kahypar/parallel/stl/zero_allocator.h
@@ -40,7 +40,7 @@ class zero_allocator : public tbb::tbb_allocator<T> {
 
   zero_allocator() = default;
   template <typename U>
-  explicit zero_allocator(const zero_allocator<U>&) noexcept {}
+  explicit zero_allocator(const U&) noexcept {}
 
   T* allocate(std::size_t n) {
     T* ptr = tbb::tbb_allocator<T>::allocate(n);

--- a/mt-kahypar/parallel/thread_pinning_observer.h
+++ b/mt-kahypar/parallel/thread_pinning_observer.h
@@ -81,7 +81,7 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
       _cpus.push_back(HwTopology::instance().get_backup_cpu(_numa_node, _cpus[0]));
     }
 
-    #ifdef KAHYPAR_ENABLE_THREAD_PINNING
+    #if defined(KAHYPAR_ENABLE_THREAD_PINNING) and not defined(__APPLE__)
     #ifndef MT_KAHYPAR_LIBRARY_MODE
     observe(true); // Enable thread pinning
     #endif
@@ -172,7 +172,8 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
  private:
 
   void pin_thread_to_cpu(const int cpu_id) {
-    #ifdef __linux__
+    #ifndef __APPLE__
+    #if __linux__
     const size_t size = CPU_ALLOC_SIZE(_num_cpus);
     cpu_set_t mask;
     CPU_ZERO(&mask);
@@ -192,6 +193,7 @@ class ThreadPinningObserver : public tbb::task_scheduler_observer {
     ASSERT(THREAD_ID == cpu_id);
     DBG << "Thread with PID" << std::this_thread::get_id()
         << "successfully pinned to CPU" << cpu_id;
+    #endif
   }
 
   std::string pin_thread_message(const int cpu_id) {

--- a/mt-kahypar/partition/mapping/target_graph.cpp
+++ b/mt-kahypar/partition/mapping/target_graph.cpp
@@ -73,7 +73,7 @@ HyperedgeWeight TargetGraph::distance(const ds::StaticBitset& connectivity_set) 
       handle.insert(idx, mst_weight);
       return mst_weight;
     }
-    #elif _WIN32
+    #elif defined(_WIN32) or defined(__APPLE__)
     auto res = _cache.find(idx);
     if ( likely ( res != _cache.end() ) ) {
       if constexpr ( TRACK_STATS ) ++_stats.cache_hits;

--- a/mt-kahypar/partition/mapping/target_graph.h
+++ b/mt-kahypar/partition/mapping/target_graph.h
@@ -39,7 +39,7 @@
 #include "data-structures/hash_table_mods.hpp"
 #include "data-structures/table_config.hpp"
 #pragma GCC diagnostic pop
-#elif _WIN32
+#elif defined(_WIN32) or defined(__APPLE__)
 #include "tbb/concurrent_unordered_map.h"
 #endif
 
@@ -65,7 +65,7 @@ class TargetGraph {
   using ConcurrentHashTable = typename growt::table_config<
     size_t, size_t, hasher_type, allocator_type, hmod::growable, hmod::sync>::table_type;
   using HashTableHandle = typename ConcurrentHashTable::handle_type;
-  #elif _WIN32
+  #elif defined(_WIN32) or defined(__APPLE__)
   using ConcurrentHashTable = tbb::concurrent_unordered_map<size_t, size_t>;
   #endif
 

--- a/mt-kahypar/partition/refinement/fm/fm_commons.h
+++ b/mt-kahypar/partition/refinement/fm/fm_commons.h
@@ -155,12 +155,15 @@ class UnconstrainedFMData {
   using BucketID = uint32_t;
   using AtomicBucketID = parallel::IntegralAtomicWrapper<BucketID>;
 
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wmismatched-tags"
   template<typename GraphAndGainTypes>
   struct InitializationHelper {
     static void initialize(UnconstrainedFMData& data, const Context& context,
                            const typename GraphAndGainTypes::PartitionedHypergraph& phg,
                            const typename GraphAndGainTypes::GainCache& gain_cache);
   };
+  #pragma GCC diagnostic pop
 
   static constexpr BucketID NUM_BUCKETS = 16;
   static constexpr double BUCKET_FACTOR = 1.5;

--- a/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/local_gain_cache_strategy.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "mt-kahypar/partition/refinement/fm/fm_commons.h"
 
 

--- a/mt-kahypar/partition/refinement/fm/strategies/local_unconstrained_strategy.h
+++ b/mt-kahypar/partition/refinement/fm/strategies/local_unconstrained_strategy.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "mt-kahypar/datastructures/sparse_map.h"
 #include "mt-kahypar/partition/refinement/fm/fm_commons.h"
 

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -26,6 +26,7 @@
 
 #include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
 
+#include <array>
 #include <optional>
 
 #include "mt-kahypar/partition/refinement/gains/gain_definitions.h"

--- a/mt-kahypar/utils/progress_bar.h
+++ b/mt-kahypar/utils/progress_bar.h
@@ -32,7 +32,7 @@
 #include <atomic>
 #include <sstream>
 #include <chrono>
-#ifdef __linux__
+#if defined(__linux__) or defined(__APPLE__)
 #include <sys/ioctl.h>
 #elif _WIN32
 #include <windows.h>
@@ -60,7 +60,7 @@ class ProgressBar {
     _objective(objective),
     _progress_bar_size(0),
     _enable(enable) {
-    #ifdef __linux__
+    #if defined(__linux__) or defined(__APPLE__)
     struct winsize w;
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
     _progress_bar_size = w.ws_col / 2;

--- a/mt-kahypar/utils/reproducible_random.h
+++ b/mt-kahypar/utils/reproducible_random.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <array>
 #include <random>
 #include <tbb/tick_count.h>
 


### PR DESCRIPTION
This PR adds a MacOS build. It comes with a few restrictions. `sched_getcpu` is not available. We therefore use `tbb::this_task_arena::current_thread_index()` as cpu ID. Moreover, thread pinning is disabled. Submodule `growt` does also not compile on MacOS. We therefore switch to `tbb::concurrent_unordered_map` to cache minimal Steiner trees (same as for Windows). 