### PR TITLE
Unconstrained Refinement for n-level Config

### DIFF
--- a/config/old_configs/highest_quality_preset.ini
+++ b/config/old_configs/highest_quality_preset.ini
@@ -73,16 +73,11 @@ r-lp-he-size-activation-threshold=100
 # main -> refinement -> fm
 r-fm-type=kway_fm
 r-fm-multitry-rounds=10
-r-fm-unconstrained-rounds=8
 r-fm-rollback-parallel=false
-r-fm-rollback-balance-violation-factor=1.0
-r-fm-threshold-border-node-inclusion=0.7
-r-fm-imbalance-penalty-min=0.2
-r-fm-imbalance-penalty-max=1.0
+r-fm-rollback-balance-violation-factor=1.25
 r-fm-seed-nodes=5
 r-fm-release-nodes=true
 r-fm-min-improvement=-1.0
-r-fm-unconstrained-min-improvement=0.001
 r-fm-obey-minimal-parallelism=false
 r-fm-time-limit-factor=0.25
 # applies only to global fm
@@ -90,11 +85,10 @@ r-fm-iter-moves-on-recalc=false
 # main -> refinement -> global
 r-use-global-fm=true
 r-global-refine-until-no-improvement=true
-r-global-fm-type=unconstrained_fm
+r-global-fm-type=kway_fm
 r-global-fm-seed-nodes=5
 r-global-fm-obey-minimal-parallelism=true
-r-global-lp-type=label_propagation
-r-global-lp-unconstrained=true
+r-global-lp-type=do_nothing
 # main -> refinement -> flows
 r-flow-algo=flow_cutter
 r-flow-scaling=16

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -486,25 +486,56 @@ namespace mt_kahypar {
              "If the FM refiner exceeds 2 * time_limit, than the current multitry FM run is aborted and the algorithm proceeds to"
              "the next finer level.")
             ((initial_partitioning ? "i-r-use-global-fm" : "r-use-global-fm"),
-             po::value<bool>((!initial_partitioning ? &context.refinement.global_fm.use_global_fm :
-                              &context.initial_partitioning.refinement.global_fm.use_global_fm))->value_name(
+             po::value<bool>((!initial_partitioning ? &context.refinement.global.use_global_refinement :
+                              &context.initial_partitioning.refinement.global.use_global_refinement))->value_name(
                      "<bool>")->default_value(false),
              "If true, than we execute a globalized FM local search interleaved with the localized searches."
              "Note, gobalized FM local searches are performed in multilevel style (not after each batch uncontraction)")
             ((initial_partitioning ? "i-r-global-refine-until-no-improvement" : "r-global-refine-until-no-improvement"),
-             po::value<bool>((!initial_partitioning ? &context.refinement.global_fm.refine_until_no_improvement :
-                              &context.initial_partitioning.refinement.global_fm.refine_until_no_improvement))->value_name(
+             po::value<bool>((!initial_partitioning ? &context.refinement.global.refine_until_no_improvement :
+                              &context.initial_partitioning.refinement.global.refine_until_no_improvement))->value_name(
                      "<bool>")->default_value(false),
              "Executes a globalized FM local search as long as it finds an improvement on the current partition.")
+            ((initial_partitioning ? "i-r-global-fm-type" : "r-global-fm-type"),
+             po::value<std::string>()->value_name("<string>")->notifier(
+                     [&, initial_partitioning](const std::string& type) {
+                       if (initial_partitioning) {
+                         context.initial_partitioning.refinement.global.fm_algorithm = fmAlgorithmFromString(type);
+                       } else {
+                         context.refinement.global.fm_algorithm = fmAlgorithmFromString(type);
+                       }
+                     })->default_value("kway_fm"),
+             "FM Algorithm for the globalized FM local search:\n"
+             "- kway_fm\n"
+             "- unconstrained_fm\n"
+             "- do_nothing")
             ((initial_partitioning ? "i-r-global-fm-seed-nodes" : "r-global-fm-seed-nodes"),
-             po::value<size_t>((initial_partitioning ? &context.initial_partitioning.refinement.global_fm.num_seed_nodes :
-                                &context.refinement.global_fm.num_seed_nodes))->value_name("<size_t>")->default_value(25),
+             po::value<size_t>((initial_partitioning ? &context.initial_partitioning.refinement.global.fm_num_seed_nodes :
+                                &context.refinement.global.fm_num_seed_nodes))->value_name("<size_t>")->default_value(25),
              "Number of nodes to start the 'highly localized FM' with during the globalized FM local search.")
             ((initial_partitioning ? "i-r-global-fm-obey-minimal-parallelism" : "r-global-fm-obey-minimal-parallelism"),
              po::value<bool>(
-                     (initial_partitioning ? &context.initial_partitioning.refinement.global_fm.obey_minimal_parallelism :
-                      &context.refinement.global_fm.obey_minimal_parallelism))->value_name("<bool>")->default_value(true),
+                     (initial_partitioning ? &context.initial_partitioning.refinement.global.fm_obey_minimal_parallelism :
+                      &context.refinement.global.fm_obey_minimal_parallelism))->value_name("<bool>")->default_value(true),
              "If true, then the globalized FM local search stops if more than a certain number of threads are finished.")
+             ((initial_partitioning ? "i-r-global-lp-type" : "r-global-lp-type"),
+              po::value<std::string>()->value_name("<string>")->notifier(
+                      [&, initial_partitioning](const std::string& type) {
+                        if (initial_partitioning) {
+                          context.initial_partitioning.refinement.global.lp_algorithm = labelPropagationAlgorithmFromString(type);
+                        } else {
+                          context.refinement.global.lp_algorithm = labelPropagationAlgorithmFromString(type);
+                        }
+                      })->default_value("label_propagation"),
+              "Label Propagation Algorithm for the globalized label propagation refinement:\n"
+              "- label_propagation\n"
+              "- deterministic\n"
+              "- do_nothing")
+            ((initial_partitioning ? "i-r-global-lp-unconstrained" : "r-global-lp-unconstrained"),
+             po::value<bool>(
+                     (initial_partitioning ? &context.initial_partitioning.refinement.global.lp_unconstrained :
+                      &context.refinement.global.lp_unconstrained))->value_name("<bool>")->default_value(false),
+             "If true, then the unconstrained LP is used for the globalized LP.")
             ((initial_partitioning ? "i-r-rebalancer-type" : "r-rebalancer-type"),
              po::value<std::string>()->value_name("<string>")->notifier(
                      [&, initial_partitioning](const std::string& type) {

--- a/mt-kahypar/io/presets.cpp
+++ b/mt-kahypar/io/presets.cpp
@@ -322,11 +322,16 @@ std::vector<option> load_highest_quality_preset() {
     // main -> refinement -> fm
     create_option("r-fm-type", "kway_fm"),
     create_option("r-fm-multitry-rounds", "10"),
+    create_option("r-fm-unconstrained-rounds", "8"),
     create_option("r-fm-rollback-parallel", "false"),
-    create_option("r-fm-rollback-balance-violation-factor", "1.25"),
+    create_option("r-fm-rollback-balance-violation-factor", "1.0"),
+    create_option("r-fm-threshold-border-node-inclusion", "0.7"),
+    create_option("r-fm-imbalance-penalty-min", "0.2"),
+    create_option("r-fm-imbalance-penalty-max", "1.0"),
     create_option("r-fm-seed-nodes", "5"),
     create_option("r-fm-release-nodes", "true"),
     create_option("r-fm-min-improvement", "-1.0"),
+    create_option("r-fm-unconstrained-min-improvement", "0.001"),
     create_option("r-fm-obey-minimal-parallelism", "false"),
     create_option("r-fm-time-limit-factor", "0.25"),
     // applies only to global fm
@@ -334,8 +339,11 @@ std::vector<option> load_highest_quality_preset() {
     // main -> refinement -> global
     create_option("r-use-global-fm", "true"),
     create_option("r-global-refine-until-no-improvement", "true"),
+    create_option("r-global-fm-type", "unconstrained_fm"),
     create_option("r-global-fm-seed-nodes", "5"),
     create_option("r-global-fm-obey-minimal-parallelism", "true"),
+    create_option("r-global-lp-type", "label_propagation"),
+    create_option("r-global-lp-unconstrained", "true"),
     // main -> refinement -> flows
     create_option("r-flow-algo", "flow_cutter"),
     create_option("r-flow-scaling", "16"),

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -139,10 +139,13 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " fm_imbalance_penalty_max=" << context.refinement.fm.imbalance_penalty_max
         << " fm_activate_unconstrained_dynamically=" << std::boolalpha << context.refinement.fm.activate_unconstrained_dynamically
         << " fm_penalty_for_activation_test=" << context.refinement.fm.penalty_for_activation_test
-        << " global_fm_use_global_fm=" << std::boolalpha << context.refinement.global_fm.use_global_fm
-        << " global_fm_refine_until_no_improvement=" << std::boolalpha << context.refinement.global_fm.refine_until_no_improvement
-        << " global_fm_num_seed_nodes=" << context.refinement.global_fm.num_seed_nodes
-        << " global_fm_obey_minimal_parallelism=" << std::boolalpha << context.refinement.global_fm.obey_minimal_parallelism;
+        << " global_refine_use_global_refinement=" << std::boolalpha << context.refinement.global.use_global_refinement
+        << " global_refine_refine_until_no_improvement=" << std::boolalpha << context.refinement.global.refine_until_no_improvement
+        << " global_refine_fm_algorithm=" << context.refinement.global.fm_algorithm
+        << " global_refine_fm_num_seed_nodes=" << context.refinement.global.fm_num_seed_nodes
+        << " global_refine_fm_obey_minimal_parallelism=" << std::boolalpha << context.refinement.global.fm_obey_minimal_parallelism
+        << " global_refine_lp_algorithm=" << context.refinement.global.lp_algorithm
+        << " global_refine_lp_unconstrained=" << std::boolalpha << context.refinement.global.lp_unconstrained;
     oss << " flow_algorithm=" << context.refinement.flows.algorithm
         << " flow_parallel_searches_multiplier=" << context.refinement.flows.parallel_searches_multiplier
         << " flow_num_parallel_searches=" << context.refinement.flows.num_parallel_searches

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
@@ -306,23 +306,24 @@ namespace mt_kahypar {
           << ", imbalance = " << _current_metrics.imbalance;
     }
 
+    _timer.start_timer("local_refinement", "Local Refinement", false, _force_measure_timings);
     bool improvement_found = true;
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
     while( improvement_found ) {
       improvement_found = false;
 
       if ( _label_propagation && _context.refinement.label_propagation.algorithm != LabelPropagationAlgorithm::do_nothing ) {
-        _timer.start_timer("label_propagation", "Label Propagation", false, _force_measure_timings);
+        _timer.start_timer("local_label_propagation", "Label Propagation", false, _force_measure_timings);
         improvement_found |= _label_propagation->refine(phg,
           refinement_nodes, _current_metrics, std::numeric_limits<double>::max());
-        _timer.stop_timer("label_propagation", _force_measure_timings);
+        _timer.stop_timer("local_label_propagation", _force_measure_timings);
       }
 
       if ( _fm && _context.refinement.fm.algorithm != FMAlgorithm::do_nothing ) {
-        _timer.start_timer("fm", "FM", false, _force_measure_timings);
+        _timer.start_timer("local_fm", "FM", false, _force_measure_timings);
         improvement_found |= _fm->refine(phg,
           refinement_nodes, _current_metrics, std::numeric_limits<double>::max());
-        _timer.stop_timer("fm", _force_measure_timings);
+        _timer.stop_timer("local_fm", _force_measure_timings);
       }
 
       if ( _context.type == ContextType::main ) {
@@ -335,6 +336,7 @@ namespace mt_kahypar {
         break;
       }
     }
+    _timer.stop_timer("local_refinement", _force_measure_timings);
 
     if ( _context.type == ContextType::main) {
       DBG << "--------------------------------------------------\n";

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
@@ -93,6 +93,8 @@ class NLevelUncoarsener : public IUncoarsener<TypeTraits>,
     Base(hypergraph, context, uncoarseningData),
     _target_graph(target_graph),
     _hierarchy(),
+    _global_label_propagation(nullptr),
+    _global_fm(nullptr),
     _tmp_refinement_nodes(),
     _border_vertices_of_batch(hypergraph.initialNumNodes()),
     _stats(context),
@@ -136,6 +138,9 @@ class NLevelUncoarsener : public IUncoarsener<TypeTraits>,
   void globalRefine(PartitionedHypergraph& partitioned_hypergraph,
                     const double time_limit);
 
+  template<typename Func>
+  void runInGlobalRefinementContext(Func func);
+
   using Base::_hg;
   using Base::_context;
   using Base::_uncoarseningData;
@@ -155,6 +160,10 @@ class NLevelUncoarsener : public IUncoarsener<TypeTraits>,
   // ! a new version (simply increment a counter) of the hypergraph. Once a batch vector is
   // ! completly processed single-pin and parallel nets have to be restored.
   VersionedBatchVector _hierarchy;
+
+  // ! If we use different algorithms for local and global refinement, we need two LP/FM refiner instances
+  std::unique_ptr<IRefiner> _global_label_propagation;
+  std::unique_ptr<IRefiner> _global_fm;
 
   ds::StreamingVector<HypernodeID> _tmp_refinement_nodes;
   kahypar::ds::FastResetFlagArray<> _border_vertices_of_batch;

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -163,12 +163,15 @@ namespace mt_kahypar {
     return out;
   }
 
-  std::ostream& operator<<(std::ostream& out, const NLevelGlobalFMParameters& params) {
-    if ( params.use_global_fm ) {
-      out << "  Boundary FM Parameters: \n";
+  std::ostream& operator<<(std::ostream& out, const NLevelGlobalRefinementParameters& params) {
+    if ( params.use_global_refinement ) {
+      out << "  Global Refinement Parameters:" << std::endl;
       out << "    Refine Until No Improvement:      " << std::boolalpha << params.refine_until_no_improvement << std::endl;
-      out << "    Num Seed Nodes:                   " << params.num_seed_nodes << std::endl;
-      out << "    Obey Minimal Parallelism:         " << std::boolalpha << params.obey_minimal_parallelism << std::endl;
+      out << "    FM Algorithm:                     " << params.fm_algorithm << std::endl;
+      out << "    FM Num Seed Nodes:                " << params.fm_num_seed_nodes << std::endl;
+      out << "    FM Obey Minimal Parallelism:      " << std::boolalpha << params.fm_obey_minimal_parallelism << std::endl;
+      out << "    LP Algorithm:                     " << params.lp_algorithm << std::endl;
+      out << "    LP Unconstrained:                 " << std::boolalpha << params.lp_unconstrained << std::endl;
     }
     return out;
   }
@@ -210,8 +213,8 @@ namespace mt_kahypar {
     str << "  Min Border Vertices Per Thread:     " << params.min_border_vertices_per_thread << std::endl;
     str << "\n" << params.label_propagation;
     str << "\n" << params.fm;
-    if ( params.global_fm.use_global_fm ) {
-      str << "\n" << params.global_fm;
+    if ( params.global.use_global_refinement ) {
+      str << "\n" << params.global;
     }
     str << "\n" << params.flows;
     return str;

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -133,7 +133,7 @@ std::ostream & operator<< (std::ostream& str, const CoarseningParameters& params
 struct LabelPropagationParameters {
   LabelPropagationAlgorithm algorithm = LabelPropagationAlgorithm::do_nothing;
   size_t maximum_iterations = 1;
-  bool unconstrained = false;
+  mutable bool unconstrained = false;
   bool rebalancing = true;
   bool execute_sequential = false;
   size_t hyperedge_size_activation_threshold = std::numeric_limits<size_t>::max();
@@ -143,7 +143,7 @@ struct LabelPropagationParameters {
 std::ostream & operator<< (std::ostream& str, const LabelPropagationParameters& params);
 
 struct FMParameters {
-  FMAlgorithm algorithm = FMAlgorithm::do_nothing;
+  mutable FMAlgorithm algorithm = FMAlgorithm::do_nothing;
 
   size_t multitry_rounds = 1;
   mutable size_t num_seed_nodes = 1;
@@ -173,14 +173,19 @@ struct FMParameters {
 
 std::ostream& operator<<(std::ostream& out, const FMParameters& params);
 
-struct NLevelGlobalFMParameters {
-  bool use_global_fm = false;   // TODO this should be renamed to something more appropriate: e.g. log_level_fm or refine_after_coarsening_pass
+struct NLevelGlobalRefinementParameters {
+  bool use_global_refinement = false;
   bool refine_until_no_improvement = false;
-  size_t num_seed_nodes = 0;
-  bool obey_minimal_parallelism = false;
+
+  FMAlgorithm fm_algorithm = FMAlgorithm::do_nothing;
+  size_t fm_num_seed_nodes = 0;
+  bool fm_obey_minimal_parallelism = false;
+
+  LabelPropagationAlgorithm lp_algorithm = LabelPropagationAlgorithm::do_nothing;
+  bool lp_unconstrained = false;
 };
 
-std::ostream& operator<<(std::ostream& out, const NLevelGlobalFMParameters& params);
+std::ostream& operator<<(std::ostream& out, const NLevelGlobalRefinementParameters& params);
 
 struct FlowParameters {
   FlowAlgorithm algorithm = FlowAlgorithm::do_nothing;
@@ -212,7 +217,7 @@ struct RefinementParameters {
   LabelPropagationParameters label_propagation;
   FMParameters fm;
   DeterministicRefinementParameters deterministic_refinement;
-  NLevelGlobalFMParameters global_fm;
+  NLevelGlobalRefinementParameters global;
   FlowParameters flows;
   RebalancingAlgorithm rebalancer = RebalancingAlgorithm::do_nothing;
   bool refine_until_no_improvement = false;

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -69,8 +69,8 @@ class LabelPropagationRefiner final : public IRefiner {
     _gain(context),
     _active_nodes(),
     _active_node_was_moved(2 * num_hypernodes, uint8_t(false)),
-    _old_part(_context.refinement.label_propagation.unconstrained ? num_hypernodes : 0, kInvalidPartition),
-    _old_part_is_initialized(_context.refinement.label_propagation.unconstrained ? num_hypernodes : 0),
+    _old_part(_context.refinement.label_propagation.unconstrained || context.refinement.global.lp_unconstrained ? num_hypernodes : 0, kInvalidPartition),
+    _old_part_is_initialized(_context.refinement.label_propagation.unconstrained || context.refinement.global.lp_unconstrained ? num_hypernodes : 0),
     _next_active(num_hypernodes),
     _visited_he(Hypergraph::is_graph ? 0 : num_hyperedges),
     _rebalancer(rb) { }

--- a/tests/io/sql_plottools_serializer_test.cc
+++ b/tests/io/sql_plottools_serializer_test.cc
@@ -44,7 +44,7 @@ namespace io {
 std::vector<std::string> target_structs =
   { "PartitioningParameters", "CommunityDetectionParameters", "CommunityRedistributionParameters",
     "PreprocessingParameters", "RatingParameters", "CoarseningParameters", "InitialPartitioningParameters",
-    "LabelPropagationParameters", "FMParameters", "NLevelGlobalFMParameters",
+    "LabelPropagationParameters", "FMParameters", "NLevelGlobalRefinementParameters",
     "FlowParameters", "RefinementParameters", "SharedMemoryParameters", "DeterministicRefinement",
     "FlowParameters", "MappingParameters" };
 
@@ -52,7 +52,7 @@ std::unordered_map<std::string, std::string> target_struct_prefix =
   { {"PartitioningParameters", ""}, {"CommunityDetectionParameters", "community_"}, {"CommunityRedistributionParameters", "community_redistribution_"},
     {"PreprocessingParameters", ""}, {"RatingParameters", "rating_"}, {"CoarseningParameters", "coarsening_"},
     {"InitialPartitioningParameters", "initial_partitioning_"},
-    {"LabelPropagationParameters", "lp_"}, {"FMParameters", "fm_"}, {"NLevelGlobalFMParameters", "global_fm_"},
+    {"LabelPropagationParameters", "lp_"}, {"FMParameters", "fm_"}, {"NLevelGlobalRefinementParameters", "global_refine_"},
     {"RefinementParameters", ""}, {"SharedMemoryParameters", ""},
     {"DeterministicRefinement", "sync_lp_"}, {"FlowParameters", "flow_"}, {"MappingParameters", "mapping_"} };
 
@@ -61,7 +61,7 @@ std::set<std::string> excluded_members =
     "measure_detailed_uncontraction_timings", "write_partition_file", "graph_partition_output_folder", "graph_partition_filename", "graph_community_filename", "community_detection",
     "community_redistribution", "coarsening_rating", "label_propagation", "lp_execute_sequential", "deterministic_refinement",
     "snapshot_interval", "initial_partitioning_refinement", "initial_partitioning_enabled_ip_algos", "original_num_threads",
-    "stable_construction_of_incident_edges", "fm", "global_fm", "flows", "csv_output", "preset_file", "preset_type", "instance_type", "degree_of_parallelism",
+    "stable_construction_of_incident_edges", "fm", "global", "flows", "csv_output", "preset_file", "preset_type", "instance_type", "degree_of_parallelism",
     "mapping_target_graph_file" };
 
 bool is_target_struct(const std::string& line) {


### PR DESCRIPTION
This adds support for unconstrained refinement (unconstrained LP + unconstrained FM instead of constrained FM) for the global refinement step in n-level partitioning.

Specifically, it adds the `r-global-fm-type`, `r-global-use-lp` and `r-global-lp-unconstrained` parameters to control this.

As we can see, this brings a notable quality improvement for irregular graphs (center) and a small improvement for hypergraphs (left).

![quality](https://github.com/user-attachments/assets/bd8f2c94-3674-4f70-aca1-79928b8b5115)

Running time increases on irregular graphs but otherwise isn't much affected.

<img src="https://github.com/user-attachments/assets/526d84de-761b-429b-b34f-c62b5ed58893" alt="running_time_hypergraph" width="250"/>
<img src="https://github.com/user-attachments/assets/471ac6a4-2bab-408a-b459-ac5a111dd1ae" alt="running_time_hypergraph" width="250"/>
<img src="https://github.com/user-attachments/assets/d4d13426-2616-471e-9bff-aa6d11a9282e" alt="running_time_hypergraph" width="250"/>
