### PR TITLE
Deterministic Jet and Rebalancing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option(KAHYPAR_BUILD_DEBIAN_PACKAGE "Provide a target to build a debian package.
 option(KAHYPAR_DOWNLOAD_BOOST "Download boost automatically and compile required libraries." OFF)
 option(KAHYPAR_DOWNLOAD_TBB "Download TBB automatically." OFF)
 option(KAHYPAR_DISABLE_HWLOC "Exclude components requiring hwloc. Might impact performance on NUMA platforms." OFF)
+option(KAHYPAR_DISABLE_PARLAY "Remove the parlay dependency. Might impact running time of deterministic mode on some instances." OFF)
 
 # specific compile features/build properties
 option(KAHYPAR_USE_64_BIT_IDS "Enables 64-bit vertex and hyperedge IDs." OFF)
@@ -247,6 +248,10 @@ if(KAHYPAR_DISABLE_HWLOC)
   target_compile_definitions(MtKaHyPar-BuildFlags INTERFACE KAHYPAR_DISABLE_HWLOC)
 endif()
 
+if(KAHYPAR_DISABLE_PARLAY)
+  target_compile_definitions(MtKaHyPar-BuildFlags INTERFACE KAHYPAR_DISABLE_PARLAY)
+endif()
+
 
 #################################################################
 ## Setup of dependencies                                       ##
@@ -256,6 +261,7 @@ include(FetchContent)
 set(KAHYPAR_SHARED_RESOURCES_TAG 6d5c8e2444e4310667ec1925e995f26179d7ee88)
 set(KAHYPAR_WHFC_TAG             30b0eeb0e49577d06c3deb09a44b035d81c529d2)
 set(KAHYPAR_GROWT_TAG            0c1148ebcdfd4c04803be79706533ad09cc81d37)
+set(KAHYPAR_PARLAY_TAG           e1f1dc0ccf930492a2723f7fbef8510d35bf57f5)
 set(KAHYPAR_TBB_VERSION          v2022.0.0)
 set(KAHYPAR_GOOGLETEST_VERSION   v1.15.2)
 set(KAHYPAR_PYBIND11_VERSION     v2.13.6)
@@ -281,6 +287,17 @@ FetchContent_Populate(
   GIT_TAG        ${KAHYPAR_GROWT_TAG}
   SOURCE_DIR     external_tools/growt
 )
+
+if(NOT KAHYPAR_DISABLE_PARLAY)
+  FetchContent_Populate(
+    parlay QUIET EXLUDE_FROM_ALL
+    GIT_REPOSITORY https://github.com/cmuparlay/parlaylib.git
+    GIT_TAG        ${KAHYPAR_PARLAY_TAG}
+    SOURCE_DIR     external_tools/parlay
+  )
+  target_include_directories(MtKaHyPar-Include INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/external_tools/parlay/include)
+  target_compile_options(MtKaHyPar-BuildFlags INTERFACE -DPARLAY_TBB)
+endif()
 
 target_include_directories(MtKaHyPar-Include INTERFACE
                            ${CMAKE_CURRENT_BINARY_DIR}/external_tools/kahypar-shared-resources

--- a/mt-kahypar/datastructures/delta_partitioned_graph.h
+++ b/mt-kahypar/datastructures/delta_partitioned_graph.h
@@ -37,6 +37,7 @@
 #include "mt-kahypar/datastructures/sparse_map.h"
 #include "mt-kahypar/datastructures/delta_connectivity_set.h"
 #include "mt-kahypar/datastructures/connectivity_set.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/stl/scalable_vector.h"
 #include "mt-kahypar/partition/context.h"
 #include "mt-kahypar/utils/exception.h"

--- a/mt-kahypar/datastructures/delta_partitioned_hypergraph.h
+++ b/mt-kahypar/datastructures/delta_partitioned_hypergraph.h
@@ -35,6 +35,7 @@
 #include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
 #include "mt-kahypar/datastructures/delta_connectivity_set.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/stl/scalable_vector.h"
 #include "mt-kahypar/partition/context.h"
 

--- a/mt-kahypar/datastructures/hypergraph_common.h
+++ b/mt-kahypar/datastructures/hypergraph_common.h
@@ -34,7 +34,6 @@
 
 #include "mt-kahypar/parallel/stl/scalable_vector.h"
 #include "mt-kahypar/parallel/tbb_initializer.h"
-#include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/datastructures/array.h"
 
 #ifndef KAHYPAR_DISABLE_HWLOC
@@ -138,34 +137,13 @@ using SearchID = uint32_t;
 // Forward Declaration
 class TargetGraph;
 namespace ds {
-class Bitset;
 class StaticGraph;
-class PinCountSnapshot;
 class StaticHypergraph;
 class DynamicGraph;
 class DynamicHypergraph;
 class ConnectivityInfo;
 class SparseConnectivityInfo;
 }
-
-struct SynchronizedEdgeUpdate {
-  HyperedgeID he = kInvalidHyperedge;
-  PartitionID from = kInvalidPartition;
-  PartitionID to = kInvalidPartition;
-  HyperedgeID edge_weight = 0;
-  HypernodeID edge_size = 0;
-  HypernodeID pin_count_in_from_part_after = kInvalidHypernode;
-  HypernodeID pin_count_in_to_part_after = kInvalidHypernode;
-  PartitionID block_of_other_node = kInvalidPartition;
-  mutable ds::Bitset* connectivity_set_after = nullptr;
-  mutable ds::PinCountSnapshot* pin_counts_after = nullptr;
-  const TargetGraph* target_graph = nullptr;
-  ds::Array<SpinLock>* edge_locks = nullptr;
-};
-
-struct NoOpDeltaFunc {
-  void operator() (const SynchronizedEdgeUpdate&) { }
-};
 
 template<typename Hypergraph, typename ConInfo>
 struct PartitionedHypergraphType {

--- a/mt-kahypar/datastructures/synchronized_edge_update.h
+++ b/mt-kahypar/datastructures/synchronized_edge_update.h
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2024 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "include/mtkahypartypes.h"
+
+#include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/parallel/atomic_wrapper.h"
+#include "mt-kahypar/datastructures/pin_count_snapshot.h"
+#include "mt-kahypar/datastructures/bitset.h"
+
+
+namespace mt_kahypar {
+
+struct SynchronizedEdgeUpdate {
+  HyperedgeID he = kInvalidHyperedge;
+  PartitionID from = kInvalidPartition;
+  PartitionID to = kInvalidPartition;
+  HyperedgeID edge_weight = 0;
+  HypernodeID edge_size = 0;
+  HypernodeID pin_count_in_from_part_after = kInvalidHypernode;
+  HypernodeID pin_count_in_to_part_after = kInvalidHypernode;
+  PartitionID block_of_other_node = kInvalidPartition;
+  ds::Bitset* connectivity_set_after = nullptr;
+  ds::PinCountSnapshot* pin_counts_after = nullptr;
+  const TargetGraph* target_graph = nullptr;
+  ds::Array<SpinLock>* edge_locks = nullptr;
+
+  MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
+  HypernodeID decrementPinCountInPart(PartitionID part) {
+    ASSERT(pin_counts_after != nullptr);
+    HypernodeID decremented = pin_counts_after->decrementPinCountInPart(part);
+    if (connectivity_set_after != nullptr && decremented == 0) {
+      ASSERT(connectivity_set_after->isSet(part));
+      connectivity_set_after->unset(part);
+    }
+    return decremented;
+  }
+
+  MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE
+  HypernodeID incrementPinCountInPart(PartitionID part) {
+    ASSERT(pin_counts_after != nullptr);
+    HypernodeID incremented = pin_counts_after->incrementPinCountInPart(part);
+    if (connectivity_set_after != nullptr && incremented == 1) {
+      ASSERT(!connectivity_set_after->isSet(part));
+      connectivity_set_after->set(part);
+    }
+    return incremented;
+  }
+};
+
+struct NoOpDeltaFunc {
+  void operator() (const SynchronizedEdgeUpdate&) { }
+};
+
+} // namespace mt_kahypar

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -411,6 +411,21 @@ namespace mt_kahypar {
                                 &context.initial_partitioning.refinement.jet.relative_improvement_threshold))->value_name(
                      "<double>")->default_value(0.001),
              "Relative improvement threshold for Jet.")
+             ((initial_partitioning ? "i-r-jet-dynamic-rounds" : "r-jet-dynamic-rounds"),
+             po::value<size_t>(
+                     (initial_partitioning ? &context.initial_partitioning.refinement.jet.dynamic_rounds :
+                      &context.refinement.jet.dynamic_rounds))->value_name("<size_t>")->default_value(1),
+             "Number of dynamic rounds with decreasing temperature")
+             ((initial_partitioning ? "i-r-jet-initial-negative-gain" : "r-jet-initial-negative-gain"),
+             po::value<double>(
+                     (initial_partitioning ? &context.initial_partitioning.refinement.jet.initial_negative_gain_factor :
+                      &context.refinement.jet.initial_negative_gain_factor))->value_name("<double>")->default_value(0.75),
+             "Initial negative gain factor for dynamic gain factor")
+             ((initial_partitioning ? "i-r-jet-final-negative-gain" : "r-jet-final-negative-gain"),
+             po::value<double>(
+                     (initial_partitioning ? &context.initial_partitioning.refinement.jet.final_negative_gain_factor :
+                      &context.refinement.jet.final_negative_gain_factor))->value_name("<double>")->default_value(0.0),
+             "Final negative gain factor for dynamic gain factor")
             ((initial_partitioning ? "i-r-fm-type" : "r-fm-type"),
              po::value<std::string>()->value_name("<string>")->notifier(
                      [&, initial_partitioning](const std::string& type) {

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -389,6 +389,28 @@ namespace mt_kahypar {
                                 &context.initial_partitioning.refinement.label_propagation.relative_improvement_threshold))->value_name(
                      "<double>")->default_value(-1.0),
              "Relative improvement threshold for label propagation.")
+            ((initial_partitioning ? "i-r-jet-type" : "r-jet-type"),
+             po::value<std::string>()->value_name("<string>")->notifier(
+                     [&, initial_partitioning](const std::string& type) {
+                       if (initial_partitioning) {
+                         context.initial_partitioning.refinement.jet.algorithm = jetAlgorithmFromString(type);
+                       } else {
+                         context.refinement.jet.algorithm = jetAlgorithmFromString(type);
+                       }
+                     })->default_value("do_nothing"),
+             "Jet Algorithm:\n"
+             "- deterministic\n"
+             "- do_nothing")
+            ((initial_partitioning ? "i-r-jet-num-iterations": "r-jet-num-iterations"),
+            po::value<size_t>((!initial_partitioning ? &context.refinement.jet.num_iterations :
+                              &context.initial_partitioning.refinement.jet.num_iterations))->value_name(
+                    "<size_t>")->default_value(12),
+             "Number of iterations without significant improvement")
+            ((initial_partitioning ? "i-r-jet-relative-improvement-threshold" : "r-jet-relative-improvement-threshold"),
+             po::value<double>((!initial_partitioning ? &context.refinement.jet.relative_improvement_threshold :
+                                &context.initial_partitioning.refinement.jet.relative_improvement_threshold))->value_name(
+                     "<double>")->default_value(0.001),
+             "Relative improvement threshold for Jet.")
             ((initial_partitioning ? "i-r-fm-type" : "r-fm-type"),
              po::value<std::string>()->value_name("<string>")->notifier(
                      [&, initial_partitioning](const std::string& type) {

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -584,9 +584,25 @@ namespace mt_kahypar {
                        }
                      })->default_value("do_nothing"),
              "Rebalancer Algorithm:\n"
+             "- deterministic\n"
              "- simple_rebalancer\n"
              "- advanced_rebalancer\n"
-             "- do_nothing");
+             "- do_nothing")
+            ((initial_partitioning ? "i-r-det-rebalancing-deadzone": "r-det-rebalancing-deadzone"),
+            po::value<double>((!initial_partitioning ? &context.refinement.rebalancing.det_relative_deadzone_size :
+                              &context.initial_partitioning.refinement.rebalancing.det_relative_deadzone_size))->value_name(
+                    "<double>")->default_value(1.0),
+             "Relative deadzone size for deterministic rebalancer")
+            ((initial_partitioning ? "i-r-det-rebalancing-heavy-vertex-exclusion": "r-det-rebalancing-heavy-vertex-exclusion"),
+            po::value<double>((!initial_partitioning ? &context.refinement.rebalancing.det_heavy_vertex_exclusion_factor :
+                              &context.initial_partitioning.refinement.rebalancing.det_heavy_vertex_exclusion_factor))->value_name(
+                    "<double>")->default_value(1.5),
+             "Relative weight threshold for heavy vertices which are ignored in deterministic rebalancing.")
+            ((initial_partitioning ? "i-r-max-det-rebalancing-rounds": "r-max-det-rebalancing-rounds"),
+            po::value<size_t>((!initial_partitioning ? &context.refinement.rebalancing.det_max_rounds :
+                              &context.initial_partitioning.refinement.rebalancing.det_max_rounds))->value_name(
+                    "<size_t>")->default_value(0),
+            "Deterministic rebalancer: maximum number of iterations per rebalancing call");
     return options;
   }
 

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -578,9 +578,9 @@ namespace mt_kahypar {
              po::value<std::string>()->value_name("<string>")->notifier(
                      [&, initial_partitioning](const std::string& type) {
                        if (initial_partitioning) {
-                         context.initial_partitioning.refinement.rebalancer = rebalancingAlgorithmFromString(type);
+                         context.initial_partitioning.refinement.rebalancing.algorithm = rebalancingAlgorithmFromString(type);
                        } else {
-                         context.refinement.rebalancer = rebalancingAlgorithmFromString(type);
+                         context.refinement.rebalancing.algorithm = rebalancingAlgorithmFromString(type);
                        }
                      })->default_value("do_nothing"),
              "Rebalancer Algorithm:\n"

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -117,7 +117,11 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " lp_relative_improvement_threshold=" << context.refinement.label_propagation.relative_improvement_threshold
         << " lp_hyperedge_size_activation_threshold=" << context.refinement.label_propagation.hyperedge_size_activation_threshold
         << " sync_lp_num_sub_rounds_sync_lp=" << context.refinement.deterministic_refinement.num_sub_rounds_sync_lp
-        << " sync_lp_use_active_node_set=" << context.refinement.deterministic_refinement.use_active_node_set;
+        << " sync_lp_use_active_node_set=" << context.refinement.deterministic_refinement.use_active_node_set
+        << " jet_algorithm=" << context.refinement.jet.algorithm
+        << " jet_num_iterations_without_improvement=" << context.refinement.jet.num_iterations
+        << " jet_fixed_num_iterations=" << context.refinement.jet.fixed_n_iterations
+        << " jet_realtive_improvement_threshold=" << context.refinement.jet.relative_improvement_threshold;
     oss << " fm_algorithm=" << context.refinement.fm.algorithm
         << " fm_multitry_rounds=" << context.refinement.fm.multitry_rounds
         << " fm_rollback_parallel=" << std::boolalpha << context.refinement.fm.rollback_parallel

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -105,11 +105,11 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " initial_partitioning_lp_maximum_iterations=" << context.initial_partitioning.lp_maximum_iterations
         << " initial_partitioning_lp_initial_block_size=" << context.initial_partitioning.lp_initial_block_size
         << " initial_partitioning_population_size=" << context.initial_partitioning.population_size;
-    oss << " rebalancer=" << std::boolalpha << context.refinement.rebalancer
-        << " refine_until_no_improvement=" << std::boolalpha << context.refinement.refine_until_no_improvement
+    oss << " refine_until_no_improvement=" << std::boolalpha << context.refinement.refine_until_no_improvement
         << " relative_improvement_threshold=" << context.refinement.relative_improvement_threshold
         << " max_batch_size=" << context.refinement.max_batch_size
         << " min_border_vertices_per_thread=" << context.refinement.min_border_vertices_per_thread
+        << " rebalancing_algorithm=" << context.refinement.rebalancing.algorithm
         << " lp_algorithm=" << context.refinement.label_propagation.algorithm
         << " lp_maximum_iterations=" << context.refinement.label_propagation.maximum_iterations
         << " lp_rebalancing=" << std::boolalpha << context.refinement.label_propagation.rebalancing

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -110,6 +110,9 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " max_batch_size=" << context.refinement.max_batch_size
         << " min_border_vertices_per_thread=" << context.refinement.min_border_vertices_per_thread
         << " rebalancing_algorithm=" << context.refinement.rebalancing.algorithm
+        << " rebalancing_heavy_vertex_exclusion_factor=" << context.refinement.rebalancing.det_heavy_vertex_exclusion_factor
+        << " rebalancing_relative_deadzone_size=" << context.refinement.rebalancing.det_relative_deadzone_size
+        << " rebalancing_det_max_rounds=" << context.refinement.rebalancing.det_max_rounds
         << " lp_algorithm=" << context.refinement.label_propagation.algorithm
         << " lp_maximum_iterations=" << context.refinement.label_propagation.maximum_iterations
         << " lp_rebalancing=" << std::boolalpha << context.refinement.label_propagation.rebalancing

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -120,8 +120,10 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " sync_lp_use_active_node_set=" << context.refinement.deterministic_refinement.use_active_node_set
         << " jet_algorithm=" << context.refinement.jet.algorithm
         << " jet_num_iterations_without_improvement=" << context.refinement.jet.num_iterations
-        << " jet_fixed_num_iterations=" << context.refinement.jet.fixed_n_iterations
-        << " jet_realtive_improvement_threshold=" << context.refinement.jet.relative_improvement_threshold;
+        << " jet_relative_improvement_threshold=" << context.refinement.jet.relative_improvement_threshold
+        << " jet_dynamic_rounds=" << context.refinement.jet.dynamic_rounds
+        << " jet_initial_negative_gain_factor=" << context.refinement.jet.initial_negative_gain_factor
+        << " jet_initial_final_negative_gain_factor=" << context.refinement.jet.final_negative_gain_factor;
     oss << " fm_algorithm=" << context.refinement.fm.algorithm
         << " fm_multitry_rounds=" << context.refinement.fm.multitry_rounds
         << " fm_rollback_parallel=" << std::boolalpha << context.refinement.fm.rollback_parallel

--- a/mt-kahypar/parallel/scalable_sort.h
+++ b/mt-kahypar/parallel/scalable_sort.h
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2025 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#ifndef KAHYPAR_DISABLE_PARLAY
+#include <parlay/primitives.h>
+#else
+#include <tbb/parallel_sort.h>
+#endif
+
+namespace mt_kahypar::parallel {
+
+// scalable sort implementation (with fallback to TBB sort if parlay dependency is disabled)
+template <typename Range, typename Compare>
+void scalable_sort(Range&& input, Compare&& cmp) {
+  #ifndef KAHYPAR_DISABLE_PARLAY
+    parlay::sort_inplace(std::forward<Range>(input), std::forward<Compare>(cmp));
+  #else
+    tbb::parallel_sort(std::forward<Range>(input), std::forward<Compare>(cmp));
+  #endif
+}
+
+}  // namespace mt_kahypar::parallel

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
@@ -228,6 +228,16 @@ namespace mt_kahypar {
         _timer.stop_timer("label_propagation");
       }
 
+      if ( _jet && _context.refinement.jet.algorithm != JetAlgorithm::do_nothing ) {
+        _timer.start_timer("initialize_jet_refiner", "Initialize Jet Refiner");
+        _jet->initialize(phg);
+        _timer.stop_timer("initialize_jet_refiner");
+
+        _timer.start_timer("jet", "Jet");
+        improvement_found |= _jet->refine(phg, dummy, _current_metrics, time_limit);
+        _timer.stop_timer("jet");
+      }
+
       if ( _fm && _context.refinement.fm.algorithm != FMAlgorithm::do_nothing ) {
         _timer.start_timer("initialize_fm_refiner", "Initialize FM Refiner");
         _fm->initialize(phg);

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
@@ -214,7 +214,7 @@ namespace mt_kahypar {
       improvement_found = false;
       const HyperedgeWeight metric_before = _current_metrics.quality;
 
-      if ( _rebalancer && _context.refinement.rebalancer != RebalancingAlgorithm::do_nothing ) {
+      if ( _rebalancer && _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
         _rebalancer->initialize(phg);
       }
 

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.h
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.h
@@ -98,6 +98,7 @@ class MultilevelUncoarsener : public IUncoarsener<TypeTraits>,
   using Base::_uncoarseningData;
   using Base::_gain_cache;
   using Base::_label_propagation;
+  using Base::_jet;
   using Base::_fm;
   using Base::_flows;
   using Base::_rebalancer;

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
@@ -394,6 +394,16 @@ namespace mt_kahypar {
             _timer.stop_timer("label_propagation");
           }
 
+          if ( _jet && _context.refinement.jet.algorithm != JetAlgorithm::do_nothing ) {
+            _timer.start_timer("initialize_jet_refiner", "Initialize Jet Refiner");
+            _jet->initialize(phg);
+            _timer.stop_timer("initialize_jet_refiner");
+
+            _timer.start_timer("jet", "Jet");
+            improvement_found |= _jet->refine(phg, {}, _current_metrics, time_limit);
+            _timer.stop_timer("jet");
+          }
+
           IRefiner* fm_ptr = _global_fm ? _global_fm.get() : _fm.get();
           if ( fm_ptr && _context.refinement.global.fm_algorithm != FMAlgorithm::do_nothing ) {
             _timer.start_timer("fm", "FM");

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.h
@@ -146,6 +146,7 @@ class NLevelUncoarsener : public IUncoarsener<TypeTraits>,
   using Base::_uncoarseningData;
   using Base::_gain_cache;
   using Base::_label_propagation;
+  using Base::_jet;
   using Base::_fm;
   using Base::_flows;
   using Base::_rebalancer;

--- a/mt-kahypar/partition/coarsening/uncoarsener_base.h
+++ b/mt-kahypar/partition/coarsening/uncoarsener_base.h
@@ -123,7 +123,7 @@ class UncoarsenerBase {
     _gain_cache = GainCachePtr::constructGainCache(_context);
     // refinement algorithms require access to the rebalancer
     _rebalancer = RebalancerFactory::getInstance().createObject(
-      _context.refinement.rebalancer, _hg.initialNumNodes(), _context, _gain_cache);
+      _context.refinement.rebalancing.algorithm, _hg.initialNumNodes(), _context, _gain_cache);
     _label_propagation = LabelPropagationFactory::getInstance().createObject(
       _context.refinement.label_propagation.algorithm,
       _hg.initialNumNodes(), _hg.initialNumEdges(), _context, _gain_cache, *_rebalancer);

--- a/mt-kahypar/partition/coarsening/uncoarsener_base.h
+++ b/mt-kahypar/partition/coarsening/uncoarsener_base.h
@@ -61,6 +61,7 @@ class UncoarsenerBase {
           _uncoarseningData(uncoarseningData),
           _gain_cache(gain_cache_t {nullptr, GainPolicy::none}),
           _label_propagation(nullptr),
+          _jet(nullptr),
           _fm(nullptr),
           _flows(nullptr),
           _rebalancer(nullptr) {}
@@ -81,6 +82,7 @@ class UncoarsenerBase {
   UncoarseningData<TypeTraits>& _uncoarseningData;
   gain_cache_t _gain_cache;
   std::unique_ptr<IRefiner> _label_propagation;
+  std::unique_ptr<IRefiner> _jet;
   std::unique_ptr<IRefiner> _fm;
   std::unique_ptr<IRefiner> _flows;
   std::unique_ptr<IRebalancer> _rebalancer;
@@ -124,6 +126,9 @@ class UncoarsenerBase {
       _context.refinement.rebalancer, _hg.initialNumNodes(), _context, _gain_cache);
     _label_propagation = LabelPropagationFactory::getInstance().createObject(
       _context.refinement.label_propagation.algorithm,
+      _hg.initialNumNodes(), _hg.initialNumEdges(), _context, _gain_cache, *_rebalancer);
+    _jet = JetFactory::getInstance().createObject(
+      _context.refinement.jet.algorithm,
       _hg.initialNumNodes(), _hg.initialNumEdges(), _context, _gain_cache, *_rebalancer);
     _fm = FMFactory::getInstance().createObject(
       _context.refinement.fm.algorithm,

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -138,6 +138,9 @@ namespace mt_kahypar {
     if ( params.algorithm != JetAlgorithm::do_nothing ) {
       str << "    Iterations without Improvement:   " << params.num_iterations << std::endl;
       str << "    Relative Improvement Threshold:   " << params.relative_improvement_threshold << std::endl;
+      str << "    Dynamic Rounds:                   " << params.dynamic_rounds << std::endl;
+      str << "    Initial Negative Gain Factor:     " << params.initial_negative_gain_factor << std::endl;
+      str << "    Final Negative Gain Factor:       " << params.final_negative_gain_factor << std::endl;
     }
     return str;
   }

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -217,9 +217,14 @@ namespace mt_kahypar {
     return out;
   }
 
+  std::ostream& operator<<(std::ostream& out, const RebalancingParameters& params) {
+    out << "  Rebalancing Parameters:" << std::endl;
+    out << "    Algorithm:                        " << params.algorithm << std::endl;
+    return out;
+  }
+
   std::ostream & operator<< (std::ostream& str, const RefinementParameters& params) {
     str << "Refinement Parameters:" << std::endl;
-    str << "  Rebalancing Algorithm:              " << params.rebalancer << std::endl;
     str << "  Refine Until No Improvement:        " << std::boolalpha << params.refine_until_no_improvement << std::endl;
     str << "  Relative Improvement Threshold:     " << params.relative_improvement_threshold << std::endl;
     str << "  Maximum Batch Size:                 " << params.max_batch_size << std::endl;
@@ -231,6 +236,7 @@ namespace mt_kahypar {
       str << "\n" << params.global;
     }
     str << "\n" << params.flows;
+    str << "\n" << params.rebalancing;
     return str;
   }
 

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -132,6 +132,16 @@ namespace mt_kahypar {
     return str;
   }
 
+  std::ostream & operator<< (std::ostream& str, const JetParameters& params) {
+    str << "  Jet Parameters:" << std::endl;
+    str << "    Algorithm:                        " << params.algorithm << std::endl;
+    if ( params.algorithm != JetAlgorithm::do_nothing ) {
+      str << "    Iterations without Improvement:   " << params.num_iterations << std::endl;
+      str << "    Relative Improvement Threshold:   " << params.relative_improvement_threshold << std::endl;
+    }
+    return str;
+  }
+
   std::ostream& operator<<(std::ostream& out, const FMParameters& params) {
     out << "  FM Parameters: \n";
     out << "    Algorithm:                        " << params.algorithm << std::endl;
@@ -212,6 +222,7 @@ namespace mt_kahypar {
     str << "  Maximum Batch Size:                 " << params.max_batch_size << std::endl;
     str << "  Min Border Vertices Per Thread:     " << params.min_border_vertices_per_thread << std::endl;
     str << "\n" << params.label_propagation;
+    str << "\n" << params.jet;
     str << "\n" << params.fm;
     if ( params.global.use_global_refinement ) {
       str << "\n" << params.global;

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -220,6 +220,11 @@ namespace mt_kahypar {
   std::ostream& operator<<(std::ostream& out, const RebalancingParameters& params) {
     out << "  Rebalancing Parameters:" << std::endl;
     out << "    Algorithm:                        " << params.algorithm << std::endl;
+    if ( params.algorithm == RebalancingAlgorithm::deterministic ) {
+      out << "    Heavy vertex exclusion factor:    " << params.det_heavy_vertex_exclusion_factor << std::endl;
+      out << "    Relative deadone size:            " << params.det_relative_deadzone_size << std::endl;
+      out << "    Max rounds:                       " << params.det_max_rounds << std::endl;
+    }
     return out;
   }
 

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -224,6 +224,12 @@ struct DeterministicRefinementParameters {
 
 std::ostream& operator<<(std::ostream& out, const DeterministicRefinementParameters& params);
 
+struct RebalancingParameters {
+  RebalancingAlgorithm algorithm = RebalancingAlgorithm::do_nothing;
+};
+
+std::ostream& operator<<(std::ostream& out, const RebalancingParameters& params);
+
 struct RefinementParameters {
   LabelPropagationParameters label_propagation;
   JetParameters jet;
@@ -231,7 +237,7 @@ struct RefinementParameters {
   DeterministicRefinementParameters deterministic_refinement;
   NLevelGlobalRefinementParameters global;
   FlowParameters flows;
-  RebalancingAlgorithm rebalancer = RebalancingAlgorithm::do_nothing;
+  RebalancingParameters rebalancing;
   bool refine_until_no_improvement = false;
   double relative_improvement_threshold = 0.0;
   size_t max_batch_size = std::numeric_limits<size_t>::max();

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -145,10 +145,10 @@ std::ostream & operator<< (std::ostream& str, const LabelPropagationParameters& 
 struct JetParameters {
   JetAlgorithm algorithm = JetAlgorithm::do_nothing;
   size_t num_iterations = 12;
-  size_t fixed_n_iterations = 0;
   double relative_improvement_threshold = 0.001;
-  double negative_gain_factor_coarse = 0.75;
-  double negative_gain_factor_fine = 0.25;
+  size_t dynamic_rounds = 3;
+  double initial_negative_gain_factor = 0.75;
+  double final_negative_gain_factor = 0.0;
 };
 
 std::ostream & operator<< (std::ostream& str, const JetParameters& params);

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -226,6 +226,9 @@ std::ostream& operator<<(std::ostream& out, const DeterministicRefinementParamet
 
 struct RebalancingParameters {
   RebalancingAlgorithm algorithm = RebalancingAlgorithm::do_nothing;
+  double det_heavy_vertex_exclusion_factor = 1.5;
+  double det_relative_deadzone_size = 1.0;
+  size_t det_max_rounds = std::numeric_limits<size_t>::max();
 };
 
 std::ostream& operator<<(std::ostream& out, const RebalancingParameters& params);

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -142,6 +142,17 @@ struct LabelPropagationParameters {
 
 std::ostream & operator<< (std::ostream& str, const LabelPropagationParameters& params);
 
+struct JetParameters {
+  JetAlgorithm algorithm = JetAlgorithm::do_nothing;
+  size_t num_iterations = 12;
+  size_t fixed_n_iterations = 0;
+  double relative_improvement_threshold = 0.001;
+  double negative_gain_factor_coarse = 0.75;
+  double negative_gain_factor_fine = 0.25;
+};
+
+std::ostream & operator<< (std::ostream& str, const JetParameters& params);
+
 struct FMParameters {
   mutable FMAlgorithm algorithm = FMAlgorithm::do_nothing;
 
@@ -215,6 +226,7 @@ std::ostream& operator<<(std::ostream& out, const DeterministicRefinementParamet
 
 struct RefinementParameters {
   LabelPropagationParameters label_propagation;
+  JetParameters jet;
   FMParameters fm;
   DeterministicRefinementParameters deterministic_refinement;
   NLevelGlobalRefinementParameters global;

--- a/mt-kahypar/partition/context_enum_classes.cpp
+++ b/mt-kahypar/partition/context_enum_classes.cpp
@@ -259,6 +259,7 @@ namespace mt_kahypar {
 
   std::ostream & operator<< (std::ostream& os, const RebalancingAlgorithm& algo) {
       switch (algo) {
+        case RebalancingAlgorithm::deterministic: return os << "deterministic";
         case RebalancingAlgorithm::simple_rebalancer: return os << "simple_rebalancer";
         case RebalancingAlgorithm::advanced_rebalancer: return os << "advanced_rebalancer";
         case RebalancingAlgorithm::do_nothing: return os << "do_nothing";
@@ -489,7 +490,9 @@ namespace mt_kahypar {
   }
 
   RebalancingAlgorithm rebalancingAlgorithmFromString(const std::string& type) {
-    if (type == "simple_rebalancer") {
+    if (type == "deterministic") {
+      return RebalancingAlgorithm::deterministic;
+    } else if (type == "simple_rebalancer") {
       return RebalancingAlgorithm::simple_rebalancer;
     } else if (type == "advanced_rebalancer") {
       return RebalancingAlgorithm::advanced_rebalancer;

--- a/mt-kahypar/partition/context_enum_classes.cpp
+++ b/mt-kahypar/partition/context_enum_classes.cpp
@@ -227,6 +227,15 @@ namespace mt_kahypar {
     return os << static_cast<uint8_t>(algo);
   }
 
+  std::ostream & operator<< (std::ostream& os, const JetAlgorithm& algo) {
+    switch (algo) {
+      case JetAlgorithm::deterministic: return os << "deterministic";
+      case JetAlgorithm::do_nothing: return os << "jet_do_nothing";
+        // omit default case to trigger compiler warning for missing cases
+    }
+    return os << static_cast<uint8_t>(algo);
+  }
+
   std::ostream & operator<< (std::ostream& os, const FMAlgorithm& algo) {
     switch (algo) {
       case FMAlgorithm::kway_fm: return os << "kway_fm";
@@ -445,6 +454,16 @@ namespace mt_kahypar {
     }
     throw InvalidParameterException("Illegal option: " + type);
     return LabelPropagationAlgorithm::do_nothing;
+  }
+
+  JetAlgorithm jetAlgorithmFromString(const std::string& type) {
+    if (type == "deterministic") {
+      return JetAlgorithm::deterministic;
+    } else if (type == "do_nothing") {
+      return JetAlgorithm::do_nothing;
+    }
+    throw InvalidParameterException("Illegal option: " + type);
+    return JetAlgorithm::do_nothing;
   }
 
   FMAlgorithm fmAlgorithmFromString(const std::string& type) {

--- a/mt-kahypar/partition/context_enum_classes.h
+++ b/mt-kahypar/partition/context_enum_classes.h
@@ -172,6 +172,7 @@ enum class FlowAlgorithm : uint8_t {
 };
 
 enum class RebalancingAlgorithm : uint8_t {
+  deterministic,
   simple_rebalancer,
   advanced_rebalancer,
   do_nothing

--- a/mt-kahypar/partition/context_enum_classes.h
+++ b/mt-kahypar/partition/context_enum_classes.h
@@ -154,6 +154,11 @@ enum class LabelPropagationAlgorithm : uint8_t {
   do_nothing
 };
 
+enum class JetAlgorithm : uint8_t {
+  deterministic,
+  do_nothing
+};
+
 enum class FMAlgorithm : uint8_t {
   kway_fm,
   unconstrained_fm,
@@ -217,6 +222,8 @@ std::ostream & operator<< (std::ostream& os, const InitialPartitioningAlgorithm&
 
 std::ostream & operator<< (std::ostream& os, const LabelPropagationAlgorithm& algo);
 
+std::ostream & operator<< (std::ostream& os, const JetAlgorithm& algo);
+
 std::ostream & operator<< (std::ostream& os, const FMAlgorithm& algo);
 
 std::ostream & operator<< (std::ostream& os, const FlowAlgorithm& algo);
@@ -250,6 +257,8 @@ RatingFunction ratingFunctionFromString(const std::string& function);
 InitialPartitioningAlgorithm initialPartitioningAlgorithmFromString(const std::string& algo);
 
 LabelPropagationAlgorithm labelPropagationAlgorithmFromString(const std::string& type);
+
+JetAlgorithm jetAlgorithmFromString(const std::string& type);
 
 FMAlgorithm fmAlgorithmFromString(const std::string& type);
 

--- a/mt-kahypar/partition/deep_multilevel.cpp
+++ b/mt-kahypar/partition/deep_multilevel.cpp
@@ -504,10 +504,11 @@ void apply_bipartitions_to_hypergraph(typename TypeTraits::PartitionedHypergraph
       if ( gain_cache.isInitialized() ) {
         partitioned_hg.changeNodePart(gain_cache, hn, from, to);
       } else {
-        partitioned_hg.changeNodePart(hn, from, to);
+        partitioned_hg.changeNodePartNoSync(hn, from, to);
       }
     }
   });
+  partitioned_hg.resetEdgeSynchronization();
 
   if ( GainCache::invalidates_entries && gain_cache.isInitialized() ) {
     partitioned_hg.doParallelForAllNodes([&](const HypernodeID& hn) {

--- a/mt-kahypar/partition/factories.h
+++ b/mt-kahypar/partition/factories.h
@@ -52,6 +52,9 @@ using InitialPartitionerFactory = kahypar::meta::Factory<InitialPartitioningAlgo
 using LabelPropagationFactory = kahypar::meta::Factory<LabelPropagationAlgorithm,
                                   IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;
 
+using JetFactory = kahypar::meta::Factory<JetAlgorithm,
+                     IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;
+
 using FMFactory = kahypar::meta::Factory<FMAlgorithm,
                     IRefiner* (*)(HypernodeID, HyperedgeID, const Context&, gain_cache_t, IRebalancer&)>;
 

--- a/mt-kahypar/partition/initial_partitioning/greedy_initial_partitioner.h
+++ b/mt-kahypar/partition/initial_partitioning/greedy_initial_partitioner.h
@@ -107,7 +107,7 @@ class GreedyInitialPartitionerBase {
 
         if ( allow_overfitting || fitsIntoBlock(hg, hn, to, use_perfect_balanced_as_upper_bound) ) {
           if ( _default_block != kInvalidPartition ) {
-            hg.changeNodePart(hn, _default_block, to);
+            hg.changeNodePartNoSync(hn, _default_block, to);
           } else {
             hg.setNodePart(hn, to);
           }
@@ -117,6 +117,7 @@ class GreedyInitialPartitionerBase {
           kway_pq.disablePart(to);
         }
       }
+      hg.resetEdgeSynchronization();
 
       HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
       double time = std::chrono::duration<double>(end - start).count();

--- a/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
+++ b/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
@@ -219,7 +219,7 @@ class InitialPartitioningDataContainer {
       } else if ( _context.refinement.label_propagation.algorithm != LabelPropagationAlgorithm::do_nothing ) {
         // In case of a direct-kway initial partition we instantiate the LP refiner
         _rebalancer = RebalancerFactory::getInstance().createObject(
-          _context.refinement.rebalancer, hypergraph.initialNumNodes(), _context, _gain_cache);
+          _context.refinement.rebalancing.algorithm, hypergraph.initialNumNodes(), _context, _gain_cache);
         _label_propagation = LabelPropagationFactory::getInstance().createObject(
           _context.refinement.label_propagation.algorithm,
           hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), _context, _gain_cache, *_rebalancer);

--- a/mt-kahypar/partition/initial_partitioning/label_propagation_initial_partitioner.cpp
+++ b/mt-kahypar/partition/initial_partitioning/label_propagation_initial_partitioner.cpp
@@ -118,7 +118,7 @@ void LabelPropagationInitialPartitioner<TypeTraits>::partitionImpl() {
               converged = false;
 
               #ifndef KAHYPAR_ENABLE_HEAVY_INITIAL_PARTITIONING_ASSERTIONS
-              hg.changeNodePart(hn, from, to);
+              hg.changeNodePartNoSync(hn, from, to);
               #else
               Gain expected_gain = 0;
               auto cut_delta = [&](const HyperedgeID he,
@@ -152,6 +152,7 @@ void LabelPropagationInitialPartitioner<TypeTraits>::partitionImpl() {
       }
 
     }
+    hg.resetEdgeSynchronization();
 
     // If there are still unassigned vertices left, we assign them to the
     // block with minimum weight.

--- a/mt-kahypar/partition/mapping/kerninghan_lin.cpp
+++ b/mt-kahypar/partition/mapping/kerninghan_lin.cpp
@@ -36,7 +36,7 @@ namespace mt_kahypar {
 namespace {
 
 template<typename CommunicationHypergraph>
-MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE void swap(CommunicationHypergraph& communication_hg,
+MT_KAHYPAR_ATTRIBUTE_ALWAYS_INLINE void vertex_swap(CommunicationHypergraph& communication_hg,
                                              const HypernodeID u,
                                              const HypernodeID v) {
   const PartitionID block_of_u = communication_hg.partID(u);
@@ -182,7 +182,7 @@ void KerninghanLin<CommunicationHypergraph>::improve(CommunicationHypergraph& co
       }
 
       // Perform swap
-      swap(communication_hg, u, v);
+      vertex_swap(communication_hg, u, v);
       current_objective -= gain;
       performed_swaps.push_back(elem);
       already_moved[u] = true;
@@ -199,7 +199,7 @@ void KerninghanLin<CommunicationHypergraph>::improve(CommunicationHypergraph& co
     // Rollback to best seen solution
     for ( int i = performed_swaps.size() - 1; i >= best_idx; --i ) {
       const PQElement& elem = performed_swaps[i];
-      swap(communication_hg, elem.swap.first, elem.swap.second);
+      vertex_swap(communication_hg, elem.swap.first, elem.swap.second);
       current_objective += elem.gain;
     }
     ASSERT(current_objective == metrics::quality(communication_hg, Objective::steiner_tree));

--- a/mt-kahypar/partition/partitioner.cpp
+++ b/mt-kahypar/partition/partitioner.cpp
@@ -309,10 +309,11 @@ namespace mt_kahypar {
                   << ", but it is assigned to block" << from << "!"
                   << "It is now moved to its fixed vertex block." << END;
             }
-            partitioned_hg.changeNodePart(hn, from, to, NOOP_FUNC, true);
+            partitioned_hg.changeNodePartNoSync(hn, from, to, true);
           }
         }
       });
+      partitioned_hg.resetEdgeSynchronization();
     }
   }
 

--- a/mt-kahypar/partition/recursive_bipartitioning.cpp
+++ b/mt-kahypar/partition/recursive_bipartitioning.cpp
@@ -360,10 +360,11 @@ void rb::recursively_bipartition_block(typename TypeTraits::PartitionedHypergrap
         PartitionID to = block + rb_phg.partID(mapping[hn]);
         ASSERT(to != kInvalidPartition && to < phg.k());
         if ( block != to ) {
-          phg.changeNodePart(hn, block, to, NOOP_FUNC, true);
+          phg.changeNodePartNoSync(hn, block, to, true);
         }
       }
     });
+    phg.resetEdgeSynchronization();
     DBG << "Recursive Bipartitioning Result -"
         << "k =" << (k1 - k0)
         << "Objective =" << metrics::quality(phg, context)

--- a/mt-kahypar/partition/refinement/CMakeLists.txt
+++ b/mt-kahypar/partition/refinement/CMakeLists.txt
@@ -8,6 +8,7 @@ set(RefinementSources
         rebalancing/simple_rebalancer.cpp
         rebalancing/advanced_rebalancer.cpp
         deterministic/deterministic_label_propagation.cpp
+        deterministic/deterministic_jet_refiner.cpp
         flows/refiner_adapter.cpp
         flows/problem_construction.cpp
         flows/scheduler.cpp

--- a/mt-kahypar/partition/refinement/CMakeLists.txt
+++ b/mt-kahypar/partition/refinement/CMakeLists.txt
@@ -7,6 +7,7 @@ set(RefinementSources
         label_propagation/label_propagation_refiner.cpp
         rebalancing/simple_rebalancer.cpp
         rebalancing/advanced_rebalancer.cpp
+        rebalancing/deterministic_rebalancer.cpp
         deterministic/deterministic_label_propagation.cpp
         deterministic/deterministic_jet_refiner.cpp
         flows/refiner_adapter.cpp

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.cpp
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.cpp
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Robert Krause <robert.krause@student.kit.edu>
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h"
+
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
+
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/partition/metrics.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/utils/randomize.h"
+#include "mt-kahypar/utils/utilities.h"
+#include "mt-kahypar/utils/timer.h"
+#include "mt-kahypar/utils/cast.h"
+#include "mt-kahypar/datastructures/streaming_vector.h"
+
+
+namespace mt_kahypar {
+
+template<typename GraphAndGainTypes>
+bool DeterministicJetRefiner<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                            const vec<HypernodeID>& refinement_nodes,
+                                                            Metrics& best_metrics,
+                                                            const double time_limit) {
+    if (!refinement_nodes.empty()) {
+        throw UnsupportedOperationException("Deterministic Jet does not support local refinement");
+    }
+
+    utils::Timer& timer = utils::Utilities::instance().getTimer(_context.utility_id);
+    Metrics current_metrics = best_metrics;
+    PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
+    const HyperedgeWeight input_quality = best_metrics.quality;
+    bool was_already_balanced = metrics::isBalanced(phg, _context);
+
+    resizeDataStructuresForCurrentK();
+
+    auto afterburner = [&](const HypernodeID hn, auto add_node_fn) {
+        const PartitionID from = phg.partID(hn);
+        const auto [gain, to] = _gains_and_target[hn];
+        Gain total_gain = 0;
+        for (const HyperedgeID& he : phg.incidentEdges(hn)) {
+            HypernodeID pin_count_in_from_part_after = 0;
+            HypernodeID pin_count_in_to_part_after = 1;
+            for (const HypernodeID& pin : phg.pins(he)) {
+                if (pin != hn) {
+                    // Jet uses an order based on the precomputed gain values:
+                    // If the precomputed gain of another node is better than for the current node
+                    // (or the gain is equal and the id is smaller), we assume the node is already
+                    // moved to its target part.
+                    auto [gain_p, to_p] = _gains_and_target[pin];
+                    PartitionID part = (gain_p < gain || (gain_p == gain && pin < hn)) ? to_p : phg.partID(pin);
+                    if (part == from) {
+                        pin_count_in_from_part_after++;
+                    } else if (part == to) {
+                        pin_count_in_to_part_after++;
+                    }
+                }
+            }
+            SynchronizedEdgeUpdate sync_update;
+            sync_update.he = he;
+            sync_update.edge_weight = phg.edgeWeight(he);
+            sync_update.edge_size = phg.edgeSize(he);
+            sync_update.pin_count_in_from_part_after = pin_count_in_from_part_after;
+            sync_update.pin_count_in_to_part_after = pin_count_in_to_part_after;
+            total_gain += AttributedGains::gain(sync_update);
+        }
+
+        if (total_gain <= 0) {
+            add_node_fn();
+            _locks.set(hn);
+        }
+    };
+    _current_partition_is_best = true;
+    size_t rounds_without_improvement = 0;
+    const size_t max_rounds = _context.refinement.jet.fixed_n_iterations;
+    const size_t max_rounds_without_improvement = _context.refinement.jet.num_iterations;
+    for (size_t i = 0; rounds_without_improvement < max_rounds_without_improvement && (max_rounds == 0 || i < max_rounds); ++i) {
+        if (_current_partition_is_best) {
+            phg.doParallelForAllNodes([&](const HypernodeID hn) {
+                _best_partition[hn] = phg.partID(hn);
+            });
+        }
+
+        HEAVY_REFINEMENT_ASSERT(noInvalidPartitions(phg, _best_partition));
+        timer.start_timer("active_nodes", "Active Nodes");
+        computeActiveNodesFromGraph(phg);
+        timer.stop_timer("active_nodes");
+        HEAVY_REFINEMENT_ASSERT(arePotentialMovesToOtherParts(phg, _active_nodes), "active nodes");
+
+        // label prop round
+        timer.start_timer("afterburner", "Afterburner");
+        _locks.reset();
+        _tmp_active_nodes.clear_sequential();
+        tbb::parallel_for(UL(0), _active_nodes.size(), [&](size_t j) {
+            const auto n = _active_nodes[j];
+            afterburner(n, [&] {_tmp_active_nodes.stream(n);});
+        });
+        _moves = _tmp_active_nodes.copy_parallel();
+        HEAVY_REFINEMENT_ASSERT(arePotentialMovesToOtherParts(phg, _moves), "moves");
+        timer.stop_timer("afterburner");
+
+        // Apply all moves
+        timer.start_timer("apply_moves", "Apply Moves");
+
+        auto range = tbb::blocked_range<size_t>(UL(0), _moves.size());
+        auto accum = [&](const tbb::blocked_range<size_t>& r, const Gain& init) -> Gain {
+            Gain my_gain = init;
+            for (size_t i = r.begin(); i < r.end(); ++i) {
+                my_gain += performMoveWithAttributedGain(phg, _moves[i]);
+            }
+            return my_gain;
+        };
+        Gain gain = tbb::parallel_reduce(range, 0, accum, std::plus<>());
+        timer.stop_timer("apply moves");
+
+        current_metrics.quality -= gain;
+        current_metrics.imbalance = metrics::imbalance(phg, _context);
+        HEAVY_REFINEMENT_ASSERT(current_metrics.quality == metrics::quality(phg, _context, false),
+            V(current_metrics.quality) << V(metrics::quality(phg, _context, false)));
+
+        // rebalance
+        if (!metrics::isBalanced(phg, _context)) {
+            DBG << "[JET] starting rebalancing with quality " << current_metrics.quality << " and imbalance " << current_metrics.imbalance;
+            timer.start_timer("rebalance", "Rebalance");
+            mt_kahypar_partitioned_hypergraph_t part_hg = utils::partitioned_hg_cast(phg);
+            _rebalancer.refine(part_hg, {}, current_metrics, time_limit);
+            current_metrics.imbalance = metrics::imbalance(phg, _context);
+            timer.stop_timer("rebalance");
+            DBG << "[JET] finished rebalancing with quality " << current_metrics.quality << " and imbalance " << current_metrics.imbalance;
+        }
+
+        ASSERT(current_metrics.quality == metrics::quality(phg, _context, false), V(current_metrics.quality) << V(metrics::quality(phg, _context, false)));
+        ++rounds_without_improvement;
+
+        // if the parition was ever balanced => look for balanced partition with better quality
+        // if the partition was never balanced => look for less imbalanced partition regardless of quality
+        const bool is_balanced = metrics::isBalanced(phg, _context);
+        if ((current_metrics.quality < best_metrics.quality && was_already_balanced && is_balanced) || (!was_already_balanced && current_metrics.imbalance < best_metrics.imbalance)) {
+            if (best_metrics.quality - current_metrics.quality > _context.refinement.jet.relative_improvement_threshold * best_metrics.quality) {
+                rounds_without_improvement = 0;
+            }
+            best_metrics = current_metrics;
+            _current_partition_is_best = true;
+            was_already_balanced |= is_balanced;
+        } else {
+            _current_partition_is_best = false;
+        }
+        DBG << "[JET] Finished iteration " << i << " with quality " << current_metrics.quality << " and imbalance " << current_metrics.imbalance;
+    }
+
+    if (!_current_partition_is_best) {
+        DBG << "[JET] Rollback to best partition with value " << best_metrics.quality;
+        rollbackToBestPartition(phg);
+    }
+    HEAVY_REFINEMENT_ASSERT(best_metrics.quality == metrics::quality(phg, _context, false),
+        V(best_metrics.quality) << V(metrics::quality(phg, _context, false)));
+    return best_metrics.quality < input_quality;
+}
+
+
+template<typename GraphAndGainTypes>
+void DeterministicJetRefiner<GraphAndGainTypes>::computeActiveNodesFromGraph(const PartitionedHypergraph& phg) {
+    const bool top_level = (phg.initialNumNodes() == _top_level_num_nodes);
+    _active_nodes.clear();
+    _tmp_active_nodes.clear_sequential();
+
+    // compute gain for every node 
+    phg.doParallelForAllNodes([&](const HypernodeID& hn) {
+        const bool is_locked = _locks[hn];
+        if (!phg.isBorderNode(hn) || is_locked || phg.isFixed(hn)) {
+            _gains_and_target[hn] = { 0, phg.partID(hn) };
+        } else {
+            const double gain_factor = top_level ? _context.refinement.jet.negative_gain_factor_fine :
+                _context.refinement.jet.negative_gain_factor_coarse;
+            RatingMap& tmp_scores = _gain_computation.localScores();
+            Gain isolated_block_gain = 0;
+            _gain_computation.precomputeGains(phg, hn, tmp_scores, isolated_block_gain, true);
+            // Note: rebalance=true is important here to allow negative gain moves
+            Move best_move = _gain_computation.computeMaxGainMoveForScores(phg, tmp_scores, isolated_block_gain, hn,
+                /*rebalance=*/true,
+                /*consider_non_adjacent_blocks=*/false,
+                /*allow_imbalance=*/true);
+            tmp_scores.clear();
+            bool accept_node = (best_move.gain <= 0 || best_move.gain < std::floor(gain_factor * isolated_block_gain))
+                && best_move.to != phg.partID(hn);
+            if (accept_node) {
+                _gains_and_target[hn] = { best_move.gain, best_move.to };
+                _tmp_active_nodes.stream(hn);
+            } else {
+                _gains_and_target[hn] = { 0, phg.partID(hn) };
+            }
+        }
+    });
+    _active_nodes = _tmp_active_nodes.copy_parallel();
+}
+
+template <typename GraphAndGainTypes>
+void DeterministicJetRefiner<GraphAndGainTypes>::initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg) {
+    _rebalancer.initialize(phg);
+}
+
+template<typename GraphAndGainTypes>
+Gain DeterministicJetRefiner<GraphAndGainTypes>::performMoveWithAttributedGain(PartitionedHypergraph& phg, const HypernodeID hn) {
+    const auto from = phg.partID(hn);
+    const auto [gain, to] = _gains_and_target[hn];
+    Gain attributed_gain = 0;
+    auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
+        attributed_gain -= AttributedGains::gain(sync_update);
+    };
+    ASSERT(to >= 0 && to < _current_k);
+    changeNodePart(phg, hn, from, to, objective_delta);
+    return attributed_gain;
+}
+
+template <typename GraphAndGainTypes>
+void DeterministicJetRefiner<GraphAndGainTypes>::rollbackToBestPartition(PartitionedHypergraph& phg) {
+    // This function is passed as lambda to the changeNodePart function and used
+    // to calculate the "real" delta of a move (in terms of the used objective function).
+    auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
+        _gain_computation.computeDeltaForHyperedge(sync_update);
+    };
+
+    auto reset_node = [&](const HypernodeID hn) {
+        const PartitionID part_id = phg.partID(hn);
+        if (part_id != _best_partition[hn]) {
+            ASSERT(_best_partition[hn] != kInvalidPartition);
+            ASSERT(_best_partition[hn] >= 0 && _best_partition[hn] < _current_k);
+            changeNodePart(phg, hn, part_id, _best_partition[hn], objective_delta);
+        }
+    };
+    phg.doParallelForAllNodes(reset_node);
+    _current_partition_is_best = true;
+}
+
+template <typename GraphAndGainTypes>
+template<typename F>
+void DeterministicJetRefiner<GraphAndGainTypes>::changeNodePart(PartitionedHypergraph& phg,
+                                                                const HypernodeID hn,
+                                                                const PartitionID from,
+                                                                const PartitionID to,
+                                                                const F& objective_delta) {
+    constexpr HypernodeWeight inf_weight = std::numeric_limits<HypernodeWeight>::max();
+    const bool success = phg.changeNodePart(hn, from, to, inf_weight, [] {}, objective_delta);
+    ASSERT(success);
+    unused(success);
+}
+
+template <typename GraphAndGainTypes>
+bool DeterministicJetRefiner<GraphAndGainTypes>::arePotentialMovesToOtherParts(const PartitionedHypergraph& phg, const parallel::scalable_vector<HypernodeID>& moves) {
+    for (auto hn : moves) {
+        const auto [gain, to] = _gains_and_target[hn];
+        if (to == phg.partID(hn)) {
+            DBG << "Trying to move node " << hn << " to own part expecting gain " << gain;
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename GraphAndGainTypes>
+bool DeterministicJetRefiner<GraphAndGainTypes>::noInvalidPartitions(const PartitionedHypergraph& phg, const parallel::scalable_vector<PartitionID>& parts) {
+    phg.doParallelForAllNodes([&](const HypernodeID hn) {
+        ASSERT(parts[hn] != kInvalidPartition);
+        ASSERT(parts[hn] < _current_k);
+        unused(hn);
+    });
+    unused(parts);
+    return true;
+}
+
+template <typename GraphAndGainTypes>
+void DeterministicJetRefiner<GraphAndGainTypes>::resizeDataStructuresForCurrentK() {
+    // If the number of blocks changes, we resize data structures
+    // (can happen during deep multilevel partitioning)
+    if (_current_k != _context.partition.k) {
+        _current_k = _context.partition.k;
+        _gain_computation.changeNumberOfBlocks(_current_k);
+    }
+}
+
+namespace {
+#define DETERMINISTIC_JET_REFINER(X) DeterministicJetRefiner<X>
+}
+
+
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(DETERMINISTIC_JET_REFINER)
+}; // namespace

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -67,6 +67,8 @@ public:
     _current_k(context.partition.k),
     _top_level_num_nodes(num_hypernodes),
     _current_partition_is_best(true),
+    _was_already_balanced(false),
+    _negative_gain_factor(0.0),
     _active_nodes(),
     _tmp_active_nodes(),
     _moves(),
@@ -91,6 +93,8 @@ private:
                   Metrics& best_metrics, double) final;
 
   void initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg);
+
+  void runJetRounds(PartitionedHypergraph& phg, Metrics& best_metrics, double time_limit);
 
   void computeActiveNodesFromGraph(const PartitionedHypergraph& hypergraph);
 
@@ -123,6 +127,8 @@ private:
   PartitionID _current_k;
   HypernodeID _top_level_num_nodes;
   bool _current_partition_is_best;
+  bool _was_already_balanced;
+  double _negative_gain_factor;
   ActiveNodes _active_nodes;
   ds::StreamingVector<HypernodeID> _tmp_active_nodes;
   parallel::scalable_vector<HypernodeID> _moves;

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -71,6 +71,7 @@ public:
     _tmp_active_nodes(),
     _moves(),
     _best_partition(num_hypernodes, kInvalidPartition),
+    _part_before_round(num_hypernodes, kInvalidPartition),
     _gains_and_target(num_hypernodes),
     _locks(num_hypernodes),
     _gain_computation(context, true /* disable_randomization */),
@@ -99,6 +100,8 @@ private:
                       const PartitionID to,
                       const F& objective_delta);
 
+  HyperedgeWeight calculateGainDelta(const PartitionedHypergraph& phg) const;
+
   void recomputePenalties(const PartitionedHypergraph& hypergraph, bool did_rebalance);
 
   bool arePotentialMovesToOtherParts(const PartitionedHypergraph& hypergraph, const parallel::scalable_vector<HypernodeID>& moves);
@@ -115,6 +118,7 @@ private:
   ds::StreamingVector<HypernodeID> _tmp_active_nodes;
   parallel::scalable_vector<HypernodeID> _moves;
   parallel::scalable_vector<PartitionID> _best_partition;
+  parallel::scalable_vector<PartitionID> _part_before_round;
   parallel::scalable_vector<std::pair<Gain, PartitionID>> _gains_and_target;
   kahypar::ds::FastResetFlagArray<> _locks;
   GainComputation _gain_computation;

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -61,7 +61,7 @@ public:
   explicit DeterministicJetRefiner(const HypernodeID num_hypernodes,
                                    const HyperedgeID num_hyperedges,
                                    const Context& context,
-                                   GainCache&,
+                                   GainCache& gain_cache,
                                    IRebalancer& rebalancer) :
     _context(context),
     _current_k(context.partition.k),
@@ -76,6 +76,7 @@ public:
     _part_before_round(num_hypernodes, kInvalidPartition),
     _gains_and_target(num_hypernodes),
     _locks(num_hypernodes),
+    _gain_cache(gain_cache),
     _gain_computation(context, true /* disable_randomization */),
     _rebalancer(rebalancer),
     _afterburner_gain(PartitionedHypergraph::is_graph ? 0 : num_hypernodes),
@@ -134,6 +135,7 @@ private:
   parallel::scalable_vector<PartitionID> _part_before_round;
   parallel::scalable_vector<std::pair<Gain, PartitionID>> _gains_and_target;
   kahypar::ds::FastResetFlagArray<> _locks;
+  GainCache& _gain_cache;
   GainComputation _gain_computation;
   IRebalancer& _rebalancer;
 

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Robert Krause <robert.krause@student.kit.edu>
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+
+#pragma once
+
+#include "mt-kahypar/datastructures/streaming_vector.h"
+#include "mt-kahypar/parallel/stl/scalable_vector.h"
+#include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/refinement/i_refiner.h"
+#include "mt-kahypar/partition/refinement/i_rebalancer.h"
+#include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
+#include "mt-kahypar/utils/reproducible_random.h"
+
+namespace mt_kahypar {
+
+template<typename GraphAndGainTypes>
+class DeterministicJetRefiner final : public IRefiner {
+
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainComputation = typename GraphAndGainTypes::GainComputation;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using ActiveNodes = typename parallel::scalable_vector<HypernodeID>;
+  using RatingMap = typename GainComputation::RatingMap;
+
+public:
+
+  explicit DeterministicJetRefiner(const HypernodeID num_hypernodes,
+                                   const HyperedgeID num_hyperedges,
+                                   const Context& context,
+                                   gain_cache_t gain_cache,
+                                   IRebalancer& rebalancer) :
+    DeterministicJetRefiner(num_hypernodes, num_hyperedges, context,
+      GainCachePtr::cast<GainCache>(gain_cache), rebalancer) {}
+
+  explicit DeterministicJetRefiner(const HypernodeID num_hypernodes,
+                                   const HyperedgeID,
+                                   const Context& context,
+                                   GainCache&,
+                                   IRebalancer& rebalancer) :
+    _context(context),
+    _current_k(context.partition.k),
+    _top_level_num_nodes(num_hypernodes),
+    _current_partition_is_best(true),
+    _active_nodes(),
+    _tmp_active_nodes(),
+    _moves(),
+    _best_partition(num_hypernodes, kInvalidPartition),
+    _gains_and_target(num_hypernodes),
+    _locks(num_hypernodes),
+    _gain_computation(context, true /* disable_randomization */),
+    _rebalancer(rebalancer) {}
+
+private:
+  static constexpr bool debug = false;
+  static constexpr bool enable_heavy_assert = false;
+
+  bool refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                  const vec<HypernodeID>&,
+                  Metrics& best_metrics, double) final;
+
+  void initializeImpl(mt_kahypar_partitioned_hypergraph_t& phg);
+
+  void computeActiveNodesFromGraph(const PartitionedHypergraph& hypergraph);
+
+  Gain performMoveWithAttributedGain(PartitionedHypergraph& phg, const HypernodeID hn);
+
+  void rollbackToBestPartition(PartitionedHypergraph& hypergraph);
+
+  template<typename F>
+  void changeNodePart(PartitionedHypergraph& phg,
+                      const HypernodeID hn,
+                      const PartitionID from,
+                      const PartitionID to,
+                      const F& objective_delta);
+
+  void recomputePenalties(const PartitionedHypergraph& hypergraph, bool did_rebalance);
+
+  bool arePotentialMovesToOtherParts(const PartitionedHypergraph& hypergraph, const parallel::scalable_vector<HypernodeID>& moves);
+
+  bool noInvalidPartitions(const PartitionedHypergraph& phg, const parallel::scalable_vector<PartitionID>& parts);
+
+  void resizeDataStructuresForCurrentK();
+
+  const Context& _context;
+  PartitionID _current_k;
+  HypernodeID _top_level_num_nodes;
+  bool _current_partition_is_best;
+  ActiveNodes _active_nodes;
+  ds::StreamingVector<HypernodeID> _tmp_active_nodes;
+  parallel::scalable_vector<HypernodeID> _moves;
+  parallel::scalable_vector<PartitionID> _best_partition;
+  parallel::scalable_vector<std::pair<Gain, PartitionID>> _gains_and_target;
+  kahypar::ds::FastResetFlagArray<> _locks;
+  GainComputation _gain_computation;
+  IRebalancer& _rebalancer;
+};
+
+}

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -75,7 +75,10 @@ public:
     _gains_and_target(num_hypernodes),
     _locks(num_hypernodes),
     _gain_computation(context, true /* disable_randomization */),
-    _rebalancer(rebalancer) {}
+    _rebalancer(rebalancer),
+    _afterburner_gain(PartitionedHypergraph::is_graph ? 0 : num_hypernodes),
+    _afterburner_buffer(PartitionedHypergraph::is_graph ? 0 : _current_k, 0),
+    _hyperedge_buffer()  {}
 
 private:
   static constexpr bool debug = false;
@@ -100,6 +103,10 @@ private:
                       const PartitionID to,
                       const F& objective_delta);
 
+  void graphAfterburner(const PartitionedHypergraph& phg);
+
+  void hypergraphAfterburner(const PartitionedHypergraph& phg);
+
   HyperedgeWeight calculateGainDelta(const PartitionedHypergraph& phg) const;
 
   void recomputePenalties(const PartitionedHypergraph& hypergraph, bool did_rebalance);
@@ -123,6 +130,11 @@ private:
   kahypar::ds::FastResetFlagArray<> _locks;
   GainComputation _gain_computation;
   IRebalancer& _rebalancer;
+
+  // hypergraph afterburner
+  parallel::scalable_vector<std::atomic<Gain>> _afterburner_gain;
+  tbb::enumerable_thread_specific<std::vector<size_t>> _afterburner_buffer;
+  tbb::enumerable_thread_specific<std::vector<HypernodeID>> _hyperedge_buffer;
 };
 
 }

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -59,7 +59,7 @@ public:
       GainCachePtr::cast<GainCache>(gain_cache), rebalancer) {}
 
   explicit DeterministicJetRefiner(const HypernodeID num_hypernodes,
-                                   const HyperedgeID,
+                                   const HyperedgeID num_hyperedges,
                                    const Context& context,
                                    GainCache&,
                                    IRebalancer& rebalancer) :
@@ -78,7 +78,9 @@ public:
     _rebalancer(rebalancer),
     _afterburner_gain(PartitionedHypergraph::is_graph ? 0 : num_hypernodes),
     _afterburner_buffer(PartitionedHypergraph::is_graph ? 0 : _current_k, 0),
-    _hyperedge_buffer()  {}
+    _hyperedge_buffer(),
+    _edge_flag(num_hyperedges),
+    _current_edge_flag(1) {}
 
 private:
   static constexpr bool debug = false;
@@ -135,6 +137,9 @@ private:
   parallel::scalable_vector<std::atomic<Gain>> _afterburner_gain;
   tbb::enumerable_thread_specific<std::vector<size_t>> _afterburner_buffer;
   tbb::enumerable_thread_specific<std::vector<HypernodeID>> _hyperedge_buffer;
+  // incident edges in hypergraph afterburner
+  parallel::scalable_vector<std::atomic<size_t>> _edge_flag;
+  size_t _current_edge_flag;
 };
 
 }

--- a/mt-kahypar/partition/refinement/fm/sequential_twoway_fm_refiner.cpp
+++ b/mt-kahypar/partition/refinement/fm/sequential_twoway_fm_refiner.cpp
@@ -296,8 +296,9 @@ void SequentialTwoWayFmRefiner<TypeTraits>::rollback(const parallel::scalable_ve
     const HypernodeID hn = performed_moves[i];
     const PartitionID from = _phg.partID(hn);
     const PartitionID to = 1 - from;
-    _phg.changeNodePart(hn, from, to);
+    _phg.changeNodePartNoSync(hn, from, to);
   }
+  _phg.resetEdgeSynchronization();
 }
 
 template<typename TypeTraits>

--- a/mt-kahypar/partition/refinement/gains/cut/cut_attributed_gains.h
+++ b/mt-kahypar/partition/refinement/gains/cut/cut_attributed_gains.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/refinement/gains/cut/cut_gain_cache.cpp
+++ b/mt-kahypar/partition/refinement/gains/cut/cut_gain_cache.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/cut/cut_gain_cache.h
+++ b/mt-kahypar/partition/refinement/gains/cut/cut_gain_cache.h
@@ -30,6 +30,7 @@
 
 #include "mt-kahypar/partition/context_enum_classes.h"
 #include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/datastructures/array.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"

--- a/mt-kahypar/partition/refinement/gains/cut/cut_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/cut/cut_gain_computation.h
@@ -39,11 +39,12 @@ namespace mt_kahypar {
 
 class CutGainComputation : public GainComputationBase<CutGainComputation, CutAttributedGains> {
   using Base = GainComputationBase<CutGainComputation, CutAttributedGains>;
-  using RatingMap = typename Base::RatingMap;
 
   static constexpr bool enable_heavy_assert = false;
 
  public:
+  using RatingMap = typename Base::RatingMap;
+
   CutGainComputation(const Context& context,
                      bool disable_randomization = false) :
     Base(context, disable_randomization) { }

--- a/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_attributed_gains_for_graphs.h
+++ b/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_attributed_gains_for_graphs.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_gain_cache_for_graphs.cpp
+++ b/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_gain_cache_for_graphs.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_gain_cache_for_graphs.h
+++ b/mt-kahypar/partition/refinement/gains/cut_for_graphs/cut_gain_cache_for_graphs.h
@@ -32,6 +32,7 @@
 #include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "mt-kahypar/datastructures/array.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/macros.h"
 #include "mt-kahypar/utils/range.h"

--- a/mt-kahypar/partition/refinement/gains/gain_computation_base.h
+++ b/mt-kahypar/partition/refinement/gains/gain_computation_base.h
@@ -47,6 +47,7 @@ class GainComputationBase {
  public:
   using RatingMap = ds::SparseMap<PartitionID, Gain>;
   using TmpScores = tbb::enumerable_thread_specific<RatingMap>;
+  using Penalty = tbb::enumerable_thread_specific<Gain>;
 
   GainComputationBase(const Context& context,
                       const bool disable_randomization) :
@@ -55,7 +56,8 @@ class GainComputationBase {
     _deltas(0),
     _tmp_scores([&] {
       return constructLocalTmpScores();
-    }) { }
+    }),
+    _isolated_block_gain(0) { }
 
   template<typename PartitionedHypergraph>
   Move computeMaxGainMove(const PartitionedHypergraph& phg,
@@ -65,8 +67,25 @@ class GainComputationBase {
                           const bool allow_imbalance = false) {
     Derived* derived = static_cast<Derived*>(this);
     RatingMap& tmp_scores = _tmp_scores.local();
-    Gain isolated_block_gain = 0;
+    Gain& isolated_block_gain = _isolated_block_gain.local();
     derived->precomputeGains(phg, hn, tmp_scores, isolated_block_gain, consider_non_adjacent_blocks);
+    Move best_move = computeMaxGainMoveForScores(phg, tmp_scores, isolated_block_gain, hn,
+                        rebalance, consider_non_adjacent_blocks, allow_imbalance);
+
+    isolated_block_gain = 0;
+    tmp_scores.clear();
+    return best_move;
+  }
+
+  template<typename PartitionedHypergraph>
+  Move computeMaxGainMoveForScores(const PartitionedHypergraph& phg,
+                                   const RatingMap& tmp_scores,
+                                   const Gain isolated_block_gain,
+                                   const HypernodeID hn,
+                                   const bool rebalance = false,
+                                   const bool consider_non_adjacent_blocks = false,
+                                   const bool allow_imbalance = false) {
+    Derived* derived = static_cast<Derived*>(this);
 
     PartitionID from = phg.partID(hn);
     Move best_move { from, from, hn, rebalance ? std::numeric_limits<Gain>::max() : 0 };
@@ -119,12 +138,16 @@ class GainComputationBase {
       }
     }
 
-    tmp_scores.clear();
     return best_move;
   }
 
   inline void computeDeltaForHyperedge(const SynchronizedEdgeUpdate& sync_update) {
     _deltas.local() += AttributedGains::gain(sync_update);
+  }
+
+  // ! Returns the local rating map for block scores
+  RatingMap& localScores() {
+    return _tmp_scores.local();
   }
 
   // ! Returns the delta in the objective function for all moves
@@ -170,6 +193,7 @@ private:
   const bool _disable_randomization;
   DeltaGain _deltas;
   TmpScores _tmp_scores;
+  Penalty _isolated_block_gain;
 };
 
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/gains/km1/km1_attributed_gains.h
+++ b/mt-kahypar/partition/refinement/gains/km1/km1_attributed_gains.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/refinement/gains/km1/km1_gain_cache.cpp
+++ b/mt-kahypar/partition/refinement/gains/km1/km1_gain_cache.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/km1/km1_gain_cache.h
+++ b/mt-kahypar/partition/refinement/gains/km1/km1_gain_cache.h
@@ -34,6 +34,7 @@
 #include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "mt-kahypar/datastructures/array.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/macros.h"
 #include "mt-kahypar/utils/range.h"

--- a/mt-kahypar/partition/refinement/gains/km1/km1_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/km1/km1_gain_computation.h
@@ -37,11 +37,12 @@ namespace mt_kahypar {
 
 class Km1GainComputation : public GainComputationBase<Km1GainComputation, Km1AttributedGains> {
   using Base = GainComputationBase<Km1GainComputation, Km1AttributedGains>;
-  using RatingMap = typename Base::RatingMap;
 
   static constexpr bool enable_heavy_assert = false;
 
  public:
+  using RatingMap = typename Base::RatingMap;
+
   Km1GainComputation(const Context& context,
                      bool disable_randomization = false) :
     Base(context, disable_randomization) { }

--- a/mt-kahypar/partition/refinement/gains/soed/soed_attributed_gains.h
+++ b/mt-kahypar/partition/refinement/gains/soed/soed_attributed_gains.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 
 namespace mt_kahypar {
 

--- a/mt-kahypar/partition/refinement/gains/soed/soed_gain_cache.cpp
+++ b/mt-kahypar/partition/refinement/gains/soed/soed_gain_cache.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/soed/soed_gain_cache.h
+++ b/mt-kahypar/partition/refinement/gains/soed/soed_gain_cache.h
@@ -34,6 +34,7 @@
 #include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "mt-kahypar/datastructures/array.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/macros.h"
 #include "mt-kahypar/utils/range.h"

--- a/mt-kahypar/partition/refinement/gains/soed/soed_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/soed/soed_gain_computation.h
@@ -37,11 +37,12 @@ namespace mt_kahypar {
 
 class SoedGainComputation : public GainComputationBase<SoedGainComputation, SoedAttributedGains> {
   using Base = GainComputationBase<SoedGainComputation, SoedAttributedGains>;
-  using RatingMap = typename Base::RatingMap;
 
   static constexpr bool enable_heavy_assert = false;
 
  public:
+  using RatingMap = typename Base::RatingMap;
+
   SoedGainComputation(const Context& context,
                       bool disable_randomization = false) :
     Base(context, disable_randomization) { }

--- a/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_attributed_gains.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_attributed_gains.h
@@ -28,6 +28,7 @@
 
 #include "mt-kahypar/datastructures/hypergraph_common.h"
 #include "mt-kahypar/datastructures/static_bitset.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/partition/mapping/target_graph.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_cache.cpp
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_cache.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_cache.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_cache.h
@@ -40,6 +40,7 @@
 #include "mt-kahypar/datastructures/static_bitset.h"
 #include "mt-kahypar/datastructures/connectivity_set.h"
 #include "mt-kahypar/datastructures/delta_connectivity_set.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/macros.h"
 #include "mt-kahypar/utils/range.h"

--- a/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_computation.h
@@ -41,12 +41,13 @@ namespace mt_kahypar {
 
 class SteinerTreeGainComputation : public GainComputationBase<SteinerTreeGainComputation, SteinerTreeAttributedGains> {
   using Base = GainComputationBase<SteinerTreeGainComputation, SteinerTreeAttributedGains>;
-  using RatingMap = typename Base::RatingMap;
 
   static constexpr bool enable_heavy_assert = false;
   static constexpr size_t BITS_PER_BLOCK = ds::StaticBitset::BITS_PER_BLOCK;
 
  public:
+  using RatingMap = typename Base::RatingMap;
+
   SteinerTreeGainComputation(const Context& context,
                                 bool disable_randomization = false) :
     Base(context, disable_randomization),

--- a/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_cache_for_graphs.cpp
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_cache_for_graphs.cpp
@@ -30,6 +30,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/concurrent_vector.h>
 
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/definitions.h"
 
 namespace mt_kahypar {

--- a/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_cache_for_graphs.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_cache_for_graphs.h
@@ -42,6 +42,7 @@
 #include "mt-kahypar/datastructures/static_bitset.h"
 #include "mt-kahypar/datastructures/connectivity_set.h"
 #include "mt-kahypar/datastructures/delta_connectivity_set.h"
+#include "mt-kahypar/datastructures/synchronized_edge_update.h"
 #include "mt-kahypar/parallel/atomic_wrapper.h"
 #include "mt-kahypar/macros.h"
 #include "mt-kahypar/utils/range.h"

--- a/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_computation_for_graphs.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_computation_for_graphs.h
@@ -41,12 +41,13 @@ namespace mt_kahypar {
 
 class GraphSteinerTreeGainComputation : public GainComputationBase<GraphSteinerTreeGainComputation, GraphSteinerTreeAttributedGains> {
   using Base = GainComputationBase<GraphSteinerTreeGainComputation, GraphSteinerTreeAttributedGains>;
-  using RatingMap = typename Base::RatingMap;
 
   static constexpr bool enable_heavy_assert = false;
   static constexpr size_t BITS_PER_BLOCK = ds::StaticBitset::BITS_PER_BLOCK;
 
  public:
+  using RatingMap = typename Base::RatingMap;
+
   GraphSteinerTreeGainComputation(const Context& context,
                                      bool disable_randomization = false) :
     Base(context, disable_randomization),

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
@@ -30,9 +30,9 @@
 #include <tbb/parallel_for_each.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
-#include <tbb/parallel_sort.h>
 
 #include "mt-kahypar/definitions.h"
+#include "mt-kahypar/parallel/scalable_sort.h"
 #include "mt-kahypar/partition/metrics.h"
 #include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
 #include "mt-kahypar/utils/cast.h"
@@ -161,7 +161,7 @@ void DeterministicRebalancer<GraphAndGainTypes>::weakRebalancingRound(Partitione
       ASSERT(_moves[part].size() > 0);
 
       // sort the moves from each overweight part by priority
-      tbb::parallel_sort(_moves[part].begin(), _moves[part].end(), [&](const rebalancer::RebalancingMove& a, const rebalancer::RebalancingMove& b) {
+      parallel::scalable_sort(_moves[part], [](const rebalancer::RebalancingMove& a, const rebalancer::RebalancingMove& b) {
         return a.priority < b.priority || (a.priority == b.priority && a.hn > b.hn);
       });
 

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Robert Krause <robert.krause@student.kit.edu>
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h"
+
+#include <tbb/parallel_for_each.h>
+#include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_sort.h>
+
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/partition/metrics.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/utils/cast.h"
+
+namespace mt_kahypar {
+static constexpr size_t ABSOLUTE_MAX_ROUNDS = 30;
+
+static float transformGain(Gain gain_, HypernodeWeight wu) {
+  float gain = gain_;
+  if (gain > 0) {
+    gain /= wu;
+  } else if (gain < 0) {
+    gain *= wu;
+  }
+  return gain;
+}
+
+template <typename GraphAndGainTypes>
+bool DeterministicRebalancer<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                            const vec<HypernodeID>&,
+                                                            Metrics& best_metrics,
+                                                            double) {
+  PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
+  resizeDataStructuresForCurrentK();
+  updateImbalance(phg);
+  _gain_computation.reset();
+
+  size_t iteration = 0;
+  const size_t max_rounds = _context.refinement.rebalancing.det_max_rounds == 0 ? ABSOLUTE_MAX_ROUNDS : std::min(ABSOLUTE_MAX_ROUNDS, _context.refinement.rebalancing.det_max_rounds);
+  while (_num_imbalanced_parts > 0 && iteration < max_rounds) {
+    weakRebalancingRound(phg);
+    ASSERT(checkPreviouslyOverweightParts(phg));
+    updateImbalance(phg);
+    ++iteration;
+  }
+
+  Gain delta = _gain_computation.delta();
+  HEAVY_REFINEMENT_ASSERT(best_metrics.quality + delta == metrics::quality(phg, _context),
+    V(best_metrics.quality) << V(delta) << V(metrics::quality(phg, _context)));
+  best_metrics.quality += delta;
+  best_metrics.imbalance = metrics::imbalance(phg, _context);
+  return delta < 0;
+}
+
+template <typename  GraphAndGainTypes>
+void DeterministicRebalancer<GraphAndGainTypes>::updateImbalance(const PartitionedHypergraph& phg) {
+  _num_imbalanced_parts = 0;
+  for (PartitionID part = 0; part < _context.partition.k; ++part) {
+    if (imbalance(phg, part) > 0) {
+      ++_num_imbalanced_parts;
+    }
+  }
+}
+
+template <typename GraphAndGainTypes>
+rebalancer::RebalancingMove DeterministicRebalancer<GraphAndGainTypes>::computeGainAndTargetPart(const PartitionedHypergraph& phg,
+                                                                                                 const HypernodeID hn,
+                                                                                                 bool non_adjacent_blocks) {
+  const HypernodeWeight hn_weight = phg.nodeWeight(hn);
+  RatingMap& tmp_scores = _gain_computation.localScores();
+  Gain isolated_block_gain = 0;
+  _gain_computation.precomputeGains(phg, hn, tmp_scores, isolated_block_gain, true);
+
+  Gain best_gain = isolated_block_gain;
+  PartitionID best_target = kInvalidPartition;
+  for (const auto& entry : tmp_scores) {
+    const PartitionID to = entry.key;
+    const Gain gain = _gain_computation.gain(entry.value, isolated_block_gain);
+    if (gain <= best_gain && isValidTarget(phg, to, hn_weight)) {
+      best_gain = gain;
+      best_target = to;
+    }
+  }
+
+  // if no adjacent block with free capacity exists, we need to consider non-adjacent blocks
+  if (non_adjacent_blocks && best_target == kInvalidPartition) {
+    // we start with a block that is chosen by random, to ensure a reasonable distribution of nodes
+    // to target blocks (note: this does not always result in a uniform distribution since some blocks
+    // are not an acceptable target, but it should be good enough)
+    const PartitionID start = hn % _current_k;
+    PartitionID to = start;
+    do {
+      if (isValidTarget(phg, to, hn_weight)
+        && !tmp_scores.contains(to)) {
+        best_target = to;
+        break;
+      }
+
+      ++to;
+      if (to == _current_k) {
+        to = 0;
+      }
+    } while (to != start);
+    ASSERT(best_target == kInvalidPartition || (best_target >= 0 && best_target < _current_k));
+  }
+  tmp_scores.clear();
+  return { hn, best_target, transformGain(best_gain, hn_weight) };
+}
+
+template <typename GraphAndGainTypes>
+void DeterministicRebalancer<GraphAndGainTypes>::weakRebalancingRound(PartitionedHypergraph& phg) {
+  ASSERT(_current_k == _context.partition.k && _current_k == phg.k());
+  for (auto& moves : _tmp_potential_moves) {
+    moves.clear_sequential();
+  }
+
+  // calculate gain and target for each node in a overweight part
+  // group moves by source part
+  phg.doParallelForAllNodes([&](const HypernodeID hn) {
+    const PartitionID from = phg.partID(hn);
+    const HypernodeWeight weight = phg.nodeWeight(hn);
+    if (imbalance(phg, from) > 0 && mayMoveNode(phg, from, weight) && !phg.isFixed(hn)) {
+      const auto triple = computeGainAndTargetPart(phg, hn, true);
+      if (from != triple.to && triple.to != kInvalidPartition) {
+        _tmp_potential_moves[from].stream(triple);
+      }
+    }
+  });
+
+  tbb::parallel_for(0, _current_k, [&](const PartitionID part) {
+    if (_tmp_potential_moves[part].size() > 0) {
+      _moves[part] = _tmp_potential_moves[part].copy_parallel();
+      ASSERT(_moves[part].size() > 0);
+
+      // sort the moves from each overweight part by priority
+      tbb::parallel_sort(_moves[part].begin(), _moves[part].end(), [&](const rebalancer::RebalancingMove& a, const rebalancer::RebalancingMove& b) {
+        return a.priority < b.priority || (a.priority == b.priority && a.hn > b.hn);
+      });
+
+      // calculate perfix sum for each source-part to know which moves to execute (prefix_sum > current_weight - max_weight)
+      _move_weights[part].resize(_moves[part].size());
+      tbb::parallel_for(0UL, _moves[part].size(), [&](const size_t j) {
+        _move_weights[part][j] = phg.nodeWeight(_moves[part][j].hn);
+      });
+      parallel_prefix_sum(_move_weights[part].begin(), _move_weights[part].end(), _move_weights[part].begin(), std::plus<HypernodeWeight>(), 0);
+      const size_t last_move_idx = std::upper_bound(_move_weights[part].begin(), _move_weights[part].end(), phg.partWeight(part) - _context.partition.max_part_weights[part] - 1) - _move_weights[part].begin();
+      tbb::parallel_for(0UL, last_move_idx + 1, [&](const size_t j) {
+        const auto move = _moves[part][j];
+        changeNodePart(phg, move.hn, part, move.to, false);
+      });
+    }
+  });
+}
+
+// explicitly instantiate so the compiler can generate them when compiling this cpp file
+namespace {
+#define DETERMINISTIC_REBALANCER(X) DeterministicRebalancer<X>
+}
+
+// explicitly instantiate so the compiler can generate them when compiling this cpp file
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(DETERMINISTIC_REBALANCER)
+}

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
@@ -69,12 +69,15 @@ bool DeterministicRebalancer<GraphAndGainTypes>::refineImpl(mt_kahypar_partition
     ++iteration;
   }
 
-  Gain delta = _gain_computation.delta();
-  HEAVY_REFINEMENT_ASSERT(best_metrics.quality + delta == metrics::quality(phg, _context),
-    V(best_metrics.quality) << V(delta) << V(metrics::quality(phg, _context)));
-  best_metrics.quality += delta;
+  if constexpr (!PartitionedHypergraph::is_graph) {
+    Gain delta = _gain_computation.delta();
+    HEAVY_REFINEMENT_ASSERT(best_metrics.quality + delta == metrics::quality(phg, _context),
+      V(best_metrics.quality) << V(delta) << V(metrics::quality(phg, _context)));
+    best_metrics.quality += delta;
+  }
+  phg.resetEdgeSynchronization();
   best_metrics.imbalance = metrics::imbalance(phg, _context);
-  return delta < 0;
+  return true;
 }
 
 template <typename  GraphAndGainTypes>

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -58,7 +58,7 @@ private:
     static constexpr bool enable_heavy_assert = false;
 
 public:
-    explicit DeterministicRebalancer(const Context& context) :
+    explicit DeterministicRebalancer(HypernodeID, const Context& context) :
         _context(context),
         _current_k(context.partition.k),
         _gain_computation(context),
@@ -66,11 +66,9 @@ public:
         _moves(context.partition.k),
         _move_weights(context.partition.k),
         _tmp_potential_moves(context.partition.k) {}
-    explicit DeterministicRebalancer(HypernodeID, const Context& context) :
-        DeterministicRebalancer(context) {}
 
-    explicit DeterministicRebalancer(HypernodeID, const Context& context, GainCache&) :
-        DeterministicRebalancer(context) {}
+    explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, GainCache&) :
+        DeterministicRebalancer(num_nodes, context) {}
 
     explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, gain_cache_t gain_cache) :
         DeterministicRebalancer(num_nodes, context, GainCachePtr::cast<GainCache>(gain_cache)) {}
@@ -161,7 +159,7 @@ private:
 
         HypernodeWeight max_weight = ensure_balanced ? _context.partition.max_part_weights[to] : std::numeric_limits<HypernodeWeight>::max();
         bool success = false;
-        success = phg.changeNodePart(hn, from, to, max_weight, [] {}, objective_delta);
+        success = PartitionedHypergraph::is_graph ? phg.changeNodePartNoSync(hn, from, to, max_weight) : phg.changeNodePart(hn, from, to, max_weight, [] {}, objective_delta);
         ASSERT(success || ensure_balanced);
         return success;
     }

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -65,7 +65,9 @@ public:
         _gain_computation(context),
         _num_imbalanced_parts(0),
         _moves(context.partition.k),
-        _tmp_potential_moves(context.partition.k) {}
+        _tmp_potential_moves(context.partition.k),
+        _current_imbalance(context.partition.k),
+        _block_has_only_heavy_vertices(context.partition.k) {}
 
     explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, GainCache&) :
         DeterministicRebalancer(num_nodes, context) {}
@@ -112,6 +114,8 @@ private:
             _gain_computation.changeNumberOfBlocks(_current_k);
             _moves.resize(_current_k);
             _tmp_potential_moves.resize(_current_k);
+            _current_imbalance.resize(_current_k);
+            _block_has_only_heavy_vertices.resize(_current_k);
         }
     }
 
@@ -121,11 +125,7 @@ private:
     bool mayMoveNode(const PartitionedHypergraph& phg, PartitionID part, HypernodeWeight hn_weight) const {
         double allowed_weight = phg.partWeight(part) - _context.partition.perfect_balance_part_weights[part];
         allowed_weight *= _context.refinement.rebalancing.det_heavy_vertex_exclusion_factor;
-        return hn_weight <= allowed_weight;
-    }
-
-    HypernodeWeight imbalance(const PartitionedHypergraph& phg, PartitionID part) const {
-        return phg.partWeight(part) - _context.partition.max_part_weights[part];
+        return hn_weight <= allowed_weight || _block_has_only_heavy_vertices[part];
     }
 
     HypernodeWeight deadzoneForPart(PartitionID part) const {
@@ -169,9 +169,9 @@ private:
         for (PartitionID i = 0; i < _current_k; ++i) {
             const auto partWeight = phg.partWeight(i);
             unused(partWeight);
-            if (_moves[i].size() > 0) {
+            if (_current_imbalance[i] > 0) {
                 const auto& max_part_weights = _context.partition.max_part_weights;
-                ASSERT(partWeight <= max_part_weights[i], V(partWeight) << V(max_part_weights[i]));
+                ASSERT(partWeight <= max_part_weights[i] || _block_has_only_heavy_vertices[i], V(partWeight) << V(max_part_weights[i]));
                 unused(max_part_weights);
             }
         }
@@ -184,6 +184,8 @@ private:
     PartitionID _num_imbalanced_parts;
     parallel::scalable_vector<parallel::scalable_vector<rebalancer::RebalancingMove>> _moves;
     parallel::scalable_vector<ds::StreamingVector<rebalancer::RebalancingMove>> _tmp_potential_moves;
+    parallel::scalable_vector<HypernodeWeight> _current_imbalance;
+    parallel::scalable_vector<uint8_t> _block_has_only_heavy_vertices;
 };
 
 }  // namespace kahypar

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -106,39 +106,16 @@ public:
 
 private:
 
-    void resizeDataStructuresForCurrentK() {
-        // If the number of blocks changes, we resize data structures
-        // (can happen during deep multilevel partitioning)
-        if (_current_k != _context.partition.k) {
-            _current_k = _context.partition.k;
-            _gain_computation.changeNumberOfBlocks(_current_k);
-            _moves.resize(_current_k);
-            _tmp_potential_moves.resize(_current_k);
-            _current_imbalance.resize(_current_k);
-            _block_has_only_heavy_vertices.resize(_current_k);
-        }
-    }
+    void resizeDataStructuresForCurrentK();
 
     void updateImbalance(const PartitionedHypergraph& hypergraph);
 
-    // ! decides wether the node is allowed to be moved based on the heavy vertex excclusion hyperparameter
-    bool mayMoveNode(const PartitionedHypergraph& phg, PartitionID part, HypernodeWeight hn_weight) const {
-        double allowed_weight = phg.partWeight(part) - _context.partition.perfect_balance_part_weights[part];
-        allowed_weight *= _context.refinement.rebalancing.det_heavy_vertex_exclusion_factor;
-        return hn_weight <= allowed_weight || _block_has_only_heavy_vertices[part];
-    }
+    // ! decides wether the node is allowed to be moved based on the heavy vertex excclusion parameter
+    bool mayMoveNode(const PartitionedHypergraph& phg, PartitionID part, HypernodeWeight hn_weight) const;
 
-    HypernodeWeight deadzoneForPart(PartitionID part) const {
-        const HypernodeWeight balanced = _context.partition.perfect_balance_part_weights[part];
-        const HypernodeWeight max = _context.partition.max_part_weights[part];
-        return max - _context.refinement.rebalancing.det_relative_deadzone_size * (max - balanced);
-    }
+    HypernodeWeight deadzoneForPart(PartitionID part) const;
 
-    bool isValidTarget(const PartitionedHypergraph& hypergraph, PartitionID part, HypernodeWeight hn_weight) const {
-        const HypernodeWeight part_weight = hypergraph.partWeight(part);
-        return (part_weight < deadzoneForPart(part)) &&
-            part_weight + hn_weight <= _context.partition.max_part_weights[part];
-    }
+    bool isValidTarget(const PartitionedHypergraph& hypergraph, PartitionID part, HypernodeWeight hn_weight) const;
 
     rebalancer::RebalancingMove computeGainAndTargetPart(const PartitionedHypergraph& hypergraph,
                                                          const HypernodeID hn,
@@ -148,35 +125,12 @@ private:
                         const HypernodeID hn,
                         const PartitionID from,
                         const PartitionID to,
-                        bool ensure_balanced) {
-
-        // This function is passed as lambda to the changeNodePart function and used
-        // to calculate the "real" delta of a move (in terms of the used objective function).
-        auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
-            _gain_computation.computeDeltaForHyperedge(sync_update);
-        };
-
-        HypernodeWeight max_weight = ensure_balanced ? _context.partition.max_part_weights[to] : std::numeric_limits<HypernodeWeight>::max();
-        bool success = false;
-        success = PartitionedHypergraph::is_graph ? phg.changeNodePartNoSync(hn, from, to, max_weight) : phg.changeNodePart(hn, from, to, max_weight, [] {}, objective_delta);
-        ASSERT(success || ensure_balanced);
-        return success;
-    }
+                        bool ensure_balanced);
 
     void weakRebalancingRound(PartitionedHypergraph& phg);
 
-    bool checkPreviouslyOverweightParts(const PartitionedHypergraph& phg) const {
-        for (PartitionID i = 0; i < _current_k; ++i) {
-            const auto partWeight = phg.partWeight(i);
-            unused(partWeight);
-            if (_current_imbalance[i] > 0) {
-                const auto& max_part_weights = _context.partition.max_part_weights;
-                ASSERT(partWeight <= max_part_weights[i] || _block_has_only_heavy_vertices[i], V(partWeight) << V(max_part_weights[i]));
-                unused(max_part_weights);
-            }
-        }
-        return true;
-    }
+    bool checkPreviouslyOverweightParts(const PartitionedHypergraph& phg) const;
+
 
     const Context& _context;
     PartitionID _current_k;

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -42,6 +42,7 @@ struct RebalancingMove {
     HypernodeID hn;
     PartitionID to;
     float priority;
+    HypernodeWeight weight;
 };
 }; // namespace rebalancer
 
@@ -64,7 +65,6 @@ public:
         _gain_computation(context),
         _num_imbalanced_parts(0),
         _moves(context.partition.k),
-        _move_weights(context.partition.k),
         _tmp_potential_moves(context.partition.k) {}
 
     explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, GainCache&) :
@@ -111,7 +111,6 @@ private:
             _current_k = _context.partition.k;
             _gain_computation.changeNumberOfBlocks(_current_k);
             _moves.resize(_current_k);
-            _move_weights.resize(_current_k);
             _tmp_potential_moves.resize(_current_k);
         }
     }
@@ -184,7 +183,6 @@ private:
     GainComputation _gain_computation;
     PartitionID _num_imbalanced_parts;
     parallel::scalable_vector<parallel::scalable_vector<rebalancer::RebalancingMove>> _moves;
-    parallel::scalable_vector<parallel::scalable_vector<HypernodeWeight>> _move_weights;
     parallel::scalable_vector<ds::StreamingVector<rebalancer::RebalancingMove>> _tmp_potential_moves;
 };
 

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Robert Krause <robert.krause@student.kit.edu>
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include "mt-kahypar/datastructures/streaming_vector.h"
+#include "mt-kahypar/parallel/stl/scalable_vector.h"
+#include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/metrics.h"
+#include "mt-kahypar/partition/refinement/i_refiner.h"
+#include "mt-kahypar/partition/refinement/i_rebalancer.h"
+#include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
+
+namespace mt_kahypar {
+
+namespace rebalancer {
+struct RebalancingMove {
+    HypernodeID hn;
+    PartitionID to;
+    float priority;
+};
+}; // namespace rebalancer
+
+template <typename GraphAndGainTypes>
+class DeterministicRebalancer final : public IRebalancer {
+private:
+    using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+    using GainCache = typename GraphAndGainTypes::GainCache;
+    using GainComputation = typename GraphAndGainTypes::GainComputation;
+    using RatingMap = typename GainComputation::RatingMap;
+    using AtomicWeight = parallel::IntegralAtomicWrapper<HypernodeWeight>;
+
+    static constexpr bool debug = false;
+    static constexpr bool enable_heavy_assert = false;
+
+public:
+    explicit DeterministicRebalancer(const Context& context) :
+        _context(context),
+        _current_k(context.partition.k),
+        _gain_computation(context),
+        _num_imbalanced_parts(0),
+        _moves(context.partition.k),
+        _move_weights(context.partition.k),
+        _tmp_potential_moves(context.partition.k) {}
+    explicit DeterministicRebalancer(HypernodeID, const Context& context) :
+        DeterministicRebalancer(context) {}
+
+    explicit DeterministicRebalancer(HypernodeID, const Context& context, GainCache&) :
+        DeterministicRebalancer(context) {}
+
+    explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, gain_cache_t gain_cache) :
+        DeterministicRebalancer(num_nodes, context, GainCachePtr::cast<GainCache>(gain_cache)) {}
+
+    DeterministicRebalancer(const DeterministicRebalancer&) = delete;
+    DeterministicRebalancer(DeterministicRebalancer&&) = delete;
+
+    DeterministicRebalancer& operator= (const DeterministicRebalancer&) = delete;
+    DeterministicRebalancer& operator= (DeterministicRebalancer&&) = delete;
+
+    bool refineImpl(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                    const vec<HypernodeID>&,
+                    Metrics& best_metrics,
+                    double) final;
+
+    void initializeImpl(mt_kahypar_partitioned_hypergraph_t&) final {}
+
+    bool refineAndOutputMovesImpl(mt_kahypar_partitioned_hypergraph_t&,
+                                  const vec<HypernodeID>&,
+                                  vec<vec<Move>>&,
+                                  Metrics&,
+                                  const double) override final {
+        throw UnsupportedOperationException("deterministic rebalancer can not be used for unconstrained refinement");
+    }
+
+    bool refineAndOutputMovesLinearImpl(mt_kahypar_partitioned_hypergraph_t&,
+        const vec<HypernodeID>&,
+        vec<Move>&,
+        Metrics&,
+        const double) override final {
+        throw UnsupportedOperationException("deterministic rebalancer can not be used for unconstrained refinement");
+    }
+
+private:
+
+    void resizeDataStructuresForCurrentK() {
+        // If the number of blocks changes, we resize data structures
+        // (can happen during deep multilevel partitioning)
+        if (_current_k != _context.partition.k) {
+            _current_k = _context.partition.k;
+            _gain_computation.changeNumberOfBlocks(_current_k);
+            _moves.resize(_current_k);
+            _move_weights.resize(_current_k);
+            _tmp_potential_moves.resize(_current_k);
+        }
+    }
+
+    void updateImbalance(const PartitionedHypergraph& hypergraph);
+
+    // ! decides wether the node is allowed to be moved based on the heavy vertex excclusion hyperparameter
+    bool mayMoveNode(const PartitionedHypergraph& phg, PartitionID part, HypernodeWeight hn_weight) const {
+        double allowed_weight = phg.partWeight(part) - _context.partition.perfect_balance_part_weights[part];
+        allowed_weight *= _context.refinement.rebalancing.det_heavy_vertex_exclusion_factor;
+        return hn_weight <= allowed_weight;
+    }
+
+    HypernodeWeight imbalance(const PartitionedHypergraph& phg, PartitionID part) const {
+        return phg.partWeight(part) - _context.partition.max_part_weights[part];
+    }
+
+    HypernodeWeight deadzoneForPart(PartitionID part) const {
+        const HypernodeWeight balanced = _context.partition.perfect_balance_part_weights[part];
+        const HypernodeWeight max = _context.partition.max_part_weights[part];
+        return max - _context.refinement.rebalancing.det_relative_deadzone_size * (max - balanced);
+    }
+
+    bool isValidTarget(const PartitionedHypergraph& hypergraph, PartitionID part, HypernodeWeight hn_weight) const {
+        const HypernodeWeight part_weight = hypergraph.partWeight(part);
+        return (part_weight < deadzoneForPart(part)) &&
+            part_weight + hn_weight <= _context.partition.max_part_weights[part];
+    }
+
+    rebalancer::RebalancingMove computeGainAndTargetPart(const PartitionedHypergraph& hypergraph,
+                                                         const HypernodeID hn,
+                                                         bool non_adjacent_blocks);
+
+    bool changeNodePart(PartitionedHypergraph& phg,
+                        const HypernodeID hn,
+                        const PartitionID from,
+                        const PartitionID to,
+                        bool ensure_balanced) {
+
+        // This function is passed as lambda to the changeNodePart function and used
+        // to calculate the "real" delta of a move (in terms of the used objective function).
+        auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
+            _gain_computation.computeDeltaForHyperedge(sync_update);
+        };
+
+        HypernodeWeight max_weight = ensure_balanced ? _context.partition.max_part_weights[to] : std::numeric_limits<HypernodeWeight>::max();
+        bool success = false;
+        success = phg.changeNodePart(hn, from, to, max_weight, [] {}, objective_delta);
+        ASSERT(success || ensure_balanced);
+        return success;
+    }
+
+    void weakRebalancingRound(PartitionedHypergraph& phg);
+
+    bool checkPreviouslyOverweightParts(const PartitionedHypergraph& phg) const {
+        for (PartitionID i = 0; i < _current_k; ++i) {
+            const auto partWeight = phg.partWeight(i);
+            unused(partWeight);
+            if (_moves[i].size() > 0) {
+                const auto& max_part_weights = _context.partition.max_part_weights;
+                ASSERT(partWeight <= max_part_weights[i], V(partWeight) << V(max_part_weights[i]));
+                unused(max_part_weights);
+            }
+        }
+        return true;
+    }
+
+    const Context& _context;
+    PartitionID _current_k;
+    GainComputation _gain_computation;
+    PartitionID _num_imbalanced_parts;
+    parallel::scalable_vector<parallel::scalable_vector<rebalancer::RebalancingMove>> _moves;
+    parallel::scalable_vector<parallel::scalable_vector<HypernodeWeight>> _move_weights;
+    parallel::scalable_vector<ds::StreamingVector<rebalancer::RebalancingMove>> _tmp_potential_moves;
+};
+
+}  // namespace kahypar

--- a/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
@@ -47,6 +47,7 @@
 #include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
 #include "mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h"
 #include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
+#include "mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h"
 
 
 namespace mt_kahypar {
@@ -86,6 +87,11 @@ using FlowSchedulerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                 FlowRefinementScheduler,
                                 IRefiner,
                                 kahypar::meta::Typelist<GraphAndGainTypesList>>;
+
+using DeterministicRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
+                                   DeterministicRebalancer,
+                                   IRebalancer,
+                                   kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
 using SimpleRebalancerDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                    SimpleRebalancer,
@@ -271,6 +277,9 @@ void register_refinement_algorithms() {
                                     getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
   REGISTER_FLOW_SCHEDULER(FlowAlgorithm::do_nothing, DoNothingRefiner, 4);
 
+  REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::deterministic,
+                                DeterministicRebalancerDispatcher,
+                                getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
   REGISTER_DISPATCHED_REBALANCER(RebalancingAlgorithm::simple_rebalancer,
                                 SimpleRebalancerDispatcher,
                                 getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));

--- a/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
+++ b/mt-kahypar/partition/registries/register_refinement_algorithms.cpp
@@ -37,6 +37,7 @@
 #include "mt-kahypar/partition/refinement/do_nothing_refiner.h"
 #include "mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h"
 #include "mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h"
+#include "mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h"
 #include "mt-kahypar/partition/refinement/fm/multitry_kway_fm.h"
 #include "mt-kahypar/partition/refinement/fm/strategies/gain_cache_strategy.h"
 #include "mt-kahypar/partition/refinement/fm/strategies/unconstrained_strategy.h"
@@ -56,6 +57,11 @@ using LabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
 
 using DeterministicLabelPropagationDispatcher = kahypar::meta::StaticMultiDispatchFactory<
                                                 DeterministicLabelPropagationRefiner,
+                                                IRefiner,
+                                                kahypar::meta::Typelist<GraphAndGainTypesList>>;
+
+using DeterministicJetDispatcher = kahypar::meta::StaticMultiDispatchFactory<
+                                                DeterministicJetRefiner,
                                                 IRefiner,
                                                 kahypar::meta::Typelist<GraphAndGainTypesList>>;
 
@@ -110,6 +116,26 @@ using FlowRefinementDispatcher = kahypar::meta::StaticMultiDispatchFactory<
 
 #define REGISTER_LP_REFINER(id, refiner, t)                                                      \
   kahypar::meta::Registrar<LabelPropagationFactory> JOIN(register_ ## refiner, t)(               \
+    id,                                                                                          \
+    [](const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,                       \
+       const Context& context, gain_cache_t gain_cache, IRebalancer& rebalancer) -> IRefiner* {  \
+    return new refiner(num_hypernodes, num_hyperedges, context, gain_cache, rebalancer);         \
+  })
+
+
+#define REGISTER_DISPATCHED_JET_REFINER(id, dispatcher, ...)                                           \
+  kahypar::meta::Registrar<JetFactory> register_ ## dispatcher(                                        \
+    id,                                                                                                \
+    [](const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,                             \
+       const Context& context, gain_cache_t gain_cache, IRebalancer& rebalancer) {                     \
+    return dispatcher::create(                                                                         \
+      std::forward_as_tuple(num_hypernodes, num_hyperedges, context, gain_cache, rebalancer),          \
+      __VA_ARGS__                                                                                      \
+      );                                                                                               \
+  })
+
+#define REGISTER_JET_REFINER(id, refiner, t)                                                     \
+  kahypar::meta::Registrar<JetFactory> JOIN(register_ ## refiner, t)(                            \
     id,                                                                                          \
     [](const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,                       \
        const Context& context, gain_cache_t gain_cache, IRebalancer& rebalancer) -> IRefiner* {  \
@@ -219,6 +245,11 @@ void register_refinement_algorithms() {
                                 DeterministicLabelPropagationDispatcher,
                                 getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
   REGISTER_LP_REFINER(LabelPropagationAlgorithm::do_nothing, DoNothingRefiner, 1);
+
+  REGISTER_DISPATCHED_JET_REFINER(JetAlgorithm::deterministic,
+                                  DeterministicJetDispatcher,
+                                  getGraphAndGainTypesPolicy(context.partition.partition_type, context.partition.gain_policy));
+  REGISTER_JET_REFINER(JetAlgorithm::do_nothing, DoNothingRefiner, 2);
 
   REGISTER_DISPATCHED_FM_REFINER(FMAlgorithm::kway_fm,
                                 DefaultFMDispatcher,

--- a/tests/io/sql_plottools_serializer_test.cc
+++ b/tests/io/sql_plottools_serializer_test.cc
@@ -61,7 +61,7 @@ std::set<std::string> excluded_members =
     "measure_detailed_uncontraction_timings", "write_partition_file", "graph_partition_output_folder", "graph_partition_filename", "graph_community_filename", "community_detection",
     "community_redistribution", "coarsening_rating", "label_propagation", "lp_execute_sequential", "deterministic_refinement", "jet",
     "snapshot_interval", "initial_partitioning_refinement", "initial_partitioning_enabled_ip_algos", "original_num_threads",
-    "stable_construction_of_incident_edges", "fm", "global", "flows", "csv_output", "preset_file", "preset_type", "instance_type", "degree_of_parallelism",
+    "stable_construction_of_incident_edges", "fm", "global", "flows", "rebalancing", "csv_output", "preset_file", "preset_type", "instance_type", "degree_of_parallelism",
     "mapping_target_graph_file" };
 
 bool is_target_struct(const std::string& line) {

--- a/tests/io/sql_plottools_serializer_test.cc
+++ b/tests/io/sql_plottools_serializer_test.cc
@@ -53,7 +53,7 @@ std::unordered_map<std::string, std::string> target_struct_prefix =
     {"PreprocessingParameters", ""}, {"RatingParameters", "rating_"}, {"CoarseningParameters", "coarsening_"},
     {"InitialPartitioningParameters", "initial_partitioning_"},
     {"LabelPropagationParameters", "lp_"}, {"FMParameters", "fm_"}, {"NLevelGlobalRefinementParameters", "global_refine_"},
-    {"RefinementParameters", ""}, {"SharedMemoryParameters", ""},
+    {"RefinementParameters", ""}, {"SharedMemoryParameters", ""}, {"RebalancingParameters", "rebalancing_"},
     {"DeterministicRefinement", "sync_lp_"}, {"JetParameters", "jet_"}, {"FlowParameters", "flow_"}, {"MappingParameters", "mapping_"} };
 
 std::set<std::string> excluded_members =

--- a/tests/io/sql_plottools_serializer_test.cc
+++ b/tests/io/sql_plottools_serializer_test.cc
@@ -54,12 +54,12 @@ std::unordered_map<std::string, std::string> target_struct_prefix =
     {"InitialPartitioningParameters", "initial_partitioning_"},
     {"LabelPropagationParameters", "lp_"}, {"FMParameters", "fm_"}, {"NLevelGlobalRefinementParameters", "global_refine_"},
     {"RefinementParameters", ""}, {"SharedMemoryParameters", ""},
-    {"DeterministicRefinement", "sync_lp_"}, {"FlowParameters", "flow_"}, {"MappingParameters", "mapping_"} };
+    {"DeterministicRefinement", "sync_lp_"}, {"JetParameters", "jet_"}, {"FlowParameters", "flow_"}, {"MappingParameters", "mapping_"} };
 
 std::set<std::string> excluded_members =
   { "verbose_output", "show_detailed_timings", "show_detailed_clustering_timings", "timings_output_depth", "show_memory_consumption", "show_advanced_cut_analysis", "enable_progress_bar", "sp_process_output",
     "measure_detailed_uncontraction_timings", "write_partition_file", "graph_partition_output_folder", "graph_partition_filename", "graph_community_filename", "community_detection",
-    "community_redistribution", "coarsening_rating", "label_propagation", "lp_execute_sequential", "deterministic_refinement",
+    "community_redistribution", "coarsening_rating", "label_propagation", "lp_execute_sequential", "deterministic_refinement", "jet",
     "snapshot_interval", "initial_partitioning_refinement", "initial_partitioning_enabled_ip_algos", "original_num_threads",
     "stable_construction_of_incident_edges", "fm", "global", "flows", "csv_output", "preset_file", "preset_type", "instance_type", "degree_of_parallelism",
     "mapping_target_graph_file" };

--- a/tests/partition/determinism/determinism_test.cc
+++ b/tests/partition/determinism/determinism_test.cc
@@ -33,6 +33,11 @@
 #include "mt-kahypar/partition/initial_partitioning/bfs_initial_partitioner.h"
 #include "mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h"
 #include "mt-kahypar/partition/refinement/deterministic/deterministic_label_propagation.h"
+#include "mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h"
+#include "mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h"
+#include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
+#include "mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h"
+#include "mt-kahypar/partition/refinement/do_nothing_refiner.h"
 #include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
 #include "mt-kahypar/partition/preprocessing/community_detection/parallel_louvain.h"
 #include "mt-kahypar/utils/cast.h"
@@ -45,6 +50,7 @@ namespace {
   using TypeTraits = StaticHypergraphTypeTraits;
   using Hypergraph = typename TypeTraits::Hypergraph;
   using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes<TypeTraits, Km1GainTypes>::GainCache;
 }
 class DeterminismTest : public Test {
 
@@ -53,7 +59,8 @@ public:
           hypergraph(),
           partitioned_hypergraph(),
           context(),
-          metrics() {
+          metrics(),
+          gain_cache() {
     context.partition.graph_filename = "../tests/instances/powersim.mtx.hgr";
     context.partition.mode = Mode::direct;
     context.partition.preset_type = PresetType::deterministic;
@@ -89,6 +96,11 @@ public:
     context.refinement.deterministic_refinement.num_sub_rounds_sync_lp = 2;
     context.refinement.label_propagation.maximum_iterations = 5;
     context.refinement.deterministic_refinement.use_active_node_set = false;
+    context.refinement.jet.num_iterations = 12;
+    context.refinement.jet.relative_improvement_threshold = 0.001;
+    context.refinement.jet.initial_negative_gain_factor = 0.75;
+    context.refinement.jet.final_negative_gain_factor = 0.0;
+    context.refinement.jet.dynamic_rounds = 3;
 
     context.partition.objective = Objective::km1;
     context.partition.gain_policy = GainPolicy::km1;
@@ -148,11 +160,51 @@ public:
     }
   }
 
+  void performRepeatedJetRefinement() {
+    initialPartition();
+    vec<PartitionID> initial_partition(hypergraph.initialNumNodes());
+    for (HypernodeID u : hypergraph.nodes()) {
+      initial_partition[u] = partitioned_hypergraph.partID(u);
+    }
+
+    vec<PartitionID> first(hypergraph.initialNumNodes());
+    for (size_t i = 0; i < num_jet_repetitions; ++i) {
+      partitioned_hypergraph.resetPartition();
+      for (HypernodeID u : hypergraph.nodes()) {
+        partitioned_hypergraph.setNodePart(u, initial_partition[u]);
+      }
+      gain_cache.reset();
+      gain_cache.initializeGainCache(partitioned_hypergraph);
+      mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
+      auto rebalancer = std::make_unique<DeterministicRebalancer<GraphAndGainTypes<TypeTraits, Km1GainTypes>>>(hypergraph.initialNumNodes(), context, gain_cache);
+      DeterministicJetRefiner<GraphAndGainTypes<TypeTraits, Km1GainTypes>> refiner(
+        hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);
+      rebalancer->initialize(phg);
+      refiner.initialize(phg);
+      vec<HypernodeID> dummy_refinement_nodes;
+      Metrics my_metrics = metrics;
+
+      refiner.refine(phg, dummy_refinement_nodes, my_metrics, 0.0);
+
+      if (i == 0) {
+        for (HypernodeID u : hypergraph.nodes()) {
+          first[u] = partitioned_hypergraph.partID(u);
+        }
+      } else {
+        for (HypernodeID u : hypergraph.nodes()) {
+          ASSERT_EQ(first[u], partitioned_hypergraph.partID(u));
+        }
+      }
+    }
+  }
+
   Hypergraph hypergraph;
   PartitionedHypergraph partitioned_hypergraph;
   Context context;
   Metrics metrics;
+  GainCache gain_cache;
   static constexpr size_t num_repetitions = 5;
+  static constexpr size_t num_jet_repetitions = 5;
 };
 
 TEST_F(DeterminismTest, Preprocessing) {
@@ -247,6 +299,42 @@ TEST_F(DeterminismTest, RefinementOnCoarseHypergraph) {
   partitioned_hypergraph = PartitionedHypergraph(
           context.partition.k, hypergraph, parallel_tag_t());
   performRepeatedRefinement();
+}
+
+
+TEST_F(DeterminismTest, JetRefinement) {
+  performRepeatedJetRefinement();
+}
+
+TEST_F(DeterminismTest, JetRefinementOnSmallImbalance) {
+  context.partition.epsilon = 0.03;
+  context.setupPartWeights(hypergraph.totalWeight());
+  performRepeatedJetRefinement();
+}
+
+TEST_F(DeterminismTest, JetRefinementWithActiveNodeSet) {
+  context.refinement.deterministic_refinement.use_active_node_set = true;
+  performRepeatedJetRefinement();
+}
+
+TEST_F(DeterminismTest, JetRefinementK2) {
+  context.partition.k = 2;
+  partitioned_hypergraph = PartitionedHypergraph(
+    context.partition.k, hypergraph, parallel_tag_t());
+  context.setupPartWeights(hypergraph.totalWeight());
+  performRepeatedJetRefinement();
+}
+
+TEST_F(DeterminismTest, JetRefinementOnCoarseHypergraph) {
+  UncoarseningData<TypeTraits> uncoarseningData(false, hypergraph, context);
+  uncoarsening_data_t* data_ptr = uncoarsening::to_pointer(uncoarseningData);
+  mt_kahypar_hypergraph_t hg = utils::hypergraph_cast(hypergraph);
+  DeterministicMultilevelCoarsener<TypeTraits> coarsener(hg, context, data_ptr);
+  coarsener.coarsen();
+  hypergraph = utils::cast<Hypergraph>(coarsener.coarsestHypergraph()).copy();
+  partitioned_hypergraph = PartitionedHypergraph(
+    context.partition.k, hypergraph, parallel_tag_t());
+  performRepeatedJetRefinement();
 }
 
 }  // namespace mt_kahypar

--- a/tests/partition/refinement/CMakeLists.txt
+++ b/tests/partition/refinement/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(mtkahypar_tests PRIVATE
+         bipartitioning_gain_policy_test.cc
+         deterministic_jet_refiner_test.cc
          refinement_adapter_test.cc
          problem_construction_test.cc
          scheduler_test.cc
@@ -8,6 +10,7 @@ target_sources(mtkahypar_tests PRIVATE
          rollback_test.cc
          rebalance_test.cc
          advanced_rebalancer_test.cc
+         deterministic_rebalancer_test.cc
          twoway_fm_refiner_test.cc
          gain_cache_test.cc
          multitry_fm_test.cc

--- a/tests/partition/refinement/deterministic_jet_refiner_test.cc
+++ b/tests/partition/refinement/deterministic_jet_refiner_test.cc
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Robert Krause <robert.krause@student.kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "gmock/gmock.h"
+
+#include "tests/datastructures/hypergraph_fixtures.h"
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/io/hypergraph_factory.h"
+#include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/initial_partitioning/bfs_initial_partitioner.h"
+#include "mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/partition/refinement/rebalancing/simple_rebalancer.h"
+#include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
+#include "mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h"
+#include "mt-kahypar/utils/cast.h"
+
+using ::testing::Test;
+
+namespace mt_kahypar {
+template <PartitionID k, Objective objective, RebalancingAlgorithm rebalancing>
+struct TestConfig {};
+
+template < PartitionID k, RebalancingAlgorithm rebalancing>
+struct TestConfig< k, Objective::km1, rebalancing> {
+    using TypeTraits = StaticHypergraphTypeTraits;
+    using GainTypes = Km1GainTypes;
+    using Refiner = DeterministicJetRefiner<GraphAndGainTypes<TypeTraits, GainTypes>>;
+    static constexpr PartitionID K = k;
+    static constexpr Objective OBJECTIVE = Objective::km1;
+    static constexpr RebalancingAlgorithm REBALANCER = rebalancing;
+};
+
+template <PartitionID k, RebalancingAlgorithm rebalancing>
+struct TestConfig<k, Objective::cut, rebalancing> {
+    using TypeTraits = StaticHypergraphTypeTraits;
+    using GainTypes = CutGainTypes;
+    using Refiner = DeterministicJetRefiner<GraphAndGainTypes<TypeTraits, GainTypes>>;
+    static constexpr PartitionID K = k;
+    static constexpr Objective OBJECTIVE = Objective::cut;
+    static constexpr RebalancingAlgorithm REBALANCER = rebalancing;
+};
+
+template <typename Config>
+class ADeterministicJetRefiner : public Test {
+    static size_t num_threads;
+
+public:
+    using TypeTraits = typename Config::TypeTraits;
+    using GainTypes = typename Config::GainTypes;
+    using Hypergraph = typename TypeTraits::Hypergraph;
+    using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+    using Refiner = typename Config::Refiner;
+    using GainCache = typename GainTypes::GainCache;
+
+    ADeterministicJetRefiner() :
+        hypergraph(),
+        partitioned_hypergraph(),
+        context(),
+        gain_cache(),
+        refiner(nullptr),
+        rebalancer(nullptr),
+        metrics() {
+        context.partition.graph_filename = "../tests/instances/contracted_ibm01.hgr";
+        context.partition.graph_community_filename = "../tests/instances/contracted_ibm01.hgr.community";
+        context.partition.mode = Mode::direct;
+        context.partition.objective = Config::OBJECTIVE;
+        context.partition.gain_policy = context.partition.objective == Objective::km1 ? GainPolicy::km1 : GainPolicy::cut;
+        context.partition.epsilon = 0.25;
+        context.partition.k = Config::K;
+        context.partition.preset_type = PresetType::deterministic;
+        context.partition.instance_type = InstanceType::hypergraph;
+        context.partition.partition_type = PartitionedHypergraph::TYPE;
+        context.partition.verbose_output = false;
+
+        // Shared Memory
+        context.shared_memory.num_threads = num_threads;
+
+        // Initial Partitioning
+        context.initial_partitioning.mode = Mode::deep_multilevel;
+        context.initial_partitioning.runs = 1;
+
+        // Jet
+        context.refinement.rebalancing.algorithm = Config::REBALANCER;
+        context.refinement.jet.num_iterations = 12;
+        context.refinement.jet.relative_improvement_threshold = 0.001;
+        context.refinement.jet.initial_negative_gain_factor = 0.75;
+        context.refinement.jet.final_negative_gain_factor = 0.0;
+        context.refinement.jet.dynamic_rounds = 3;
+
+
+        // Read hypergraph
+        hypergraph = io::readInputFile<Hypergraph>(
+            "../tests/instances/contracted_unweighted_ibm01.hgr", FileFormat::hMetis, true);
+        partitioned_hypergraph = PartitionedHypergraph(
+            context.partition.k, hypergraph, parallel_tag_t());
+        context.setupPartWeights(hypergraph.totalWeight());
+        initialPartition();
+        if (context.refinement.rebalancing.algorithm == RebalancingAlgorithm::simple_rebalancer) {
+            rebalancer = std::make_unique<SimpleRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>>(
+                context);
+        } else if (context.refinement.rebalancing.algorithm == RebalancingAlgorithm::advanced_rebalancer) {
+            rebalancer = std::make_unique<AdvancedRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>>(
+                hypergraph.initialNumNodes(), context, gain_cache);
+        } else if (context.refinement.rebalancing.algorithm == RebalancingAlgorithm::deterministic) {
+            rebalancer = std::make_unique<DeterministicRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>>(
+                hypergraph.initialNumNodes(), context, gain_cache);
+        }
+        refiner = std::make_unique<Refiner>(
+            hypergraph.initialNumNodes(), hypergraph.initialNumEdges(), context, gain_cache, *rebalancer);
+        mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
+        rebalancer->initialize(phg);
+        refiner->initialize(phg);
+    }
+
+    void initialPartition() {
+        Context ip_context(context);
+        ip_context.refinement.label_propagation.algorithm = LabelPropagationAlgorithm::do_nothing;
+        InitialPartitioningDataContainer<TypeTraits> ip_data(partitioned_hypergraph, ip_context);
+        ip_data_container_t* ip_data_ptr = ip::to_pointer(ip_data);
+        BFSInitialPartitioner<TypeTraits> initial_partitioner(
+            InitialPartitioningAlgorithm::bfs, ip_data_ptr, ip_context, 420, 0);
+        initial_partitioner.partition();
+        ip_data.apply();
+        metrics.quality = metrics::quality(partitioned_hypergraph, context);
+        metrics.imbalance = metrics::imbalance(partitioned_hypergraph, context);
+    }
+
+    Hypergraph hypergraph;
+    PartitionedHypergraph partitioned_hypergraph;
+    Context context;
+    GainCache gain_cache;
+    std::unique_ptr<Refiner> refiner;
+    std::unique_ptr<IRebalancer> rebalancer;
+    Metrics metrics;
+};
+
+template <typename Config>
+size_t ADeterministicJetRefiner<Config>::num_threads = HardwareTopology::instance().num_cpus();
+
+static constexpr double EPS = 0.05;
+
+typedef ::testing::Types<
+    TestConfig<2, Objective::cut, RebalancingAlgorithm::deterministic>,
+    TestConfig<4, Objective::cut, RebalancingAlgorithm::deterministic>,
+    TestConfig<8, Objective::cut, RebalancingAlgorithm::deterministic>,
+    TestConfig<2, Objective::km1, RebalancingAlgorithm::deterministic>,
+    TestConfig<2, Objective::km1, RebalancingAlgorithm::advanced_rebalancer>,
+    TestConfig<4, Objective::km1, RebalancingAlgorithm::deterministic>,
+    TestConfig<4, Objective::km1, RebalancingAlgorithm::advanced_rebalancer>,
+    TestConfig<8, Objective::km1, RebalancingAlgorithm::deterministic>,
+    TestConfig<8, Objective::km1, RebalancingAlgorithm::advanced_rebalancer>
+> TestConfigs;
+
+TYPED_TEST_CASE(ADeterministicJetRefiner, TestConfigs);
+
+TYPED_TEST(ADeterministicJetRefiner, UpdatesImbalanceCorrectly) {
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+    this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+}
+
+TYPED_TEST(ADeterministicJetRefiner, DoesNotViolateBalanceConstraint) {
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+    this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon + EPS);
+}
+
+TYPED_TEST(ADeterministicJetRefiner, UpdatesMetricsCorrectly) {
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+    this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_EQ(metrics::quality(this->partitioned_hypergraph, this->context.partition.objective),
+        this->metrics.quality);
+}
+
+TYPED_TEST(ADeterministicJetRefiner, DoesNotWorsenSolutionQuality) {
+    HyperedgeWeight objective_before = metrics::quality(this->partitioned_hypergraph, this->context.partition.objective);
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+    this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_LE(this->metrics.quality, objective_before);
+}
+
+
+TYPED_TEST(ADeterministicJetRefiner, IncreasesTheNumberOfBlocks) {
+    using PartitionedHypergraph = typename TestFixture::PartitionedHypergraph;
+    HyperedgeWeight objective_before = metrics::quality(this->partitioned_hypergraph, this->context.partition.objective);
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+    this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_LE(this->metrics.quality, objective_before);
+
+    // Initialize partition with smaller K
+    const PartitionID old_k = this->context.partition.k;
+    this->context.partition.k = std::max(old_k / 2, 2);
+    this->context.setupPartWeights(this->hypergraph.totalWeight());
+    PartitionedHypergraph phg_with_new_k(
+        this->context.partition.k, this->hypergraph, mt_kahypar::parallel_tag_t());
+    vec<PartitionID> non_optimized_partition(this->hypergraph.initialNumNodes(), kInvalidPartition);
+    this->partitioned_hypergraph.doParallelForAllNodes([&](const HypernodeID hn) {
+        // create a semi-random partition
+        const PartitionID block = this->partitioned_hypergraph.partID(hn);
+        phg_with_new_k.setOnlyNodePart(hn, (block + hn) % this->context.partition.k);
+        non_optimized_partition[hn] = phg_with_new_k.partID(hn);
+    });
+    phg_with_new_k.initializePartition();
+    this->metrics.quality = metrics::quality(phg_with_new_k, this->context);
+    this->metrics.imbalance = metrics::imbalance(phg_with_new_k, this->context);
+
+    objective_before = metrics::quality(phg_with_new_k, this->context.partition.objective);
+    mt_kahypar_partitioned_hypergraph_t phg_new_k = utils::partitioned_hg_cast(phg_with_new_k);
+    this->gain_cache.reset();
+    this->refiner->initialize(phg_new_k);
+    this->rebalancer->initialize(phg_new_k);
+    this->refiner->refine(phg_new_k, {}, this->metrics, std::numeric_limits<double>::max());
+    ASSERT_LE(this->metrics.quality, objective_before);
+    ASSERT_EQ(metrics::quality(phg_with_new_k, this->context.partition.objective),
+        this->metrics.quality);
+
+    // Check if refiner has moved some nodes
+    bool has_moved_nodes = false;
+    for (const HypernodeID hn : phg_with_new_k.nodes()) {
+        if (non_optimized_partition[hn] != phg_with_new_k.partID(hn)) {
+            has_moved_nodes = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(has_moved_nodes);
+}
+
+}  // namespace mt_kahypar

--- a/tests/partition/refinement/deterministic_rebalancer_test.cc
+++ b/tests/partition/refinement/deterministic_rebalancer_test.cc
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2023 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include <functional>
+#include <random>
+
+
+#include "gmock/gmock.h"
+
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/io/hypergraph_factory.h"
+#include "mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/utils/randomize.h"
+
+using ::testing::Test;
+
+namespace mt_kahypar {
+
+template <typename TypeTraitsT, typename GainTypesT, PartitionID k>
+struct TestConfig {
+  using TypeTraits = TypeTraitsT;
+  using GainTypes = GainTypesT;
+  static constexpr PartitionID K = k;
+};
+
+template<typename Config>
+class DeterministicRebalancerTest : public Test {
+
+ public:
+  using TypeTraits = typename Config::TypeTraits;
+  using GainTypes = typename Config::GainTypes;
+  using Hypergraph = typename TypeTraits::Hypergraph;
+  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using HypergraphFactory = typename Hypergraph::Factory;
+  using GainCache = typename GainTypes::GainCache;
+  using Rebalancer = DeterministicRebalancer<GraphAndGainTypes<TypeTraits, GainTypes>>;
+
+  DeterministicRebalancerTest() :
+          hypergraph(),
+          partitioned_hypergraph(),
+          context(),
+          rebalancer(nullptr) {
+    TBBInitializer::instance(std::thread::hardware_concurrency());
+    context.partition.mode = Mode::direct;
+    context.partition.epsilon = 0.05;
+    context.partition.k = Config::K;
+
+    context.partition.preset_type = PresetType::default_preset;
+    context.partition.instance_type = InstanceType::hypergraph;
+    context.partition.partition_type = PartitionedHypergraph::TYPE;
+    context.partition.verbose_output = false;
+
+    context.refinement.rebalancing.det_heavy_vertex_exclusion_factor = 1.5;
+    context.refinement.rebalancing.det_relative_deadzone_size = 0.25;
+
+    // Shared Memory
+    context.shared_memory.original_num_threads = std::thread::hardware_concurrency();
+    context.shared_memory.num_threads = std::thread::hardware_concurrency();
+
+    context.partition.objective = Hypergraph::is_graph ? Objective::cut : Objective::km1;
+    context.partition.gain_policy = Hypergraph::is_graph ? GainPolicy::cut_for_graphs : GainPolicy::km1;
+  }
+
+  void constructFromFile() {
+    if constexpr ( Hypergraph::is_graph ) {
+      hypergraph = io::readInputFile<Hypergraph>(
+        "../tests/instances/delaunay_n10.graph", FileFormat::Metis, true);
+    } else {
+      hypergraph = io::readInputFile<Hypergraph>(
+        "../tests/instances/contracted_unweighted_ibm01.hgr", FileFormat::hMetis, true);
+    }
+  }
+
+  void constructFromValues(const HypernodeID num_hypernodes, const HyperedgeID num_hyperedges,
+                           const vec<vec<HypernodeID>>& edge_vector, const vec<HypernodeWeight> hypernode_weight) {
+    hypergraph = HypergraphFactory::construct(num_hypernodes, num_hyperedges, edge_vector, nullptr, hypernode_weight.data());
+  }
+
+  void setup() {
+    partitioned_hypergraph = PartitionedHypergraph(context.partition.k, hypergraph, parallel_tag_t());
+    context.setupPartWeights(hypergraph.totalWeight());
+
+    rebalancer = std::make_unique<Rebalancer>(hypergraph.initialNumNodes(), context);
+  }
+
+  Hypergraph hypergraph;
+  PartitionedHypergraph partitioned_hypergraph;
+  Context context;
+  std::unique_ptr<Rebalancer> rebalancer;
+};
+
+
+typedef ::testing::Types<TestConfig<StaticHypergraphTypeTraits, Km1GainTypes, 2>,
+                         TestConfig<StaticHypergraphTypeTraits, Km1GainTypes, 4>
+                         ENABLE_GRAPHS(COMMA TestConfig<StaticGraphTypeTraits COMMA CutGainForGraphsTypes COMMA 2>)
+                         ENABLE_GRAPHS(COMMA TestConfig<StaticGraphTypeTraits COMMA CutGainForGraphsTypes COMMA 4>) > TestConfigs;
+
+TYPED_TEST_CASE(DeterministicRebalancerTest, TestConfigs);
+
+
+TYPED_TEST(DeterministicRebalancerTest, CanNotBeRebalanced) {
+  this->constructFromValues(3, 1, { {0, 1} }, {6, 5, 4});
+  this->setup();
+
+  this->partitioned_hypergraph.setOnlyNodePart(0, 0);
+  this->partitioned_hypergraph.setOnlyNodePart(1, 1);
+  this->partitioned_hypergraph.setOnlyNodePart(2, 0);
+  this->partitioned_hypergraph.initializePartition();
+  mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+  this->rebalancer->initialize(phg);
+
+  Metrics metrics;
+  metrics.quality = metrics::quality(this->partitioned_hypergraph, this->context);
+  metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
+  this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
+
+  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+}
+
+
+TYPED_TEST(DeterministicRebalancerTest, ProducesBalancedResult) {
+  this->constructFromFile();
+  this->setup();
+
+  this->partitioned_hypergraph.doParallelForAllNodes([&](const HypernodeID hn) {
+    PartitionID block = 0;
+    for (PartitionID p = 1; p < this->context.partition.k; ++p) {
+      if (utils::Randomize::instance().flipCoin(THREAD_ID)) {
+        block++;
+      }
+    }
+    this->partitioned_hypergraph.setOnlyNodePart(hn, block);
+  });
+
+  this->partitioned_hypergraph.initializePartition();
+  mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+  this->rebalancer->initialize(phg);
+
+  Metrics metrics;
+  metrics.quality = metrics::quality(this->partitioned_hypergraph, this->context);
+  metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
+  this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
+
+  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  for (PartitionID part = 0; part < this->context.partition.k; ++part) {
+    ASSERT_LE(this->partitioned_hypergraph.partWeight(part), this->context.partition.max_part_weights[part]);
+  }
+}
+
+}


### PR DESCRIPTION
The deterministic Jet refinement and rebalancing from https://arxiv.org/abs/2504.12013

Does not include coarsening or flows (will be separate PRs) and doesn't use the new algorithms in the configs yet.

Experimental evaluation including the coarsening changes:

![comparison_pr](https://github.com/user-attachments/assets/c51df979-93c4-4573-8865-b8df8ad235ca)

Running time on hypergraphs, irregular & regular graphs (speedup to paper is mostly from better optimized coarsening):

<img src="https://github.com/user-attachments/assets/88586cd5-30df-4e3d-91c1-dbe4ffc36953" width="250"/>
<img src="https://github.com/user-attachments/assets/a30e7c41-1b98-4a38-9394-e508bdf1341f" width="250"/>
<img src="https://github.com/user-attachments/assets/fbf8b77b-a458-4154-acf0-d4629b898e34" width="250"/>
