### PR TITLE
use mini_boost target

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,9 @@ add_library(mtkahypar SHARED libmtkahypar.cpp)
 
 target_link_libraries(mtkahypar TBB::tbb TBB::tbbmalloc_proxy)
 
-if(NOT MT_KAHYPAR_DISABLE_BOOST)
+if(KAHYPAR_DOWNLOAD_BOOST)
+    target_link_libraries(mtkahypar mini_boost)
+elseif(NOT MT_KAHYPAR_DISABLE_BOOST)
     target_link_libraries(mtkahypar Boost::program_options)
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,7 +12,9 @@ pybind11_add_module(mtkahypar_python module.cpp)
 
 target_link_libraries(mtkahypar_python PRIVATE TBB::tbb TBB::tbbmalloc_proxy)
 
-if(NOT MT_KAHYPAR_DISABLE_BOOST)
+if(KAHYPAR_DOWNLOAD_BOOST)
+    target_link_libraries(mtkahypar_python PRIVATE mini_boost)
+elseif(NOT MT_KAHYPAR_DISABLE_BOOST)
     target_link_libraries(mtkahypar_python PRIVATE Boost::program_options)
 endif()
 


### PR DESCRIPTION
When you use the `KAHYPAR_DOWNLOAD_BOOST` cmake option without an existing boost installation (what seems to be the intended use case to me), cmake fails afterwards because `Boost::program_options` is not found.

With these changes, this is fixed. As a side effect, the download option now precedes both existing installations and the disable option introduced in  #170.