### PR TITLE
Improved Deterministic Coarsening

### DIFF
--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -310,7 +310,10 @@ namespace mt_kahypar {
             ("c-num-sub-rounds",
              po::value<size_t>(&context.coarsening.num_sub_rounds_deterministic)->value_name(
                      "<size_t>")->default_value(16),
-             "Number of sub-rounds used for deterministic coarsening.");
+             "Number of sub-rounds used for deterministic coarsening.")
+            ("c-resolve-swaps",
+             po::value<bool>(&context.coarsening.det_resolve_swaps)->value_name("<bool>")->default_value(true),
+             "Whether to resolve node swaps in a postprocessing step for deterministic coarsening.");
     return options;
   }
 

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -91,6 +91,7 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " coarsening_max_allowed_node_weight=" << context.coarsening.max_allowed_node_weight
         << " coarsening_vertex_degree_sampling_threshold=" << context.coarsening.vertex_degree_sampling_threshold
         << " coarsening_num_sub_rounds_deterministic=" << context.coarsening.num_sub_rounds_deterministic
+        << " coarsening_det_resolve_swaps=" << std::boolalpha << context.coarsening.det_resolve_swaps
         << " coarsening_contraction_limit=" << context.coarsening.contraction_limit
         << " rating_function=" << context.coarsening.rating.rating_function
         << " rating_heavy_node_penalty_policy=" << context.coarsening.rating.heavy_node_penalty_policy

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
@@ -81,6 +81,7 @@ public:
     pass(0),
     progress_bar(utils::cast<Hypergraph>(hypergraph).initialNumNodes(), 0, false),
     cluster_weights_to_fix(utils::cast<Hypergraph>(hypergraph).initialNumNodes()) {
+    initializeEdgeDeduplication(hypergraph);
   }
 
   ~DeterministicMultilevelCoarsener() {
@@ -143,6 +144,8 @@ private:
 
   void handleNodeSwaps(const size_t first, const size_t last, const Hypergraph& hg);
 
+  void initializeEdgeDeduplication(mt_kahypar_hypergraph_t hypergraph);
+
   using Base = MultilevelCoarsenerBase<TypeTraits>;
   using Base::_hg;
   using Base::_context;
@@ -160,5 +163,8 @@ private:
   size_t pass;
   utils::ProgressBar progress_bar;
   ds::BufferedVector<HypernodeID> cluster_weights_to_fix;
+
+  size_t bloom_filter_mask;
+  tbb::enumerable_thread_specific<kahypar::ds::FastResetFlagArray<>> bloom_filters;
 };
 }

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
@@ -79,8 +79,8 @@ public:
     nodes_in_too_heavy_clusters(utils::cast<Hypergraph>(hypergraph).initialNumNodes()),
     default_rating_maps(utils::cast<Hypergraph>(hypergraph).initialNumNodes()),
     pass(0),
-    progress_bar(utils::cast<Hypergraph>(hypergraph).initialNumNodes(), 0, false)
-  {
+    progress_bar(utils::cast<Hypergraph>(hypergraph).initialNumNodes(), 0, false),
+    cluster_weights_to_fix(utils::cast<Hypergraph>(hypergraph).initialNumNodes()) {
   }
 
   ~DeterministicMultilevelCoarsener() {
@@ -94,6 +94,7 @@ private:
   };
 
   static constexpr bool debug = false;
+  static constexpr bool enable_heavy_assert = false;
 
   void initializeImpl() override {
     if ( _context.partition.verbose_output && _context.partition.enable_progress_bar ) {
@@ -158,6 +159,6 @@ private:
   tbb::enumerable_thread_specific<vec<HypernodeID>> ties;
   size_t pass;
   utils::ProgressBar progress_bar;
-
+  ds::BufferedVector<HypernodeID> cluster_weights_to_fix;
 };
 }

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
@@ -122,7 +122,7 @@ private:
 
   void calculatePreferredTargetCluster(HypernodeID u, const vec<HypernodeID>& clusters);
 
-  size_t approveVerticesInTooHeavyClusters(vec<HypernodeID>& clusters);
+  size_t approveNodes(vec<HypernodeID>& clusters);
 
   HypernodeID currentNumberOfNodesImpl() const override {
     return Base::currentNumNodes();
@@ -139,6 +139,8 @@ private:
       reinterpret_cast<mt_kahypar_partitioned_hypergraph_s*>(
         &Base::currentPartitionedHypergraph()), PartitionedHypergraph::TYPE };
   }
+
+  void handleNodeSwaps(const size_t first, const size_t last, const Hypergraph& hg);
 
   using Base = MultilevelCoarsenerBase<TypeTraits>;
   using Base::_hg;

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
@@ -34,6 +34,7 @@
 #include "mt-kahypar/utils/reproducible_random.h"
 #include "mt-kahypar/datastructures/sparse_map.h"
 #include "mt-kahypar/datastructures/buffered_vector.h"
+#include "mt-kahypar/datastructures/fixed_vertex_support.h"
 #include "mt-kahypar/utils/utilities.h"
 #include "mt-kahypar/utils/progress_bar.h"
 #include "mt-kahypar/utils/cast.h"
@@ -125,12 +126,21 @@ private:
                     (hg.initialNumNodes() - hg.numRemovedHypernodes()) / _context.coarsening.maximum_shrink_factor) );
   }
 
-  void clusterNodesInRange(vec<HypernodeID>& clusters, HypernodeID& num_nodes, size_t first, size_t last);
+  template<bool has_fixed_vertices>
+  void clusterNodesInRange(vec<HypernodeID>& clusters,
+                           HypernodeID& num_nodes,
+                           size_t first,
+                           size_t last,
+                           ds::FixedVertexSupport<Hypergraph>& fixed_vertices);
 
-  template<typename RatingMap>
-  void calculatePreferredTargetCluster(HypernodeID u, const vec<HypernodeID>& clusters, RatingMap& tmp_ratings);
+  template<bool has_fixed_vertices, typename RatingMap>
+  void calculatePreferredTargetCluster(HypernodeID u,
+                                       const vec<HypernodeID>& clusters,
+                                       RatingMap& tmp_ratings,
+                                       const ds::FixedVertexSupport<Hypergraph>& fixed_vertices);
 
-  size_t approveNodes(vec<HypernodeID>& clusters);
+  template<bool has_fixed_vertices>
+  size_t approveNodes(vec<HypernodeID>& clusters, ds::FixedVertexSupport<Hypergraph>& fixed_vertices);
 
   HypernodeID currentNumberOfNodesImpl() const override {
     return Base::currentNumNodes();

--- a/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
+++ b/mt-kahypar/partition/coarsening/deterministic_multilevel_coarsener.h
@@ -122,6 +122,8 @@ private:
                     (hg.initialNumNodes() - hg.numRemovedHypernodes()) / _context.coarsening.maximum_shrink_factor) );
   }
 
+  void clusterNodesInRange(vec<HypernodeID>& clusters, HypernodeID& num_nodes, size_t first, size_t last);
+
   void calculatePreferredTargetCluster(HypernodeID u, const vec<HypernodeID>& clusters);
 
   size_t approveNodes(vec<HypernodeID>& clusters);

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -114,8 +114,13 @@ namespace mt_kahypar {
     str << "  Minimum Shrink Factor:              " << params.minimum_shrink_factor << std::endl;
     str << "  Maximum Shrink Factor:              " << params.maximum_shrink_factor << std::endl;
     str << "  Vertex Degree Sampling Threshold:   " << params.vertex_degree_sampling_threshold << std::endl;
-    str << "  Number of subrounds (deterministic):" << params.num_sub_rounds_deterministic << std::endl;
-    str << std::endl << params.rating;
+    if ( params.algorithm == CoarseningAlgorithm::deterministic_multilevel_coarsener ) {
+      str << "  Number of Subrounds:                " << params.num_sub_rounds_deterministic << std::endl;
+      str << "  Resolve Node Swaps:                 " << std::boolalpha << params.det_resolve_swaps << std::endl;
+    }
+    if ( params.algorithm == CoarseningAlgorithm::multilevel_coarsener || params.algorithm == CoarseningAlgorithm::nlevel_coarsener ) {
+      str << std::endl << params.rating;
+    }
     return str;
   }
 

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -120,7 +120,10 @@ struct CoarseningParameters {
   double minimum_shrink_factor = std::numeric_limits<double>::max();
   double maximum_shrink_factor = std::numeric_limits<double>::max();
   size_t vertex_degree_sampling_threshold = std::numeric_limits<size_t>::max();
+
+  // parameters for deterministic coarsening
   size_t num_sub_rounds_deterministic = 16;
+  bool det_resolve_swaps = true;
 
   // Those will be determined dynamically
   HypernodeWeight max_allowed_node_weight = 0;

--- a/tests/partition/determinism/determinism_test.cc
+++ b/tests/partition/determinism/determinism_test.cc
@@ -86,6 +86,7 @@ public:
     context.preprocessing.community_detection.min_vertex_move_fraction = 0.01;
 
     // coarsening
+    context.coarsening.det_resolve_swaps = true;
     context.coarsening.num_sub_rounds_deterministic = 3;
     context.coarsening.contraction_limit = 320;
     context.coarsening.max_allowed_node_weight = 30;


### PR DESCRIPTION
Improved coarsening from https://arxiv.org/abs/2504.12013

The PR contains additional optimizations, most impactful is the introduction of a cache efficient rating map. This accounts for most of the speedup compared to the paper.

The prefix doubling code is <strike>included but will be disabled in the preset</strike> not included.

Quality:

![comparison_pr](https://github.com/user-attachments/assets/c51df979-93c4-4573-8865-b8df8ad235ca)

Running time on hypergraphs, irregular & regular graphs (with prefix doubling active):

<img src="https://github.com/user-attachments/assets/88586cd5-30df-4e3d-91c1-dbe4ffc36953" width="250"/>
<img src="https://github.com/user-attachments/assets/a30e7c41-1b98-4a38-9394-e508bdf1341f" width="250"/>
<img src="https://github.com/user-attachments/assets/fbf8b77b-a458-4154-acf0-d4629b898e34" width="250"/>
