### PR TITLE
Fix(InputParser): Comments at the end

### DIFF
--- a/mt-kahypar/io/hypergraph_io.cpp
+++ b/mt-kahypar/io/hypergraph_io.cpp
@@ -438,6 +438,13 @@ namespace mt_kahypar::io {
 
     // Read Hypernode Weights
     readHypernodeWeights(handle.mapped_file, pos, handle.length, num_hypernodes, type, hypernodes_weight);
+    
+    //Check the end of the file
+    while ( handle.mapped_file[pos] == '%' ) {
+        goto_next_line(handle.mapped_file, pos, handle.length);
+        //if comment is at the end, should use <= rather than <
+        ASSERT(pos <= handle.length);
+    }
     ASSERT(pos == handle.length);
 
     munmap_file(handle);

--- a/mt-kahypar/io/hypergraph_io.cpp
+++ b/mt-kahypar/io/hypergraph_io.cpp
@@ -442,8 +442,6 @@ namespace mt_kahypar::io {
     //Check the end of the file
     while ( handle.mapped_file[pos] == '%' ) {
         goto_next_line(handle.mapped_file, pos, handle.length);
-        //if comment is at the end, should use <= rather than <
-        ASSERT(pos <= handle.length);
     }
     ASSERT(pos == handle.length);
 


### PR DESCRIPTION
This is related to #204 , I add a check at the end of `readHypergraphFile`, which will check and skip the comments and help
https://github.com/kahypar/mt-kahypar/blob/261d0079cae8efc3f4e89b166e62f0189e4926e1/mt-kahypar/io/hypergraph_io.cpp#L441
pass when there's comment at the end and no space line between data and comments, like this:
```
...
3154 3156
3155 3156
3156 481
%This file was written by ABC on Thu Feb 27 16:25:43 2025
%For information about hMetis format, refer to https://karypis.github.io/glaros/files/sw/hmetis/manual.pdf
```