### PR TITLE
Keep hypergraph alive after `partition()` and `map_onto_graph()`

### DIFF
--- a/python/module.cpp
+++ b/python/module.cpp
@@ -534,7 +534,7 @@ corresponding node or -1 if the node is not fixed.
   that spans a subset of the nodes (in our case the hyperedges) on the target graph. This objective function
   is able to acurately model wire-lengths in VLSI design or communication costs in a distributed system where some
   processors do not communicate directly with each other or different speeds.
-          )pbdoc", py::arg("target_graph"), py::arg("context"))
+          )pbdoc", py::arg("target_graph"), py::arg("context"), py::keep_alive<0, 1>())
   .def("create_partitioned_hypergraph",
     [&](mt_kahypar_hypergraph_t hypergraph,
         const Context& context,

--- a/python/module.cpp
+++ b/python/module.cpp
@@ -520,7 +520,7 @@ corresponding node or -1 if the node is not fixed.
       [&](mt_kahypar_hypergraph_t hypergraph, const Context& context) {
         return lib::partition(hypergraph, context);
       }, "Partitions the hypergraph with the parameters given in the partitioning context",
-      py::arg("context"))
+      py::arg("context"), py::keep_alive<0, 1>())
     .def("map_onto_graph",
       [&](mt_kahypar_hypergraph_t hypergraph, mt_kahypar_py_target_graph_t graph, const Context& context) {
         TargetGraph target_graph(target_graph_cast(graph).copy());

--- a/python/tests/test_mtkahypar.py
+++ b/python/tests/test_mtkahypar.py
@@ -42,6 +42,10 @@ def _make_partitioned_hg(context):
   hypergraph = mtk.create_hypergraph(context, 7, 4, [[0,2],[0,1,3,4],[3,4,6],[2,5,6]])
   return hypergraph.partition(context)
 
+def _make_mapped_hg(context, target_graph):
+  hypergraph = mtk.hypergraph_from_file(mydir + "/test_instances/ibm01.hgr", context)
+  return hypergraph.map_onto_graph(target_graph, context)
+
 class MainTest(unittest.TestCase):
 
   def test_set_partitioning_parameters_in_context(self):
@@ -1123,6 +1127,13 @@ class MainTest(unittest.TestCase):
     context.set_partitioning_parameters(2, 0.03, mtkahypar.Objective.KM1)
     partitioned_hg = _make_partitioned_hg(context)
     self.assertEqual(len(partitioned_hg.get_partition()), 7)
+
+  def test_map_onto_hypergraph(self):
+    context = mtk.context_from_preset(mtkahypar.PresetType.DEFAULT)
+    context.set_partitioning_parameters(8, 0.03, mtkahypar.Objective.KM1)
+    target_graph = mtk.target_graph_from_file(mydir + "/test_instances/target.graph", context)
+    partitioned_hg = _make_mapped_hg(context, target_graph)
+    self.assertGreater(len(partitioned_hg.get_partition()), 0)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_mtkahypar.py
+++ b/python/tests/test_mtkahypar.py
@@ -36,6 +36,12 @@ logging = False
 
 mtk = mtkahypar.initialize(multiprocessing.cpu_count())
 
+# See test_partition_hypergraph_keeps_graph_alive.
+# When `hypergraph` goes out of scope, it should _not_ be deleted.
+def _make_partitioned_hg(context):
+  hypergraph = mtk.create_hypergraph(context, 7, 4, [[0,2],[0,1,3,4],[3,4,6],[2,5,6]])
+  return hypergraph.partition(context)
+
 class MainTest(unittest.TestCase):
 
   def test_set_partitioning_parameters_in_context(self):
@@ -1111,6 +1117,13 @@ class MainTest(unittest.TestCase):
     partitioner.addFixedVertices()
     partitioner.partition()
     partitioner.improvePartition(1)
+
+  def test_partition_hypergraph_keeps_graph_alive(self):
+    context = mtk.context_from_preset(mtkahypar.PresetType.DEFAULT)
+    context.set_partitioning_parameters(2, 0.03, mtkahypar.Objective.KM1)
+    partitioned_hg = _make_partitioned_hg(context)
+    self.assertEqual(len(partitioned_hg.get_partition()), 7)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Indicate that the partitioned hypergraph returned by `hypergraph.partition()` has a reference to the original hypergraph. Without this, the added test case segfaults.