### PR TITLE
feat: add a do_nothing_coarsener to allow single-level v-cycles

### DIFF
--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -245,6 +245,7 @@ namespace mt_kahypar {
              " - multilevel_coarsener"
              " - nlevel_coarsener"
              " - deterministic_multilevel_coarsener"
+             " - do_nothing"
              )
             ("c-use-adaptive-edge-size",
              po::value<bool>(&context.coarsening.use_adaptive_edge_size)->value_name("<bool>")->default_value(true),

--- a/mt-kahypar/partition/coarsening/do_nothing_coarsener.h
+++ b/mt-kahypar/partition/coarsening/do_nothing_coarsener.h
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2025 Daniel Seemaier <daniel.seemaier@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ *all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+#pragma once
+
+#include "kahypar-resources/meta/mandatory.h"
+
+#include "include/mtkahypartypes.h"
+
+#include "mt-kahypar/datastructures/partitioned_hypergraph.h"
+#include "mt-kahypar/macros.h"
+#include "mt-kahypar/partition/coarsening/i_coarsener.h"
+#include "mt-kahypar/partition/coarsening/multilevel_coarsener_base.h"
+#include "mt-kahypar/partition/refinement/i_refiner.h"
+#include "mt-kahypar/utils/cast.h"
+
+namespace mt_kahypar {
+
+template <class TypeTraits = Mandatory>
+class DoNothingCoarsener final : public ICoarsener {
+  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using Hypergraph = typename TypeTraits::Hypergraph;
+
+public:
+  DoNothingCoarsener(mt_kahypar_hypergraph_t hypergraph,
+                     const Context & /* context */,
+                     uncoarsening_data_t *uncoarseningData)
+      : _hg(utils::cast<Hypergraph>(hypergraph)),
+        _uncoarseningData(
+            uncoarsening::to_reference<TypeTraits>(uncoarseningData)) {}
+
+  DoNothingCoarsener(const DoNothingCoarsener &) = delete;
+  DoNothingCoarsener(DoNothingCoarsener &&) = delete;
+  DoNothingCoarsener &operator=(const DoNothingCoarsener &) = delete;
+  DoNothingCoarsener &operator=(DoNothingCoarsener &&) = delete;
+
+  void disableRandomization() const {}
+
+private:
+  virtual void initializeImpl() final {}
+
+  virtual bool shouldNotTerminateImpl() const final { return false; }
+
+  virtual bool coarseningPassImpl() final { return false; }
+
+  virtual void terminateImpl() { _uncoarseningData.finalizeCoarsening(); }
+
+  virtual HypernodeID currentNumberOfNodesImpl() const final {
+    return _hg.initialNumNodes();
+  }
+
+  mt_kahypar_hypergraph_t coarsestHypergraphImpl() final {
+    return mt_kahypar_hypergraph_t{
+        reinterpret_cast<mt_kahypar_hypergraph_s *>(&_hg), Hypergraph::TYPE};
+  }
+
+  mt_kahypar_partitioned_hypergraph_t
+  coarsestPartitionedHypergraphImpl() final {
+    return mt_kahypar_partitioned_hypergraph_t{
+        reinterpret_cast<mt_kahypar_partitioned_hypergraph_s *>(
+            _uncoarseningData.partitioned_hg.get()),
+        PartitionedHypergraph::TYPE};
+  }
+
+  Hypergraph &_hg;
+  UncoarseningData<TypeTraits> &_uncoarseningData;
+};
+
+} // namespace mt_kahypar

--- a/mt-kahypar/partition/context_enum_classes.cpp
+++ b/mt-kahypar/partition/context_enum_classes.cpp
@@ -163,6 +163,7 @@ namespace mt_kahypar {
       case CoarseningAlgorithm::multilevel_coarsener: return os << "multilevel_coarsener";
       case CoarseningAlgorithm::deterministic_multilevel_coarsener: return os << "deterministic_multilevel_coarsener";
       case CoarseningAlgorithm::nlevel_coarsener: return os << "nlevel_coarsener";
+      case CoarseningAlgorithm::do_nothing_coarsener: return os << "do_nothing";
       case CoarseningAlgorithm::UNDEFINED: return os << "UNDEFINED";
         // omit default case to trigger compiler warning for missing cases
     }
@@ -362,6 +363,8 @@ namespace mt_kahypar {
       return CoarseningAlgorithm::nlevel_coarsener;
     } else if (type == "deterministic_multilevel_coarsener") {
       return CoarseningAlgorithm::deterministic_multilevel_coarsener;
+    } else if (type == "do_nothing_coarsener") {
+      return CoarseningAlgorithm::do_nothing_coarsener;
     }
     throw InvalidParameterException("Illegal option: " + type);
     return CoarseningAlgorithm::UNDEFINED;

--- a/mt-kahypar/partition/context_enum_classes.h
+++ b/mt-kahypar/partition/context_enum_classes.h
@@ -112,6 +112,7 @@ enum class CoarseningAlgorithm : uint8_t {
   multilevel_coarsener,
   deterministic_multilevel_coarsener,
   nlevel_coarsener,
+  do_nothing_coarsener,
   UNDEFINED
 };
 

--- a/mt-kahypar/partition/registries/register_coarsening_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_coarsening_algorithms.cpp
@@ -37,6 +37,7 @@
 #endif
 #include "mt-kahypar/partition/coarsening/multilevel_coarsener.h"
 #include "mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h"
+#include "mt-kahypar/partition/coarsening/do_nothing_coarsener.h"
 #include "mt-kahypar/partition/coarsening/policies/rating_acceptance_policy.h"
 #include "mt-kahypar/partition/coarsening/policies/rating_heavy_node_penalty_policy.h"
 #include "mt-kahypar/partition/context.h"
@@ -64,6 +65,9 @@ using NLevelCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<NLev
                                                                                                     AcceptancePolicies> >;
 #endif
 
+using DoNothingCoarsenerDispatcher = kahypar::meta::StaticMultiDispatchFactory<DoNothingCoarsener,
+                                                                               ICoarsener,
+                                                                               kahypar::meta::Typelist<TypeTraitsList>>;
 
 #define REGISTER_DISPATCHED_COARSENER(id, dispatcher, ...)                                                    \
   kahypar::meta::Registrar<CoarsenerFactory> register_ ## dispatcher(                                         \
@@ -103,6 +107,11 @@ void register_coarsening_algorithms() {
 
   REGISTER_DISPATCHED_COARSENER(CoarseningAlgorithm::deterministic_multilevel_coarsener,
                                 DeterministicCoarsenerDispatcher,
+                                kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
+                                  context.partition.partition_type));
+
+  REGISTER_DISPATCHED_COARSENER(CoarseningAlgorithm::do_nothing_coarsener,
+                                DoNothingCoarsenerDispatcher,
                                 kahypar::meta::PolicyRegistry<mt_kahypar_partition_type_t>::getInstance().getPolicy(
                                   context.partition.partition_type));
 

--- a/tests/partition/coarsening/coarsener_fixtures.h
+++ b/tests/partition/coarsening/coarsener_fixtures.h
@@ -86,6 +86,7 @@ class ACoarsener : public Test {
     }
 
     context.partition.k = 2;
+    context.partition.epsilon = 0.03;
     context.partition.mode = Mode::direct;
     context.partition.preset_type = PRESET;
     context.partition.instance_type = InstanceType::hypergraph;


### PR DESCRIPTION
We would like to experiment with the refinement algorithms implemented in Mt-KaHyPar, but without doing a full v-cycle. This adds a `do_nothing_coarsener` similar to the `do_nothing_refiner` that just terminates immediately.  