### PR TITLE
Proper Handling of Empty Blocks

### DIFF
--- a/config/large_k_preset.ini
+++ b/config/large_k_preset.ini
@@ -5,6 +5,7 @@ maxnet-removal-factor=0.01
 smallest-maxnet-threshold=50000
 maxnet-ignore=1000
 num-vcycles=0
+allow-empty-blocks=true
 # main -> shared_memory
 s-use-localized-random-shuffle=false
 s-static-balancing-work-packages=128

--- a/include/lib_generic_impls.h
+++ b/include/lib_generic_impls.h
@@ -350,7 +350,7 @@ double imbalance(mt_kahypar_partitioned_hypergraph_t p, const Context& context) 
     }
     Context c(context);
     c.setupPartWeights(phg.totalWeight());
-    return metrics::imbalance(phg, c);
+    return metrics::imbalance(phg, c).imbalance_value;
   });
 }
 

--- a/mt-kahypar/datastructures/dynamic_graph.h
+++ b/mt-kahypar/datastructures/dynamic_graph.h
@@ -340,6 +340,7 @@ class DynamicGraph {
 
   explicit DynamicGraph() :
     _num_removed_nodes(0),
+    _max_removed_degree_zero_hn_weight(0),
     _num_edges(0),
     _total_weight(0),
     _version(0),
@@ -355,6 +356,7 @@ class DynamicGraph {
 
   DynamicGraph(DynamicGraph&& other) :
     _num_removed_nodes(other._num_removed_nodes),
+    _max_removed_degree_zero_hn_weight(other._max_removed_degree_zero_hn_weight),
     _num_edges(other._num_edges),
     _total_weight(other._total_weight),
     _version(other._version),
@@ -369,6 +371,7 @@ class DynamicGraph {
 
   DynamicGraph & operator= (DynamicGraph&& other) {
     _num_removed_nodes = other._num_removed_nodes;
+    _max_removed_degree_zero_hn_weight = other._max_removed_degree_zero_hn_weight;
     _num_edges = other._num_edges;
     _total_weight = other._total_weight;
     _version = other._version;
@@ -396,6 +399,11 @@ class DynamicGraph {
   // ! Number of removed hypernodes
   HypernodeID numRemovedHypernodes() const {
     return _num_removed_nodes;
+  }
+
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _max_removed_degree_zero_hn_weight;
   }
 
   // ! Initial number of hyperedges
@@ -525,12 +533,15 @@ class DynamicGraph {
   void removeDegreeZeroHypernode(const HypernodeID u) {
     ASSERT(nodeDegree(u) == 0);
     removeHypernode(u);
+    _max_removed_degree_zero_hn_weight =
+      std::max(_max_removed_degree_zero_hn_weight, nodeWeight(u));
   }
 
   // ! Restores a degree zero hypernode
   void restoreDegreeZeroHypernode(const HypernodeID u) {
     hypernode(u).enable();
     ASSERT(nodeDegree(u) == 0);
+    _max_removed_degree_zero_hn_weight = 0;
   }
 
   // ####################### Hyperedge Information #######################
@@ -899,6 +910,8 @@ class DynamicGraph {
 
   // ! Number of removed hypernodes
   HypernodeID _num_removed_nodes;
+  // ! Maximum weight of all removed degree zero nodes
+  HypernodeWeight _max_removed_degree_zero_hn_weight;
   // ! Number of hyperedges
   HyperedgeID _num_edges;
   // ! Total weight of hypergraph

--- a/mt-kahypar/datastructures/dynamic_hypergraph.h
+++ b/mt-kahypar/datastructures/dynamic_hypergraph.h
@@ -412,6 +412,7 @@ class DynamicHypergraph {
   explicit DynamicHypergraph() :
     _num_hypernodes(0),
     _num_removed_hypernodes(0),
+    _max_removed_degree_zero_hn_weight(0),
     _num_hyperedges(0),
     _num_removed_hyperedges(0),
     _max_edge_size(0),
@@ -439,6 +440,7 @@ class DynamicHypergraph {
   DynamicHypergraph(DynamicHypergraph&& other) :
     _num_hypernodes(other._num_hypernodes),
     _num_removed_hypernodes(other._num_removed_hypernodes),
+    _max_removed_degree_zero_hn_weight(other._max_removed_degree_zero_hn_weight),
     _num_hyperedges(other._num_hyperedges),
     _num_removed_hyperedges(other._num_removed_hyperedges),
     _max_edge_size(other._max_edge_size),
@@ -465,6 +467,7 @@ class DynamicHypergraph {
   DynamicHypergraph & operator= (DynamicHypergraph&& other) {
     _num_hypernodes = other._num_hypernodes;
     _num_removed_hypernodes = other._num_removed_hypernodes;
+    _max_removed_degree_zero_hn_weight = other._max_removed_degree_zero_hn_weight;
     _num_hyperedges = other._num_hyperedges;
     _num_removed_hyperedges = other._num_removed_hyperedges;
     _max_edge_size = other._max_edge_size;
@@ -503,6 +506,11 @@ class DynamicHypergraph {
   // ! Number of removed hypernodes
   HypernodeID numRemovedHypernodes() const {
     return _num_removed_hypernodes;
+  }
+
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _max_removed_degree_zero_hn_weight;
   }
 
   // ! Initial number of hyperedges
@@ -650,12 +658,15 @@ class DynamicHypergraph {
   void removeDegreeZeroHypernode(const HypernodeID u) {
     ASSERT(nodeDegree(u) == 0);
     removeHypernode(u);
+    _max_removed_degree_zero_hn_weight =
+      std::max(_max_removed_degree_zero_hn_weight, nodeWeight(u));
   }
 
   // ! Restores a degree zero hypernode
   void restoreDegreeZeroHypernode(const HypernodeID u) {
     hypernode(u).enable();
     ASSERT(nodeDegree(u) == 0);
+    _max_removed_degree_zero_hn_weight = 0;
   }
 
   // ####################### Hyperedge Information #######################
@@ -1112,6 +1123,8 @@ class DynamicHypergraph {
   HypernodeID _num_hypernodes;
   // ! Number of removed hypernodes
   HypernodeID _num_removed_hypernodes;
+  // ! Maximum weight of all removed degree zero nodes
+  HypernodeWeight _max_removed_degree_zero_hn_weight;
   // ! Number of hyperedges
   HyperedgeID _num_hyperedges;
   // ! Number of removed hyperedges

--- a/mt-kahypar/datastructures/partitioned_graph.h
+++ b/mt-kahypar/datastructures/partitioned_graph.h
@@ -278,6 +278,11 @@ private:
     return _hg->numRemovedHypernodes();
   }
 
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _hg->maxWeightOfRemovedDegreeZeroNode();
+  }
+
   // ! Initial number of hyperedges
   HyperedgeID initialNumEdges() const {
     return _hg->initialNumEdges();

--- a/mt-kahypar/datastructures/partitioned_hypergraph.h
+++ b/mt-kahypar/datastructures/partitioned_hypergraph.h
@@ -190,6 +190,11 @@ class PartitionedHypergraph {
     return _hg->numRemovedHypernodes();
   }
 
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _hg->maxWeightOfRemovedDegreeZeroNode();
+  }
+
   // ! Initial number of hyperedges
   HyperedgeID initialNumEdges() const {
     return _hg->initialNumEdges();

--- a/mt-kahypar/datastructures/static_graph.h
+++ b/mt-kahypar/datastructures/static_graph.h
@@ -457,6 +457,7 @@ class StaticGraph {
   explicit StaticGraph() :
     _num_nodes(0),
     _num_removed_nodes(0),
+    _max_removed_degree_zero_hn_weight(0),
     _num_edges(0),
     _total_weight(0),
     _nodes(),
@@ -472,6 +473,7 @@ class StaticGraph {
   StaticGraph(StaticGraph&& other) :
     _num_nodes(other._num_nodes),
     _num_removed_nodes(other._num_removed_nodes),
+    _max_removed_degree_zero_hn_weight(other._max_removed_degree_zero_hn_weight),
     _num_edges(other._num_edges),
     _total_weight(other._total_weight),
     _nodes(std::move(other._nodes)),
@@ -487,6 +489,7 @@ class StaticGraph {
   StaticGraph & operator= (StaticGraph&& other) {
     _num_nodes = other._num_nodes;
     _num_removed_nodes = other._num_removed_nodes;
+    _max_removed_degree_zero_hn_weight = other._max_removed_degree_zero_hn_weight;
     _num_edges = other._num_edges;
     _total_weight = other._total_weight;
     _nodes = std::move(other._nodes);
@@ -518,6 +521,11 @@ class StaticGraph {
   // ! Number of removed hypernodes
   HypernodeID numRemovedHypernodes() const {
     return _num_removed_nodes;
+  }
+
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _max_removed_degree_zero_hn_weight;
   }
 
   // ! Initial number of hyperedges
@@ -630,12 +638,15 @@ class StaticGraph {
     ASSERT(nodeDegree(u) == 0);
     node(u).disable();
     ++_num_removed_nodes;
+    _max_removed_degree_zero_hn_weight =
+      std::max(_max_removed_degree_zero_hn_weight, nodeWeight(u));
   }
 
   // ! Restores a degree zero hypernode
   void restoreDegreeZeroHypernode(const HypernodeID u) {
     node(u).enable();
     ASSERT(nodeDegree(u) == 0);
+    _max_removed_degree_zero_hn_weight = 0;
   }
 
   // ####################### Hyperedge Information #######################
@@ -941,6 +952,8 @@ class StaticGraph {
   HypernodeID _num_nodes;
   // ! Number of removed nodes
   HypernodeID _num_removed_nodes;
+  // ! Maximum weight of all removed degree zero nodes
+  HypernodeWeight _max_removed_degree_zero_hn_weight;
   // ! Number of edges (note that each hyperedge is respresented as two graph edges)
   HyperedgeID _num_edges;
   // ! Total weight of the graph

--- a/mt-kahypar/datastructures/static_hypergraph.h
+++ b/mt-kahypar/datastructures/static_hypergraph.h
@@ -409,6 +409,7 @@ class StaticHypergraph {
   explicit StaticHypergraph() :
     _num_hypernodes(0),
     _num_removed_hypernodes(0),
+    _max_removed_degree_zero_hn_weight(0),
     _num_hyperedges(0),
     _num_removed_hyperedges(0),
     _max_edge_size(0),
@@ -429,6 +430,7 @@ class StaticHypergraph {
   StaticHypergraph(StaticHypergraph&& other) :
     _num_hypernodes(other._num_hypernodes),
     _num_removed_hypernodes(other._num_removed_hypernodes),
+    _max_removed_degree_zero_hn_weight(other._max_removed_degree_zero_hn_weight),
     _num_hyperedges(other._num_hyperedges),
     _num_removed_hyperedges(other._num_removed_hyperedges),
     _max_edge_size(other._max_edge_size),
@@ -449,6 +451,7 @@ class StaticHypergraph {
   StaticHypergraph & operator= (StaticHypergraph&& other) {
     _num_hypernodes = other._num_hypernodes;
     _num_removed_hypernodes = other._num_removed_hypernodes;
+    _max_removed_degree_zero_hn_weight = other._max_removed_degree_zero_hn_weight;
     _num_hyperedges = other._num_hyperedges;
     _num_removed_hyperedges = other._num_removed_hyperedges;
     _max_edge_size = other._max_edge_size;
@@ -485,6 +488,11 @@ class StaticHypergraph {
   // ! Number of removed hypernodes
   HypernodeID numRemovedHypernodes() const {
     return _num_removed_hypernodes;
+  }
+
+  // ! Max weight of removed degree zero vertex
+  HypernodeWeight maxWeightOfRemovedDegreeZeroNode() const {
+    return _max_removed_degree_zero_hn_weight;
   }
 
   // ! Initial number of hyperedges
@@ -620,12 +628,15 @@ class StaticHypergraph {
   void removeDegreeZeroHypernode(const HypernodeID u) {
     ASSERT(nodeDegree(u) == 0);
     removeHypernode(u);
+    _max_removed_degree_zero_hn_weight =
+      std::max(_max_removed_degree_zero_hn_weight, nodeWeight(u));
   }
 
   // ! Restores a degree zero hypernode
   void restoreDegreeZeroHypernode(const HypernodeID u) {
     hypernode(u).enable();
     ASSERT(nodeDegree(u) == 0);
+    _max_removed_degree_zero_hn_weight = 0;
   }
 
   // ####################### Hyperedge Information #######################
@@ -979,6 +990,8 @@ class StaticHypergraph {
   HypernodeID _num_hypernodes;
   // ! Number of removed hypernodes
   HypernodeID _num_removed_hypernodes;
+  // ! Maximum weight of all removed degree zero nodes
+  HypernodeWeight _max_removed_degree_zero_hn_weight;
   // ! Number of hyperedges
   HyperedgeID _num_hyperedges;
   // ! Number of removed hyperedges

--- a/mt-kahypar/io/command_line_options.cpp
+++ b/mt-kahypar/io/command_line_options.cpp
@@ -252,6 +252,11 @@ namespace mt_kahypar {
       context.partition.use_individual_part_weights = true;
       return value;
     })->check(CLI::PositiveNumber)->type_name("LIST[UINT]");
+    app.add_flag(
+      "--allow-empty-blocks",
+      context.partition.allow_empty_blocks,
+      "Allow that the partition leaves blocks empty."
+    );
     app.add_option(
       "--num-vcycles",
       context.partition.num_vcycles,

--- a/mt-kahypar/io/csv_output.cpp
+++ b/mt-kahypar/io/csv_output.cpp
@@ -67,7 +67,7 @@ namespace mt_kahypar::io::csv {
     s << context.partition.seed << sep;
 
     s << context.partition.epsilon << sep;
-    s << metrics::imbalance(phg, context) << sep;
+    s << metrics::imbalance(phg, context).imbalance_value << sep;
 
     s << context.partition.objective << sep;
     s << metrics::quality(phg, Objective::km1) << sep;

--- a/mt-kahypar/io/partitioning_output.cpp
+++ b/mt-kahypar/io/partitioning_output.cpp
@@ -316,10 +316,11 @@ namespace mt_kahypar::io {
                                 const Context& context,
                                 const std::string& description) {
     if (context.partition.enable_logging) {
+      BalanceMetrics imbalance = metrics::imbalance(hypergraph, context);
       LOG << description;
       LOG << context.partition.objective << "      ="
           << metrics::quality(hypergraph, context);
-      LOG << "imbalance =" << metrics::imbalance(hypergraph, context);
+      LOG << "imbalance =" << imbalance.imbalance_value;
       if (context.partition.verbose_logging) {
         LOG << "Part sizes and weights:";
         io::printPartWeightsAndSizes(hypergraph, context);
@@ -437,7 +438,11 @@ namespace mt_kahypar::io {
     if ( context.partition.objective != Objective::soed && !PartitionedHypergraph::is_graph ) {
       printKeyValue(Objective::soed, metrics::quality(hypergraph, Objective::soed));
     }
-    printKeyValue("Imbalance", metrics::imbalance(hypergraph, context));
+    BalanceMetrics imbalance = metrics::imbalance(hypergraph, context);
+    printKeyValue("Imbalance", imbalance.imbalance_value);
+    if ( context.partition.verbose_logging && !context.partition.allow_empty_blocks ) {
+      printKeyValue("Has Empty Blocks", imbalance.violates_non_empty_blocks ? "true" : "false");
+    }
     printKeyValue("Partitioning Time", std::to_string(elapsed_seconds.count()) + " s");
   }
 

--- a/mt-kahypar/io/partitioning_output.cpp
+++ b/mt-kahypar/io/partitioning_output.cpp
@@ -234,7 +234,7 @@ namespace mt_kahypar::io {
       max_part_size = std::max(max_part_size, part_sizes[i]);
       num_imbalanced_blocks +=
         (hypergraph.partWeight(i) > context.partition.max_part_weights[i] ||
-          ( context.partition.preset_type != PresetType::large_k && hypergraph.partWeight(i) == 0 ));
+          ( !context.partition.allow_empty_blocks && hypergraph.partWeight(i) == 0 ));
     }
     avg_part_weight /= context.partition.k;
 
@@ -244,7 +244,7 @@ namespace mt_kahypar::io {
       for (PartitionID i = 0; i != context.partition.k; ++i) {
         bool is_imbalanced =
                 hypergraph.partWeight(i) > context.partition.max_part_weights[i] ||
-                ( context.partition.preset_type != PresetType::large_k && hypergraph.partWeight(i) == 0 );
+                ( !context.partition.allow_empty_blocks && hypergraph.partWeight(i) == 0 );
         if ( is_imbalanced ) std::cout << RED;
         std::cout << "|block " << std::left  << std::setw(k_digits) << i
                   << std::setw(1) << "| = "  << std::right << std::setw(part_digits) << part_sizes[i]
@@ -268,7 +268,7 @@ namespace mt_kahypar::io {
         for (PartitionID i = 0; i != context.partition.k; ++i) {
           const bool is_imbalanced =
             hypergraph.partWeight(i) > context.partition.max_part_weights[i] ||
-            ( context.partition.preset_type != PresetType::large_k && hypergraph.partWeight(i) == 0 );
+            ( !context.partition.allow_empty_blocks && hypergraph.partWeight(i) == 0 );
           if ( is_imbalanced ) {
             std::cout << RED << "|block " << std::left  << std::setw(k_digits) << i
                       << std::setw(1) << "| = "  << std::right << std::setw(part_digits) << part_sizes[i]

--- a/mt-kahypar/io/presets.cpp
+++ b/mt-kahypar/io/presets.cpp
@@ -580,6 +580,7 @@ std::vector<std::string> load_large_k_preset() {
     create_option("maxnet-removal-factor", "0.01"),
     create_option("smallest-maxnet-threshold", "50000"),
     create_option("maxnet-ignore", "1000"),
+    create_option("allow-empty-blocks", "true"),
     create_option("num-vcycles", "0"),
     // main -> shared_memory
     create_option("s-use-localized-random-shuffle", "false"),

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -205,7 +205,9 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
       if ( context.partition.objective != Objective::soed ) {
         oss << " soed=" << metrics::quality(hypergraph, Objective::soed);
       }
-      oss << " imbalance=" << metrics::imbalance(hypergraph, context);
+      BalanceMetrics imbalance = metrics::imbalance(hypergraph, context);
+      oss << " imbalance=" << imbalance.imbalance_value;
+      oss << " violates_non_empty_blocks=" << imbalance.violates_non_empty_blocks;
     }
     oss << " totalPartitionTime=" << elapsed_seconds.count();
 

--- a/mt-kahypar/io/sql_plottools_serializer.cpp
+++ b/mt-kahypar/io/sql_plottools_serializer.cpp
@@ -63,6 +63,7 @@ std::string serialize(const PartitionedHypergraph& hypergraph,
         << " seed=" << context.partition.seed
         << " num_vcycles=" << context.partition.num_vcycles
         << " deterministic=" << context.partition.deterministic
+        << " allow_empty_blocks=" << context.partition.allow_empty_blocks
         << " perform_parallel_recursion_in_deep_multilevel=" << context.partition.perform_parallel_recursion_in_deep_multilevel;
     oss << " large_hyperedge_size_threshold_factor=" << context.partition.large_hyperedge_size_threshold_factor
         << " smallest_large_he_size_threshold=" << context.partition.smallest_large_he_size_threshold

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
@@ -122,7 +122,7 @@ namespace mt_kahypar {
   void MultilevelUncoarsener<TypeTraits>::rebalancingImpl() {
     // If we reach the top-level hypergraph and the partition is still imbalanced,
     // we use a rebalancing algorithm to restore balance.
-    if (_context.type == ContextType::main && !metrics::isBalanced(*_uncoarseningData.partitioned_hg, _context)) {
+    if (_context.type == ContextType::main && !metrics::isValidPartition(*_uncoarseningData.partitioned_hg, _context)) {
       Base::applyRebalancing();
     }
   }
@@ -177,7 +177,7 @@ namespace mt_kahypar {
     if ( _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
       _rebalancer->initialize(phg);
     }
-    if ( !metrics::isBalanced(partitioned_hypergraph, _context) && _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
+    if ( !metrics::isValidPartition(partitioned_hypergraph, _context) && _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
       _timer.start_timer("rebalance", "Rebalance");
       _rebalancer->refine(phg, dummy, _current_metrics, 0.0);
       _timer.stop_timer("rebalance");

--- a/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/multilevel_uncoarsener.cpp
@@ -101,6 +101,9 @@ namespace mt_kahypar {
       partitioned_hg.initializePartition();
       _timer.stop_timer("projecting_partition");
 
+      // some imbalance constraints (empty blocks) can be different on top level
+      _current_metrics.imbalance = metrics::imbalance(partitioned_hg, _context);
+
       // Improve partition
       IUncoarsener<TypeTraits>::refine();
 
@@ -168,15 +171,22 @@ namespace mt_kahypar {
     }
 
     parallel::scalable_vector<HypernodeID> dummy;
-    bool improvement_found = true;
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
+
+    ASSERT(_rebalancer);
+    if ( _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
+      _rebalancer->initialize(phg);
+    }
+    if ( !metrics::isBalanced(partitioned_hypergraph, _context) && _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
+      _timer.start_timer("rebalance", "Rebalance");
+      _rebalancer->refine(phg, dummy, _current_metrics, 0.0);
+      _timer.stop_timer("rebalance");
+    }
+
+    bool improvement_found = true;
     while( improvement_found ) {
       improvement_found = false;
       const HyperedgeWeight metric_before = _current_metrics.quality;
-
-      if ( _rebalancer && _context.refinement.rebalancing.algorithm != RebalancingAlgorithm::do_nothing ) {
-        _rebalancer->initialize(phg);
-      }
 
       if ( _label_propagation && _context.refinement.label_propagation.algorithm != LabelPropagationAlgorithm::do_nothing ) {
         _timer.start_timer("initialize_lp_refiner", "Initialize LP Refiner");

--- a/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
+++ b/mt-kahypar/partition/coarsening/nlevel_uncoarsener.cpp
@@ -249,7 +249,7 @@ namespace mt_kahypar {
   void NLevelUncoarsener<TypeTraits>::rebalancingImpl() {
     // If we reach the top-level hypergraph and the partition is still imbalanced,
     // we use a rebalancing algorithm to restore balance.
-    if ( _context.type == ContextType::main && !metrics::isBalanced(*_uncoarseningData.partitioned_hg, _context)) {
+    if ( _context.type == ContextType::main && !metrics::isValidPartition(*_uncoarseningData.partitioned_hg, _context)) {
       Base::applyRebalancing();
     }
   }

--- a/mt-kahypar/partition/coarsening/uncoarsener_base.h
+++ b/mt-kahypar/partition/coarsening/uncoarsener_base.h
@@ -117,7 +117,7 @@ class UncoarsenerBase {
     if ( _context.partition.objective != Objective::km1 ) {
       stats.add_stat("initial_km1", metrics::quality(phg, Objective::km1));
     }
-    stats.add_stat("initial_imbalance", m.imbalance);
+    stats.add_stat("initial_imbalance", m.imbalance.imbalance_value);
     return m;
   }
 
@@ -147,7 +147,7 @@ class UncoarsenerBase {
     const HyperedgeWeight quality_before = _current_metrics.quality;
     if (logging) {
       LOG << RED << "Partition is imbalanced (Current Imbalance:"
-      << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context) << ")" << END;
+      << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context).imbalance_value << ")" << END;
 
       LOG << "Part weights: (violations in red)";
       io::printPartWeightsAndSizes(*_uncoarseningData.partitioned_hg, _context);
@@ -170,10 +170,10 @@ class UncoarsenerBase {
         const HyperedgeWeight quality_delta = quality_after - quality_before;
         if (quality_delta > 0) {
           LOG << RED << "Rebalancer decreased solution quality by" << quality_delta
-          << "(Current Imbalance:" << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context) << ")" << END;
+          << "(Current Imbalance:" << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context).imbalance_value << ")" << END;
         } else {
           LOG << GREEN << "Rebalancer improves solution quality by" << abs(quality_delta)
-          << "(Current Imbalance:" << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context) << ")" << END;
+          << "(Current Imbalance:" << metrics::imbalance(*_uncoarseningData.partitioned_hg, _context).imbalance_value << ")" << END;
         }
       }
     } else {

--- a/mt-kahypar/partition/context.cpp
+++ b/mt-kahypar/partition/context.cpp
@@ -66,6 +66,10 @@ namespace mt_kahypar {
     str << "  Number of V-Cycles:                 " << params.num_vcycles << std::endl;
     str << "  Ignore HE Size Threshold:           " << params.ignore_hyperedge_size_threshold << std::endl;
     str << "  Large HE Size Threshold:            " << params.large_hyperedge_size_threshold << std::endl;
+    if ( params.allow_empty_blocks || verbose ) {
+      str << "  Allow Empty Blocks:                 " << std::boolalpha
+          << params.allow_empty_blocks << std::endl;
+    }
     if ( params.use_individual_part_weights ) {
       str << "  Individual Part Weights:            ";
       for ( const HypernodeWeight& w : params.max_part_weights ) {

--- a/mt-kahypar/partition/context.h
+++ b/mt-kahypar/partition/context.h
@@ -50,6 +50,7 @@ struct PartitioningParameters {
   bool perform_parallel_recursion_in_deep_multilevel = true;
 
   int time_limit = 0;
+  bool allow_empty_blocks = false;
   bool use_individual_part_weights = false;
   std::vector<HypernodeWeight> perfect_balance_part_weights;
   std::vector<HypernodeWeight> max_part_weights;

--- a/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
+++ b/mt-kahypar/partition/initial_partitioning/initial_partitioning_data_container.h
@@ -62,23 +62,17 @@ class InitialPartitioningDataContainer {
     PartitioningResult(InitialPartitioningAlgorithm algorithm,
                        HyperedgeWeight objective_ip,
                        HyperedgeWeight objective,
-                       double imbalance) :
+                       BalanceMetrics imbalance) :
       _algorithm(algorithm),
       _objective_ip(objective_ip),
       _objective(objective),
       _imbalance(imbalance) { }
 
-    bool is_other_better(const PartitioningResult& other, const double epsilon) const {
-      bool equal_metric = other._objective == _objective;
-      bool improved_metric = other._objective < _objective;
-      bool improved_imbalance = other._imbalance < _imbalance;
-      bool is_feasible = _imbalance <= epsilon;
-      bool is_other_feasible = other._imbalance <= epsilon;
-      return ( improved_metric && (is_other_feasible || improved_imbalance) ) ||
-             ( equal_metric && improved_imbalance ) ||
-             ( is_other_feasible && !is_feasible ) ||
-             ( improved_imbalance && !is_other_feasible && !is_feasible ) ||
-             ( equal_metric && _imbalance == other._imbalance     // tie breaking for deterministic mode
+    bool is_other_better(const PartitioningResult& other) const {
+      Metrics my_metric{_objective, _imbalance};
+      Metrics other_metric{other._objective, other._imbalance};
+      return other_metric.isBetter(my_metric) ||
+             ( other_metric.isEqual(my_metric)     // tie breaking for deterministic mode
                 && std::tie(other._random_tag, other._deterministic_tag) < std::tie(_random_tag, _deterministic_tag) );
     }
 
@@ -94,7 +88,7 @@ class InitialPartitioningDataContainer {
     InitialPartitioningAlgorithm _algorithm = InitialPartitioningAlgorithm::UNDEFINED;
     HyperedgeWeight _objective_ip = std::numeric_limits<HyperedgeWeight>::max();
     HyperedgeWeight _objective = std::numeric_limits<HyperedgeWeight>::max();
-    double _imbalance = std::numeric_limits<double>::max();
+    BalanceMetrics _imbalance;
     size_t _random_tag = std::numeric_limits<size_t>::max();
     size_t _deterministic_tag = std::numeric_limits<size_t>::max();
   };
@@ -202,7 +196,7 @@ class InitialPartitioningDataContainer {
       _result(InitialPartitioningAlgorithm::UNDEFINED,
               std::numeric_limits<HyperedgeWeight>::max(),
               std::numeric_limits<HyperedgeWeight>::max(),
-              std::numeric_limits<double>::max()),
+              BalanceMetrics()),
       _gain_cache(GainCachePtr::constructGainCache(context)),
       _rebalancer(nullptr),
       _label_propagation(nullptr),
@@ -255,7 +249,7 @@ class InitialPartitioningDataContainer {
       ++_stats[algorithm_index].total_calls;
 
       _global_stats.add_run(algorithm, current_metric.quality,
-        current_metric.imbalance <= _context.partition.epsilon);
+        current_metric.imbalance.isValidPartition());
 
       return result;
     }
@@ -290,7 +284,7 @@ class InitialPartitioningDataContainer {
       auto refined = performRefinementOnPartition(_partition, _result, prng);
 
       // Compare current best partition with refined partition
-      if ( _result.is_other_better(refined, _context.partition.epsilon) ) {
+      if ( _result.is_other_better(refined) ) {
         for ( const HypernodeID& hn : _partitioned_hypergraph.nodes() ) {
           const PartitionID part_id = _partitioned_hypergraph.partID(hn);
           ASSERT(hn < _partition.size());
@@ -495,20 +489,19 @@ class InitialPartitioningDataContainer {
     // already commits the result if non-deterministic
     auto& my_ip_data = _local_hg.local();
     auto my_result = my_ip_data.refineAndUpdateStats(algorithm, prng, time);
-    const double eps = _context.partition.epsilon;
 
     if ( _context.partition.deterministic ) {
       // apply result to shared pool
       my_result._random_tag = prng();   // this is deterministic since we call the prng owned exclusively by the flat IP algo object
       my_result._deterministic_tag = deterministic_tag;
       PartitioningResult worst_in_population = _best_partitions[0].first;
-      if (worst_in_population.is_other_better(my_result, eps)) {
+      if (worst_in_population.is_other_better(my_result)) {
         _pop_lock.lock();
         worst_in_population = _best_partitions[0].first;
-        if (worst_in_population.is_other_better(my_result, eps)) {
+        if (worst_in_population.is_other_better(my_result)) {
           // remove current worst and replace with my result
           my_ip_data.copyPartition(_best_partitions[0].second);
-          auto comp = [&](const auto& l, const auto& r) { return r.first.is_other_better(l.first, eps); };
+          auto comp = [&](const auto& l, const auto& r) { return r.first.is_other_better(l.first); };
           assert(std::is_heap(_best_partitions.begin(), _best_partitions.end(), comp));
           _best_partitions[0].first = my_result;
           std::pop_heap(_best_partitions.begin(), _best_partitions.end(), comp);
@@ -517,7 +510,7 @@ class InitialPartitioningDataContainer {
         _pop_lock.unlock();
       }
     } else {
-      if (my_ip_data._result.is_other_better(my_result, eps)) {
+      if (my_ip_data._result.is_other_better(my_result)) {
         my_ip_data._result = my_result;
         my_ip_data.copyPartition(my_ip_data._partition);
       }
@@ -554,7 +547,7 @@ class InitialPartitioningDataContainer {
 
       // bring them in a deterministic order
       std::sort(_best_partitions.begin(), _best_partitions.end(), [&](const auto& l, const auto& r) {
-        return r.first.is_other_better(l.first, _context.partition.epsilon);
+        return r.first.is_other_better(l.first);
       });
 
       if ( _context.initial_partitioning.perform_refinement_on_best_partitions ) {
@@ -568,7 +561,7 @@ class InitialPartitioningDataContainer {
           refined._deterministic_tag = my_objectives._deterministic_tag;
           refined._random_tag = my_objectives._random_tag;
 
-          if (my_objectives.is_other_better(refined, _context.partition.epsilon)) {
+          if (my_objectives.is_other_better(refined)) {
             for (HypernodeID node : my_phg.nodes()) {
               my_partition[node] = my_phg.partID(node);
             }
@@ -585,7 +578,7 @@ class InitialPartitioningDataContainer {
 
       size_t best_index = 0;
       for (size_t i = 1; i < _best_partitions.size(); ++i) {
-        if (_best_partitions[best_index].first.is_other_better(_best_partitions[i].first, _context.partition.epsilon) ) {
+        if (_best_partitions[best_index].first.is_other_better(_best_partitions[i].first) ) {
           best_index = i;
         }
       }
@@ -621,15 +614,15 @@ class InitialPartitioningDataContainer {
       for ( LocalInitialPartitioningHypergraph& partition : _local_hg ) {
         ++number_of_threads;
         partition.aggregate_stats(stats);
-        if ( !best || best->_result.is_other_better(partition._result, _context.partition.epsilon) ) {
+        if ( !best || best->_result.is_other_better(partition._result) ) {
           best = &partition;
         }
-        if ( !worst || !worst->_result.is_other_better(partition._result, _context.partition.epsilon) ) {
+        if ( !worst || !worst->_result.is_other_better(partition._result) ) {
           worst = &partition;
         }
-        if ( !best_imbalance || best_imbalance->_result._imbalance > partition._result._imbalance ||
-             (best_imbalance->_result._imbalance == partition._result._imbalance &&
-              best_objective->_result._objective > partition._result._objective)) {
+        if ( !best_imbalance || partition._result._imbalance.isBetter(best_imbalance->_result._imbalance) ||
+             (best_imbalance->_result._imbalance.isEqual(partition._result._imbalance) &&
+              best_imbalance->_result._objective > partition._result._objective)) {
           best_imbalance = &partition;
         }
         if ( !best_objective || best_objective->_result._objective > partition._result._objective ) {

--- a/mt-kahypar/partition/mapping/greedy_mapping.cpp
+++ b/mt-kahypar/partition/mapping/greedy_mapping.cpp
@@ -264,11 +264,13 @@ void GreedyMapping<CommunicationHypergraph>::mapToTargetGraph(CommunicationHyper
 
   utils::Timer& timer = utils::Utilities::instance().getTimer(context.utility_id);
   SpinLock best_lock;
-  HyperedgeWeight best_objective = metrics::quality(communication_hg, Objective::steiner_tree);
-  double best_imbalance = metrics::imbalance(communication_hg, context);
+  Metrics best_metrics;
+  best_metrics.quality = metrics::quality(communication_hg, Objective::steiner_tree);
+  best_metrics.imbalance = metrics::imbalance(communication_hg, context);
   HypernodeID best_hn_id = kInvalidHypernode;
   vec<PartitionID> best_mapping(communication_hg.initialNumNodes(), 0);
   std::iota(best_mapping.begin(), best_mapping.end(), 0);
+
   timer.start_timer("initial_mapping", "Initial Mapping");
   communication_hg.doParallelForAllNodes([&](const HypernodeID& hn) {
     // Compute greedy mapping with the current node as seed node
@@ -282,22 +284,13 @@ void GreedyMapping<CommunicationHypergraph>::mapToTargetGraph(CommunicationHyper
     }
 
     // Check if new mapping is better than the currently best mapping
-    const HyperedgeWeight objective = metrics::quality(tmp_communication_phg, Objective::steiner_tree);
-    const double imbalance = metrics::imbalance(tmp_communication_phg, context);
+    Metrics current_metrics;
+    current_metrics.quality = metrics::quality(tmp_communication_phg, Objective::steiner_tree);
+    current_metrics.imbalance = metrics::imbalance(tmp_communication_phg, context);
     best_lock.lock();
-    // TODO: make this less ugly along with the metrics refactoring
-    bool equal_metric = objective == best_objective;
-    bool improved_metric = objective < best_objective;
-    bool improved_imbalance = imbalance < best_imbalance;
-    bool is_feasible = imbalance <= context.partition.epsilon;
-    bool is_best_feasible = best_imbalance <= context.partition.epsilon;
-    if ( ( improved_metric && (is_feasible || improved_imbalance) ) ||
-         ( equal_metric && improved_imbalance ) ||
-         ( is_feasible && !is_best_feasible ) ||
-         ( improved_imbalance && !is_feasible && !is_best_feasible ) ||
-         ( equal_metric && imbalance == best_imbalance && hn > best_hn_id)) {
-      best_objective = objective;
-      best_imbalance = imbalance;
+    if ( current_metrics.isBetter(best_metrics) ||
+         (current_metrics.isEqual(best_metrics) && hn > best_hn_id) ) {
+      best_metrics = current_metrics;
       best_hn_id = hn;
       for ( const HypernodeID& u : tmp_communication_phg.nodes() ) {
         best_mapping[u] = tmp_communication_phg.partID(u);

--- a/mt-kahypar/partition/metrics.cpp
+++ b/mt-kahypar/partition/metrics.cpp
@@ -155,7 +155,7 @@ bool isBalanced(const PartitionedHypergraph& phg, const Context& context) {
       num_empty_parts++;
     }
   }
-  return context.partition.preset_type == PresetType::large_k ||
+  return context.partition.allow_empty_blocks ||
     num_empty_parts <= phg.numRemovedHypernodes();
 }
 

--- a/mt-kahypar/partition/metrics.cpp
+++ b/mt-kahypar/partition/metrics.cpp
@@ -207,6 +207,7 @@ BalanceMetrics imbalance_impl(const PartitionedHypergraph& hypergraph,
   ASSERT(context.partition.perfect_balance_part_weights.size() == (size_t)context.partition.k);
 
   size_t num_empty_parts = 0;
+  HypernodeWeight min_empty_part_weight = std::numeric_limits<HypernodeWeight>::max();
   double max_balance = 0.0;
   bool violates_balance = false;
   for (PartitionID i = 0; i < context.partition.k; ++i) {
@@ -219,11 +220,16 @@ BalanceMetrics imbalance_impl(const PartitionedHypergraph& hypergraph,
     }
     if (part_weight == 0) {
       num_empty_parts++;
+      min_empty_part_weight = std::min(min_empty_part_weight, max_part_weights[i]);
     }
   }
+
   bool too_many_empty_parts = num_empty_parts > hypergraph.numRemovedHypernodes();
+  // use conservative estimate
+  bool too_small_empty_parts = num_empty_parts > 0
+    && min_empty_part_weight < hypergraph.maxWeightOfRemovedDegreeZeroNode();
   return BalanceMetrics{max_balance - 1.0, violates_balance,
-    !context.partition.allow_empty_blocks && too_many_empty_parts};
+    !context.partition.allow_empty_blocks && (too_many_empty_parts || too_small_empty_parts)};
 }
 
 template<typename PartitionedHypergraph>

--- a/mt-kahypar/partition/metrics.cpp
+++ b/mt-kahypar/partition/metrics.cpp
@@ -34,7 +34,56 @@
 #include "mt-kahypar/partition/mapping/target_graph.h"
 #include "mt-kahypar/utils/exception.h"
 
-namespace mt_kahypar::metrics {
+namespace mt_kahypar {
+
+int numViolations(const BalanceMetrics& imbalance) {
+  return (imbalance.violates_balance ? 1 : 0) + (imbalance.violates_non_empty_blocks ? 1 : 0);
+}
+
+bool BalanceMetrics::isValidPartition() const {
+  return numViolations(*this) == 0;
+}
+
+bool BalanceMetrics::isBetter(const BalanceMetrics& other) const {
+  return numViolations(*this) < numViolations(other) ||
+    (numViolations(*this) == numViolations(other) && imbalance_value < other.imbalance_value);
+}
+
+bool BalanceMetrics::isEqual(const BalanceMetrics& other) const {
+  return numViolations(*this) == numViolations(other) && imbalance_value == other.imbalance_value;
+}
+
+bool BalanceMetrics::operator==(const BalanceMetrics& other) const {
+  return imbalance_value == other.imbalance_value &&
+    violates_balance == other.violates_balance &&
+    violates_non_empty_blocks == other.violates_non_empty_blocks;
+}
+
+bool Metrics::isBetter(const Metrics& other) const {
+  if (numViolations(imbalance) < numViolations(other.imbalance)) {
+    return true;
+  } else if (numViolations(imbalance) == numViolations(other.imbalance)) {
+    bool improvesBalanceViolation = other.imbalance.violates_balance && imbalance.isBetter(other.imbalance);
+    bool worsensBalanceViolation = imbalance.violates_balance && other.imbalance.isBetter(imbalance);
+    return improvesBalanceViolation
+           || (!worsensBalanceViolation && quality < other.quality)
+           || (!worsensBalanceViolation && quality == other.quality
+                && imbalance.imbalance_value < other.imbalance.imbalance_value);
+  } else {
+    return false;
+  }
+}
+
+bool Metrics::isEqual(const Metrics& other) const {
+  return quality == other.quality && imbalance.isEqual(other.imbalance);
+}
+
+std::ostream& operator<< (std::ostream& os, const BalanceMetrics& imbalance) {
+  return os << "[imb: " << imbalance.imbalance_value  << "; " << (imbalance.isValidPartition() ? "valid" : "invalid") << "]";
+}
+
+
+namespace metrics {
 
 namespace {
 
@@ -145,35 +194,69 @@ HyperedgeWeight contribution(const PartitionedHypergraph& hg,
 }
 
 template<typename PartitionedHypergraph>
-bool isBalanced(const PartitionedHypergraph& phg, const Context& context) {
+bool isValidPartition(const PartitionedHypergraph& phg, const Context& context) {
+  BalanceMetrics imbalance_metrics = imbalance(phg, context);
+  return imbalance_metrics.isValidPartition();
+}
+
+template<typename PartitionedHypergraph, typename Func>
+BalanceMetrics imbalance_impl(const PartitionedHypergraph& hypergraph,
+                              const Context& context,
+                              Func&& part_weight_fn,
+                              const std::vector<HypernodeWeight>& max_part_weights) {
+  ASSERT(context.partition.perfect_balance_part_weights.size() == (size_t)context.partition.k);
+
   size_t num_empty_parts = 0;
+  double max_balance = 0.0;
+  bool violates_balance = false;
   for (PartitionID i = 0; i < context.partition.k; ++i) {
-    if (phg.partWeight(i) > context.partition.max_part_weights[i]) {
-      return false;
+    const HypernodeWeight part_weight = part_weight_fn(i);
+    const double balance_i = (part_weight
+            / static_cast<double>(context.partition.perfect_balance_part_weights[i]));
+    max_balance = std::max(max_balance, balance_i);
+    if (part_weight > max_part_weights[i]) {
+      violates_balance = true;
     }
-    if (phg.partWeight(i) == 0) {
+    if (part_weight == 0) {
       num_empty_parts++;
     }
   }
-  return context.partition.allow_empty_blocks ||
-    num_empty_parts <= phg.numRemovedHypernodes();
+  bool too_many_empty_parts = num_empty_parts > hypergraph.numRemovedHypernodes();
+  return BalanceMetrics{max_balance - 1.0, violates_balance,
+    !context.partition.allow_empty_blocks && too_many_empty_parts};
 }
 
 template<typename PartitionedHypergraph>
-double imbalance(const PartitionedHypergraph& hypergraph, const Context& context) {
-  ASSERT(context.partition.perfect_balance_part_weights.size() == (size_t)context.partition.k);
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph, const Context& context) {
+  return imbalance_impl(
+    hypergraph,
+    context,
+    [&](PartitionID i) { return hypergraph.partWeight(i); },
+    context.partition.max_part_weights);
+}
 
-  double max_balance = (hypergraph.partWeight(0) /
-                        static_cast<double>(context.partition.perfect_balance_part_weights[0]));
+template<typename PartitionedHypergraph>
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph,
+                         const Context& context,
+                         const std::vector<HypernodeWeight>& max_part_weights) {
+  return imbalance_impl(
+    hypergraph,
+    context,
+    [&](PartitionID i) { return hypergraph.partWeight(i); },
+    max_part_weights);
+}
 
-  for (PartitionID i = 1; i < context.partition.k; ++i) {
-    const double balance_i =
-            (hypergraph.partWeight(i) /
-              static_cast<double>(context.partition.perfect_balance_part_weights[i]));
-    max_balance = std::max(max_balance, balance_i);
-  }
-
-  return max_balance - 1.0;
+template<typename PartitionedHypergraph>
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph,
+                         const Context& context,
+                         const vec<HypernodeWeight>& part_weights,
+                         const std::vector<HypernodeWeight>& max_part_weights) {
+  ASSERT(part_weights.size() == (size_t)context.partition.k);
+  return imbalance_impl(
+    hypergraph,
+    context,
+    [&](PartitionID i) { return part_weights[i]; },
+    max_part_weights);
 }
 
 template<typename PartitionedHypergraph>
@@ -194,16 +277,27 @@ namespace {
 #define OBJECTIVE_1(X) HyperedgeWeight quality(const X& hg, const Context& context, const bool parallel)
 #define OBJECTIVE_2(X) HyperedgeWeight quality(const X& hg, const Objective objective, const bool parallel)
 #define CONTRIBUTION(X) HyperedgeWeight contribution(const X& hg, const HyperedgeID he, const Objective objective)
-#define IS_BALANCED(X) bool isBalanced(const X& phg, const Context& context)
-#define IMBALANCE(X) double imbalance(const X& hypergraph, const Context& context)
+#define IS_VALID_PARTITION(X) bool isValidPartition(const X& phg, const Context& context)
+#define IMBALANCE_1(X) BalanceMetrics imbalance(const X& hypergraph, const Context& context)
+#define IMBALANCE_2(X) BalanceMetrics imbalance(const X& hypergraph, \
+                                                const Context& context, \
+                                                const std::vector<HypernodeWeight>& max_part_weights)
+#define IMBALANCE_3(X) BalanceMetrics imbalance(const X& hypergraph, \
+                                                const Context& context, \
+                                                const vec<HypernodeWeight>& part_weights, \
+                                                const std::vector<HypernodeWeight>& max_part_weights)
 #define APPROX_FACTOR(X) double approximationFactorForProcessMapping(const X& hypergraph, const Context& context)
 }
 
 INSTANTIATE_FUNC_WITH_PARTITIONED_HG(OBJECTIVE_1)
 INSTANTIATE_FUNC_WITH_PARTITIONED_HG(OBJECTIVE_2)
 INSTANTIATE_FUNC_WITH_PARTITIONED_HG(CONTRIBUTION)
-INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IS_BALANCED)
-INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IMBALANCE)
+INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IS_VALID_PARTITION)
+INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IMBALANCE_1)
+INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IMBALANCE_2)
+INSTANTIATE_FUNC_WITH_PARTITIONED_HG(IMBALANCE_3)
 INSTANTIATE_FUNC_WITH_PARTITIONED_HG(APPROX_FACTOR)
 
-} // namespace mt_kahypar::metrics
+} // namespace metrics
+
+} // namespace mt_kahypar

--- a/mt-kahypar/partition/metrics.h
+++ b/mt-kahypar/partition/metrics.h
@@ -27,13 +27,36 @@
 
 #pragma once
 
+#include <iostream>
+#include <limits>
+
 #include "mt-kahypar/partition/context.h"
 
 namespace mt_kahypar {
 
+struct BalanceMetrics {
+  double imbalance_value = std::numeric_limits<double>::max();
+  bool violates_balance = true;
+  bool violates_non_empty_blocks = true;
+
+  bool isValidPartition() const;
+
+  bool isBetter(const BalanceMetrics& other) const;
+
+  bool isEqual(const BalanceMetrics& other) const;
+
+  bool operator==(const BalanceMetrics& other) const;
+};
+
+std::ostream& operator<< (std::ostream& os, const BalanceMetrics& imbalance);
+
 struct Metrics {
   HyperedgeWeight quality;
-  double imbalance;
+  BalanceMetrics imbalance;
+
+  bool isBetter(const Metrics& other) const;
+
+  bool isEqual(const Metrics& other) const;
 };
 
 namespace metrics {
@@ -55,10 +78,21 @@ HyperedgeWeight contribution(const PartitionedHypergraph& hg,
                              const Objective objective);
 
 template<typename PartitionedHypergraph>
-bool isBalanced(const PartitionedHypergraph& phg, const Context& context);
+bool isValidPartition(const PartitionedHypergraph& phg, const Context& context);
 
 template<typename PartitionedHypergraph>
-double imbalance(const PartitionedHypergraph& hypergraph, const Context& context);
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph, const Context& context);
+
+template<typename PartitionedHypergraph>
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph,
+                         const Context& context,
+                         const std::vector<HypernodeWeight>& max_part_weights);
+
+template<typename PartitionedHypergraph>
+BalanceMetrics imbalance(const PartitionedHypergraph& hypergraph,
+                         const Context& context,
+                         const vec<HypernodeWeight>& part_weights,
+                         const std::vector<HypernodeWeight>& max_part_weights);
 
 template<typename PartitionedHypergraph>
 double approximationFactorForProcessMapping(const PartitionedHypergraph& hypergraph, const Context& context);

--- a/mt-kahypar/partition/preprocessing/sparsification/degree_zero_hn_remover.h
+++ b/mt-kahypar/partition/preprocessing/sparsification/degree_zero_hn_remover.h
@@ -79,7 +79,12 @@ class DegreeZeroHypernodeRemover {
       });
     // Sort blocks of partition in increasing order of their weight
     auto distance_to_max = [&](const PartitionID block) {
-      return hypergraph.partWeight(block) - _context.partition.max_part_weights[block];
+      if (!_context.partition.allow_empty_blocks && hypergraph.partWeight(block) == 0) {
+        // repairing empty blocks gets highest priority
+        return -(_context.partition.max_part_weights[block] + hypergraph.totalWeight());
+      } else {
+        return hypergraph.partWeight(block) - _context.partition.max_part_weights[block];
+      }
     };
     parallel::scalable_vector<PartitionID> blocks(_context.partition.k, 0);
     std::iota(blocks.begin(), blocks.end(), 0);

--- a/mt-kahypar/partition/recursive_bipartitioning.cpp
+++ b/mt-kahypar/partition/recursive_bipartitioning.cpp
@@ -107,7 +107,8 @@ namespace rb {
       const HypernodeWeight max_part_weights_sum = std::accumulate(context.partition.max_part_weights.cbegin(),
                                                                   context.partition.max_part_weights.cend(), 0);
       const double weight_fraction = total_weight / static_cast<double>(max_part_weights_sum);
-      ASSERT(weight_fraction <= 1.0);
+      // assertion doesn't hold if previous bipartitions are imbalanced...
+      // ASSERT(weight_fraction <= 1.0);
       b_context.partition.perfect_balance_part_weights.clear();
       b_context.partition.max_part_weights.clear();
       HypernodeWeight perfect_weight_p0 = 0;

--- a/mt-kahypar/partition/refinement/CMakeLists.txt
+++ b/mt-kahypar/partition/refinement/CMakeLists.txt
@@ -7,6 +7,7 @@ set(RefinementSources
         label_propagation/label_propagation_refiner.cpp
         rebalancing/advanced_rebalancer.cpp
         rebalancing/deterministic_rebalancer.cpp
+        rebalancing/repair_empty_blocks.cpp
         deterministic/deterministic_label_propagation.cpp
         deterministic/deterministic_jet_refiner.cpp
         flows/problem_construction.cpp

--- a/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
+++ b/mt-kahypar/partition/refinement/deterministic/deterministic_jet_refiner.h
@@ -69,7 +69,6 @@ public:
     _current_k(context.partition.k),
     _top_level_num_nodes(num_hypernodes),
     _current_partition_is_best(true),
-    _was_already_balanced(false),
     _negative_gain_factor(0.0),
     _active_nodes(),
     _tmp_active_nodes(),
@@ -128,7 +127,6 @@ private:
   PartitionID _current_k;
   HypernodeID _top_level_num_nodes;
   bool _current_partition_is_best;
-  bool _was_already_balanced;
   double _negative_gain_factor;
   ActiveNodes _active_nodes;
   ds::StreamingVector<HypernodeID> _tmp_active_nodes;

--- a/mt-kahypar/partition/refinement/flows/deterministic/deterministic_flow_refinement_scheduler.cpp
+++ b/mt-kahypar/partition/refinement/flows/deterministic/deterministic_flow_refinement_scheduler.cpp
@@ -155,7 +155,7 @@ bool DeterministicFlowRefinementScheduler<GraphAndGainTypes>::refineImpl(mt_kahy
         _quotient_graph.addNewCutHyperedge(phg, hyperedge.he, hyperedge.block);
       });
       num_scheduled_blocks = _schedule.getNextMatching(scheduled_blocks);
-      ASSERT(metrics::isBalanced(phg, _context));
+      ASSERT(!best_metrics.imbalance.isValidPartition() || metrics::isValidPartition(phg, _context));
     }
     overall_delta += round_delta;
     current_metrics.quality -= round_delta;

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.cpp
@@ -137,7 +137,7 @@ namespace mt_kahypar {
                              num_tasks, num_seeds, round);
       timer.stop_timer("find_moves");
 
-      if (is_unconstrained && !isBalanced(phg, max_part_weights)) {
+      if (is_unconstrained && !metrics::imbalance(phg, context, max_part_weights).isValidPartition()) {
         vec<vec<Move>> moves_by_part;
 
         // compute rebalancing moves

--- a/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
+++ b/mt-kahypar/partition/refinement/fm/multitry_kway_fm.h
@@ -95,15 +95,6 @@ class MultiTryKWayFM final : public IRefiner {
                                  vec<HypernodeWeight>& current_part_weights,
                                  vec<MoveID>& current_rebalancing_move_index);
 
-  bool isBalanced(const PartitionedHypergraph& phg, const std::vector<HypernodeWeight>& max_part_weights) {
-    for (PartitionID i = 0; i < context.partition.k; ++i) {
-      if (phg.partWeight(i) > max_part_weights[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   LocalizedFMSearch constructLocalizedKWayFMSearch() {
     return LocalizedFMSearch(context, initial_num_nodes, sharedData, gain_cache);
   }

--- a/mt-kahypar/partition/refinement/fm/sequential_twoway_fm_refiner.cpp
+++ b/mt-kahypar/partition/refinement/fm/sequential_twoway_fm_refiner.cpp
@@ -67,7 +67,6 @@ bool SequentialTwoWayFmRefiner<TypeTraits>::refine(Metrics& best_metrics, std::m
 
   parallel::scalable_vector<HypernodeID> performed_moves;
   HyperedgeWeight current_cut = best_metrics.quality;
-  double current_imbalance = best_metrics.imbalance;
   size_t min_cut_idx = 0;
   StopRule stopping_rule(_phg.initialNumNodes());
   while ( !_pq.empty() && !stopping_rule.searchShouldStop() ) {
@@ -117,29 +116,18 @@ bool SequentialTwoWayFmRefiner<TypeTraits>::refine(Metrics& best_metrics, std::m
       performed_moves.push_back(hn);
       DBG << "Moved hypernode" << hn << "from block" << from << "to block" << to << "with gain" << gain;
       current_cut -= gain;
-      current_imbalance = metrics::imbalance(_phg, _context);
       stopping_rule.update(gain);
 
-      const bool improved_cut_within_balance = (current_cut < best_metrics.quality) &&
-                                                ( _phg.partWeight(0)
-                                                  <= _context.partition.max_part_weights[0]) &&
-                                                ( _phg.partWeight(1)
-                                                  <= _context.partition.max_part_weights[1]);
-      const bool improved_balance_less_equal_cut = (current_imbalance < best_metrics.imbalance) &&
-                                                  (current_cut <= best_metrics.quality);
-      const bool move_is_feasible = ( _phg.partWeight(from) > 0) &&
-                                    ( improved_cut_within_balance ||
-                                      improved_balance_less_equal_cut );
-      if ( move_is_feasible ) {
+      Metrics current_metrics{current_cut, metrics::imbalance(_phg, _context)};
+      if ( current_metrics.isBetter(best_metrics) ) {
         DBG << GREEN << "2Way FM improved cut from" << best_metrics.quality << "to" << current_cut
-            << "(Imbalance:" << current_imbalance << ")" << END;
+            << "(Imbalance:" << current_metrics.imbalance << ")" << END;
         stopping_rule.reset();
-        best_metrics.quality = current_cut;
-        best_metrics.imbalance = current_imbalance;
+        best_metrics = current_metrics;
         min_cut_idx = performed_moves.size();
       } else {
         DBG << RED << "2Way FM decreased cut to" << current_cut
-            << "(Imbalance:" << current_imbalance << ")" << END;
+            << "(Imbalance:" << current_metrics.imbalance << ")" << END;
       }
     }
   }

--- a/mt-kahypar/partition/refinement/gains/km1/km1_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/km1/km1_gain_computation.h
@@ -43,6 +43,8 @@ class Km1GainComputation : public GainComputationBase<Km1GainComputation, Km1Att
  public:
   using RatingMap = typename Base::RatingMap;
 
+  static constexpr bool is_independent_of_block = true;
+
   Km1GainComputation(const Context& context,
                      bool disable_randomization = false) :
     Base(context, disable_randomization) { }
@@ -83,6 +85,20 @@ class Km1GainComputation : public GainComputationBase<Km1GainComputation, Km1Att
         }
       }
     }
+  }
+
+  // ! Computes only the gain (cut increase) for moving out of the current block.
+  template<typename PartitionedHypergraph>
+  static Gain computeIsolatedBlockGain(const PartitionedHypergraph& phg, const HypernodeID hn) {
+    Gain isolated_block_gain = 0;
+    PartitionID from = phg.partID(hn);
+    for (const HyperedgeID& he : phg.incidentEdges(hn)) {
+      HypernodeID pin_count_in_from_part = phg.pinCountInPart(he, from);
+      if ( pin_count_in_from_part > 1 ) {
+        isolated_block_gain += phg.edgeWeight(he);
+      }
+    }
+    return isolated_block_gain;
   }
 
   HyperedgeWeight gain(const Gain to_score,

--- a/mt-kahypar/partition/refinement/gains/soed/soed_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/soed/soed_gain_computation.h
@@ -43,6 +43,8 @@ class SoedGainComputation : public GainComputationBase<SoedGainComputation, Soed
  public:
   using RatingMap = typename Base::RatingMap;
 
+  static constexpr bool is_independent_of_block = true;
+
   SoedGainComputation(const Context& context,
                       bool disable_randomization = false) :
     Base(context, disable_randomization) { }
@@ -91,6 +93,21 @@ class SoedGainComputation : public GainComputationBase<SoedGainComputation, Soed
         }
       }
     }
+  }
+
+  // ! Computes only the gain (cut increase) for moving out of the current block.
+  template<typename PartitionedHypergraph>
+  static Gain computeIsolatedBlockGain(const PartitionedHypergraph& phg, const HypernodeID hn) {
+    Gain isolated_block_gain = 0;
+    PartitionID from = phg.partID(hn);
+    for (const HyperedgeID& he : phg.incidentEdges(hn)) {
+      const HypernodeID edge_size = phg.edgeSize(he);
+      HypernodeID pin_count_in_from_part = phg.pinCountInPart(he, from);
+      if ( pin_count_in_from_part > 1 ) {
+        isolated_block_gain += (pin_count_in_from_part == edge_size ? 2 : 1) * phg.edgeWeight(he);
+      }
+    }
+    return isolated_block_gain;
   }
 
   HyperedgeWeight gain(const Gain to_score,

--- a/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_computation.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree/steiner_tree_gain_computation.h
@@ -48,6 +48,8 @@ class SteinerTreeGainComputation : public GainComputationBase<SteinerTreeGainCom
  public:
   using RatingMap = typename Base::RatingMap;
 
+  static constexpr bool is_independent_of_block = false;
+
   SteinerTreeGainComputation(const Context& context,
                                 bool disable_randomization = false) :
     Base(context, disable_randomization),

--- a/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_computation_for_graphs.h
+++ b/mt-kahypar/partition/refinement/gains/steiner_tree_for_graphs/steiner_tree_gain_computation_for_graphs.h
@@ -48,6 +48,8 @@ class GraphSteinerTreeGainComputation : public GainComputationBase<GraphSteinerT
  public:
   using RatingMap = typename Base::RatingMap;
 
+  static constexpr bool is_independent_of_block = false;
+
   GraphSteinerTreeGainComputation(const Context& context,
                                      bool disable_randomization = false) :
     Base(context, disable_randomization),

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.cpp
@@ -30,7 +30,6 @@
 #include <tbb/parallel_for.h>
 
 #include "mt-kahypar/definitions.h"
-#include "mt-kahypar/partition/metrics.h"
 #include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
 #include "mt-kahypar/utils/randomize.h"
 #include "mt-kahypar/utils/utilities.h"
@@ -42,9 +41,9 @@ namespace mt_kahypar {
   template <typename GraphAndGainTypes>
   template<bool unconstrained, typename F>
   bool LabelPropagationRefiner<GraphAndGainTypes>::moveVertex(PartitionedHypergraph& hypergraph,
-                                                           const HypernodeID hn,
-                                                           NextActiveNodes& next_active_nodes,
-                                                           const F& objective_delta) {
+                                                              const HypernodeID hn,
+                                                              NextActiveNodes& next_active_nodes,
+                                                              const F& objective_delta) {
     bool is_moved = false;
     ASSERT(hn != kInvalidHypernode);
     if ( hypergraph.isBorderNode(hn) && !hypergraph.isFixed(hn) ) {
@@ -96,9 +95,9 @@ namespace mt_kahypar {
 
   template <typename GraphAndGainTypes>
   bool LabelPropagationRefiner<GraphAndGainTypes>::refineImpl(mt_kahypar_partitioned_hypergraph_t& phg,
-                                                           const vec<HypernodeID>& refinement_nodes,
-                                                           Metrics& best_metrics,
-                                                           const double)  {
+                                                              const vec<HypernodeID>& refinement_nodes,
+                                                              Metrics& best_metrics,
+                                                              const double)  {
     PartitionedHypergraph& hypergraph = utils::cast<PartitionedHypergraph>(phg);
     resizeDataStructuresForCurrentK();
     _gain.reset();
@@ -127,7 +126,7 @@ namespace mt_kahypar {
 
   template <typename GraphAndGainTypes>
   void LabelPropagationRefiner<GraphAndGainTypes>::labelPropagation(PartitionedHypergraph& hypergraph,
-                                                                 Metrics& best_metrics) {
+                                                                    Metrics& best_metrics) {
     NextActiveNodes next_active_nodes;
     vec<Move> rebalance_moves;
     bool should_stop = false;
@@ -147,17 +146,17 @@ namespace mt_kahypar {
 
   template <typename GraphAndGainTypes>
   bool LabelPropagationRefiner<GraphAndGainTypes>::labelPropagationRound(PartitionedHypergraph& hypergraph,
-                                                                      NextActiveNodes& next_active_nodes,
-                                                                      Metrics& best_metrics,
-                                                                      vec<Move>& rebalance_moves,
-                                                                      bool unconstrained_lp) {
+                                                                         NextActiveNodes& next_active_nodes,
+                                                                         Metrics& best_metrics,
+                                                                         vec<Move>& rebalance_moves,
+                                                                         bool unconstrained_lp) {
     Metrics current_metrics = best_metrics;
     _visited_he.reset();
     _next_active.reset();
     _gain.reset();
 
     if (unconstrained_lp) {
-      _old_partition_is_balanced = metrics::isBalanced(hypergraph, _context);
+      ASSERT(best_metrics.imbalance == metrics::imbalance(hypergraph, _context));
       moveActiveNodes<true>(hypergraph, next_active_nodes);
     } else {
       moveActiveNodes<false>(hypergraph, next_active_nodes);
@@ -177,7 +176,7 @@ namespace mt_kahypar {
     bool did_rebalance = false;
     bool should_stop = false;
     if ( unconstrained_lp ) {
-      if (!metrics::isBalanced(hypergraph, _context)) {
+      if (!metrics::isValidPartition(hypergraph, _context)) {
         should_stop = applyRebalancing(hypergraph, best_metrics, current_metrics, rebalance_moves);
         // rebalancer might initialize the gain cache
         should_update_gain_cache = GainCache::invalidates_entries && _gain_cache.isInitialized() && should_stop;
@@ -208,8 +207,7 @@ namespace mt_kahypar {
     // not decrease. Race conditions during applying/reverting moves can lead to a situation where reverting some moves
     // looks beneficial but results in a net negative. This is however so rare in practice that we can accept it instead
     // of investing more running time to fix it.
-    ASSERT(!did_rebalance || current_metrics.quality <= best_metrics.quality ||
-            (!_old_partition_is_balanced && current_metrics.imbalance < best_metrics.imbalance));
+    ASSERT(!did_rebalance || !best_metrics.isBetter(current_metrics));
     unused(did_rebalance);
     const Gain old_quality = best_metrics.quality;
     best_metrics = current_metrics;
@@ -222,7 +220,7 @@ namespace mt_kahypar {
   template <typename GraphAndGainTypes>
   template<bool unconstrained>
   void LabelPropagationRefiner<GraphAndGainTypes>::moveActiveNodes(PartitionedHypergraph& phg,
-                                                                NextActiveNodes& next_active_nodes) {
+                                                                   NextActiveNodes& next_active_nodes) {
     // This function is passed as lambda to the changeNodePart function and used
     // to calculate the "real" delta of a move (in terms of the used objective function).
     auto objective_delta = [&](const SynchronizedEdgeUpdate& sync_update) {
@@ -257,9 +255,9 @@ namespace mt_kahypar {
 
   template <typename GraphAndGainTypes>
   bool LabelPropagationRefiner<GraphAndGainTypes>::applyRebalancing(PartitionedHypergraph& hypergraph,
-                                                                 Metrics& best_metrics,
-                                                                 Metrics& current_metrics,
-                                                                 vec<Move>& rebalance_moves) {
+                                                                    const Metrics& best_metrics,
+                                                                    Metrics& current_metrics,
+                                                                    vec<Move>& rebalance_moves) {
     utils::Timer& timer = utils::Utilities::instance().getTimer(_context.utility_id);
     timer.start_timer("rebalance_lp", "Rebalance");
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(hypergraph);
@@ -282,13 +280,10 @@ namespace mt_kahypar {
     timer.stop_timer("rebalance_lp");
     DBG << "[LP] Imbalance after rebalancing: " << current_metrics.imbalance << ", quality: " << current_metrics.quality;
 
-    bool was_imbalanced_and_improved_balance = !_old_partition_is_balanced
-                                               && current_metrics.imbalance < best_metrics.imbalance;
     // We consider the new partition an improvement if either
     // (1) the old partiton was imbalanced and balance is improved or
     // (2) the quality is improved while still being balanced
-    if ( was_imbalanced_and_improved_balance
-         || (current_metrics.quality <= best_metrics.quality && metrics::isBalanced(hypergraph, _context)) ) {
+    if ( current_metrics.isBetter(best_metrics) ) {
       return false;
     } else {
       // rollback and stop LP
@@ -331,7 +326,7 @@ namespace mt_kahypar {
 
   template <typename GraphAndGainTypes>
   void LabelPropagationRefiner<GraphAndGainTypes>::initializeActiveNodes(PartitionedHypergraph& hypergraph,
-                                                                      const vec<HypernodeID>& refinement_nodes) {
+                                                                         const vec<HypernodeID>& refinement_nodes) {
     _active_nodes.clear();
     if ( refinement_nodes.empty() ) {
       _might_be_uninitialized = false;

--- a/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
+++ b/mt-kahypar/partition/refinement/label_propagation/label_propagation_refiner.h
@@ -33,6 +33,7 @@
 #include "mt-kahypar/datastructures/thread_safe_fast_reset_flag_array.h"
 #include "mt-kahypar/parallel/stl/scalable_vector.h"
 #include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/metrics.h"
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/refinement/i_rebalancer.h"
 #include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
@@ -60,7 +61,6 @@ class LabelPropagationRefiner final : public IRefiner {
                                    GainCache& gain_cache,
                                    IRebalancer& rb) :
     _might_be_uninitialized(false),
-    _old_partition_is_balanced(true),
     _context(context),
     _gain_cache(gain_cache),
     _current_k(context.partition.k),
@@ -107,7 +107,7 @@ class LabelPropagationRefiner final : public IRefiner {
   void moveActiveNodes(PartitionedHypergraph& hypergraph, NextActiveNodes& next_active_nodes);
 
   bool applyRebalancing(PartitionedHypergraph& hypergraph,
-                        Metrics& best_metrics,
+                        const Metrics& best_metrics,
                         Metrics& current_metrics,
                         vec<Move>& rebalance_moves);
 
@@ -196,7 +196,6 @@ class LabelPropagationRefiner final : public IRefiner {
   }
 
   bool _might_be_uninitialized;
-  bool _old_partition_is_balanced;
   const Context& _context;
   GainCache& _gain_cache;
   PartitionID _current_k;

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.cpp
@@ -319,10 +319,10 @@ namespace impl {
   }
 
   template <typename GraphAndGainTypes>
-  std::pair<int64_t, size_t> AdvancedRebalancer<GraphAndGainTypes>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph) {
+  void AdvancedRebalancer<GraphAndGainTypes>::findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                                                        int64_t& attributed_gain,
+                                                        size_t& global_move_id) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
-    int64_t attributed_gain = 0;
-    size_t global_move_id = 0;
     size_t num_overloaded_blocks = _overloaded_blocks.size();
 
     auto task = [&](size_t task_id) {
@@ -433,8 +433,6 @@ namespace impl {
     tbb::task_group tg;
     for (size_t i = 0; i < _context.shared_memory.num_threads; ++i) { tg.run(std::bind(task, i)); }
     tg.wait();
-
-    return std::make_pair(attributed_gain, global_move_id);
   }
 
   template <typename GraphAndGainTypes>
@@ -444,6 +442,24 @@ namespace impl {
                                                                   Metrics& best_metric) {
     auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
     HEAVY_REFINEMENT_ASSERT(phg.checkTrackedPartitionInformation(_gain_cache));
+
+    int64_t attributed_gain = 0;
+    size_t global_move_id = 0;
+    _repair_empty_blocks.repairEmptyBlocks(hypergraph, _gain, [&](const Move& m) {
+      bool success = phg.changeNodePart(
+        _gain_cache, m.node, m.from, m.to,
+        _context.partition.max_part_weights[m.to],
+        // Note: we don't explicitly exclude these nodes from being moved again. However, since the previously empty
+        // target blocks are not overloaded after the moves, these nodes won't be selected for the main rebalancing
+        // round and thus can not be moved a second time.
+        [&] { _moves[global_move_id++] = m; },
+        [&](const SynchronizedEdgeUpdate& sync_update) {
+          attributed_gain += AttributedGains::gain(sync_update);
+        }
+      );
+      ASSERT(success); unused(success);
+    });
+    ASSERT(!metrics::imbalance(phg, _context).violates_non_empty_blocks || phg.initialNumNodes() < ID(_context.partition.k));
 
     _overloaded_blocks.clear();
     _is_overloaded.assign(_context.partition.k, false);
@@ -456,10 +472,10 @@ namespace impl {
 
     insertNodesInOverloadedBlocks(hypergraph);
 
-    auto [attributed_gain, num_moves_performed] = findMoves(hypergraph);
+    findMoves(hypergraph, attributed_gain, global_move_id);
 
     if constexpr (GainCache::invalidates_entries) {
-      tbb::parallel_for(UL(0), num_moves_performed, [&](const size_t i) {
+      tbb::parallel_for(UL(0), global_move_id, [&](const size_t i) {
         _gain_cache.recomputeInvalidTerms(phg, _moves[i].node);
       });
     }
@@ -469,13 +485,13 @@ namespace impl {
     if (moves_by_part != nullptr) {
       moves_by_part->resize(_context.partition.k);
       for (auto& direction : *moves_by_part) direction.clear();
-      for (size_t i = 0; i < num_moves_performed; ++i) {
+      for (size_t i = 0; i < global_move_id; ++i) {
         (*moves_by_part)[_moves[i].from].push_back(_moves[i]);
       }
     } else if (moves_linear != nullptr) {
       moves_linear->clear();
-      moves_linear->reserve(num_moves_performed);
-      for (size_t i = 0; i < num_moves_performed; ++i) {
+      moves_linear->reserve(global_move_id);
+      for (size_t i = 0; i < global_move_id; ++i) {
         moves_linear->push_back(_moves[i]);
       }
     }
@@ -513,7 +529,8 @@ AdvancedRebalancer<GraphAndGainTypes>::AdvancedRebalancer(
         _target_part(num_nodes, kInvalidPartition),
         _pq_handles(num_nodes, invalid_position),
         _pq_id(num_nodes, -1),
-        _node_state(num_nodes) { }
+        _node_state(num_nodes),
+        _repair_empty_blocks(context, gain_cache) { }
 
 template <typename GraphAndGainTypes>
 AdvancedRebalancer<GraphAndGainTypes>::AdvancedRebalancer(

--- a/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h
@@ -32,6 +32,7 @@
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/refinement/i_rebalancer.h"
 #include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
+#include "mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.h"
 
 namespace mt_kahypar {
 
@@ -120,14 +121,15 @@ private:
                               vec<Move>* moves_linear,
                               Metrics& best_metric);
 
+
+  void insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph);
+
+  void findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph, int64_t& attributed_gain, size_t& global_move_id);
+
   const Context& _context;
   GainCache& _gain_cache;
   PartitionID _current_k;
   GainCalculator _gain;
-
-
-  void insertNodesInOverloadedBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph);
-  std::pair<int64_t, size_t> findMoves(mt_kahypar_partitioned_hypergraph_t& hypergraph);
 
   ds::Array<Move> _moves;
   vec<rebalancer::GuardedPQ> _pqs;
@@ -137,6 +139,7 @@ private:
   ds::Array<PosT> _pq_handles;
   ds::Array<int> _pq_id;
   ds::Array<rebalancer::NodeState> _node_state;
+  RepairEmptyBlocks<GraphAndGainTypes> _repair_empty_blocks;
 };
 
 }  // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.cpp
@@ -71,8 +71,13 @@ bool DeterministicRebalancer<GraphAndGainTypes>::refineImpl(mt_kahypar_partition
 
   PartitionedHypergraph& phg = utils::cast<PartitionedHypergraph>(hypergraph);
   resizeDataStructuresForCurrentK();
-  updateImbalance(phg);
   _gain_computation.reset();
+
+  _repair_empty_blocks.repairEmptyBlocks(hypergraph, _gain_computation, [&](const Move& m) {
+    changeNodePart(phg, m.node, m.from, m.to);
+  });
+  ASSERT(!metrics::imbalance(phg, _context).violates_non_empty_blocks || phg.initialNumNodes() < ID(_context.partition.k));
+  updateImbalance(phg);
 
   size_t iteration = 0;
   const size_t max_rounds = _context.refinement.rebalancing.det_max_rounds == 0 ? ABSOLUTE_MAX_ROUNDS : std::min(ABSOLUTE_MAX_ROUNDS, _context.refinement.rebalancing.det_max_rounds);

--- a/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
+++ b/mt-kahypar/partition/refinement/rebalancing/deterministic_rebalancer.h
@@ -34,6 +34,7 @@
 #include "mt-kahypar/partition/refinement/i_refiner.h"
 #include "mt-kahypar/partition/refinement/i_rebalancer.h"
 #include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
+#include "mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.h"
 
 namespace mt_kahypar {
 
@@ -68,7 +69,8 @@ public:
         _moves(context.partition.k),
         _tmp_potential_moves(context.partition.k),
         _current_imbalance(context.partition.k),
-        _block_has_only_heavy_vertices(context.partition.k) {}
+        _block_has_only_heavy_vertices(context.partition.k),
+        _repair_empty_blocks(context, gain_cache) {}
 
     explicit DeterministicRebalancer(HypernodeID num_nodes, const Context& context, gain_cache_t gain_cache) :
         DeterministicRebalancer(num_nodes, context, GainCachePtr::cast<GainCache>(gain_cache)) {}
@@ -138,6 +140,7 @@ private:
     parallel::scalable_vector<ds::StreamingVector<rebalancer::RebalancingMove>> _tmp_potential_moves;
     parallel::scalable_vector<HypernodeWeight> _current_imbalance;
     parallel::scalable_vector<uint8_t> _block_has_only_heavy_vertices;
+    RepairEmptyBlocks<GraphAndGainTypes> _repair_empty_blocks;
 };
 
 }  // namespace kahypar

--- a/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.cpp
@@ -62,6 +62,35 @@ void RepairEmptyBlocks<GraphAndGainTypes>::computeEmptyParts(PartitionedHypergra
       _empty_parts.push_back(block);
     }
   }
+
+  const auto& max_weights = _context.partition.max_part_weights;
+  if (!_empty_parts.empty() && _context.partition.use_individual_part_weights) {
+    // We sort the empty parts, so that
+    // (1) we can determine which parts to skip for degree zero nodes
+    // (2) computeBestMovesBlockIndependent can maintain the invariant that the last entry
+    // of best_move_for_part is the worst move in the list. This invariant could be broken
+    // if a node does not fit in a block (unlikely, but possible) and therefore "skips"
+    // a part of the list. However, by sorting descending by part weight, this can't happen
+    // since a move at position i + 1 is guaranteed to also fit in position i, and thus
+    // can not be better than the move at position i (or it would be placed there).
+    std::sort(_empty_parts.begin(), _empty_parts.end(), [&](PartitionID lhs, PartitionID rhs) {
+      // deterministic tie breaking
+      return max_weights[lhs] > max_weights[rhs] || (max_weights[lhs] == max_weights[rhs] && lhs < rhs);
+    });
+  }
+
+  if (!_empty_parts.empty() && phg.numRemovedHypernodes() > 0) {
+    // since some of the blocks can be filled by degree zero nodes at the end, we can throw
+    // out all blocks that can be filled in this way
+    HypernodeWeight max_removed_weight = phg.maxWeightOfRemovedDegreeZeroNode();
+    size_t last_fitting = 0;
+    while (last_fitting < _empty_parts.size()
+           && max_removed_weight <= max_weights[_empty_parts[last_fitting]]) {
+      ++last_fitting;
+    }
+    size_t start = (phg.numRemovedHypernodes() >= last_fitting) ? 0 : last_fitting - phg.numRemovedHypernodes();
+    _empty_parts.erase(_empty_parts.begin() + start, _empty_parts.begin() + last_fitting);
+  }
 }
 
 template <typename GraphAndGainTypes>
@@ -73,20 +102,6 @@ void RepairEmptyBlocks<GraphAndGainTypes>::computeBestMovesBlockIndependent(Part
     tbb::enumerable_thread_specific<vec<Move>> local_best_move_for_part(_empty_parts.size(), Move{});
     _global_best_move_for_part.clear();
     _global_best_move_for_part.resize(_empty_parts.size(), Move{});
-
-    if (_context.partition.use_individual_part_weights) {
-      // We sort the empty parts, so that we can maintain the invariant that the last entry
-      // of best_move_for_part is the worst move in the list. This invariant could be broken
-      // if a node does not fit in a block (unlikely, but possible) and therefore "skips"
-      // a part of the list. However, by sorting descending by part weight, this can't happen
-      // since a move at position i + 1 is guaranteed to also fit in position i, and thus
-      // can not be better than the move at position i (or it would be placed there).
-      const auto& max_weights = _context.partition.max_part_weights;
-      std::sort(_empty_parts.begin(), _empty_parts.end(), [&](PartitionID lhs, PartitionID rhs) {
-        // deterministic tie breaking
-        return max_weights[lhs] > max_weights[rhs] || (max_weights[lhs] == max_weights[rhs] && lhs < rhs);
-      });
-    }
 
     auto insert_move_into_list = [&](Move& current_move, vec<Move>& move_for_part) {
       const Move& worst_move = move_for_part.back();

--- a/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.cpp
+++ b/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.cpp
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2025 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.h"
+
+#include <algorithm>
+
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/utils/cast.h"
+#include "mt-kahypar/utils/hash.h"
+
+namespace mt_kahypar {
+
+bool moveIsBetter(const Move& lhs, const Move& rhs) {
+  ASSERT(lhs.isValid());
+  // tie breaking by ID for determinism
+  return !rhs.isValid() ||
+         lhs.gain < rhs.gain ||
+         (lhs.gain == rhs.gain && lhs.node < rhs.node);
+}
+
+template <typename GraphAndGainTypes>
+RepairEmptyBlocks<GraphAndGainTypes>::RepairEmptyBlocks(const Context& context, GainCache& gain_cache):
+  _context(context),
+  _gain_cache(gain_cache),
+  _is_empty(),
+  _empty_parts(),
+  _global_best_move_for_part(),
+  _local_best_move_for_part(),
+  _prng(context.partition.seed) { }
+
+template <typename GraphAndGainTypes>
+void RepairEmptyBlocks<GraphAndGainTypes>::computeEmptyParts(PartitionedHypergraph& phg) {
+  _is_empty.assign(_context.partition.k, false);
+  _empty_parts.clear();
+  for (PartitionID block = 0; block < _context.partition.k; ++block) {
+    if (phg.partWeight(block) == 0) {
+      _is_empty[block] = true;
+      _empty_parts.push_back(block);
+    }
+  }
+}
+
+template <typename GraphAndGainTypes>
+void RepairEmptyBlocks<GraphAndGainTypes>::computeBestMovesBlockIndependent(PartitionedHypergraph& phg) {
+  ALWAYS_ASSERT(GainComputation::is_independent_of_block);
+  if constexpr (GainComputation::is_independent_of_block) {  // needed to access GainComputation::computeIsolatedBlockGain
+    const bool gain_cache_initialized = _gain_cache.isInitialized();
+
+    tbb::enumerable_thread_specific<vec<Move>> local_best_move_for_part(_empty_parts.size(), Move{});
+    _global_best_move_for_part.clear();
+    _global_best_move_for_part.resize(_empty_parts.size(), Move{});
+
+    if (_context.partition.use_individual_part_weights) {
+      // We sort the empty parts, so that we can maintain the invariant that the last entry
+      // of best_move_for_part is the worst move in the list. This invariant could be broken
+      // if a node does not fit in a block (unlikely, but possible) and therefore "skips"
+      // a part of the list. However, by sorting descending by part weight, this can't happen
+      // since a move at position i + 1 is guaranteed to also fit in position i, and thus
+      // can not be better than the move at position i (or it would be placed there).
+      const auto& max_weights = _context.partition.max_part_weights;
+      std::sort(_empty_parts.begin(), _empty_parts.end(), [&](PartitionID lhs, PartitionID rhs) {
+        // deterministic tie breaking
+        return max_weights[lhs] > max_weights[rhs] || (max_weights[lhs] == max_weights[rhs] && lhs < rhs);
+      });
+    }
+
+    auto insert_move_into_list = [&](Move& current_move, vec<Move>& move_for_part) {
+      const Move& worst_move = move_for_part.back();
+      if (moveIsBetter(current_move, worst_move)) {
+        // update moves for all parts by "shifting" them
+        for (size_t i = 0; current_move.isValid() && i < _empty_parts.size(); ++i) {
+          const PartitionID to = _empty_parts[i];
+          if (moveIsBetter(current_move, move_for_part[i])
+              && phg.nodeWeight(current_move.node) <= _context.partition.max_part_weights[to]) {
+            current_move.to = to;
+            std::swap(current_move, move_for_part[i]);
+          }
+        }
+      }
+    };
+
+    // find best available moves in parallel, accumulate locally
+    phg.doParallelForAllNodes([&](const HypernodeID hn) {
+      const PartitionID from = phg.partID(hn);
+
+      // skip weight zero nodes and if it is the only node in the block
+      const HypernodeWeight hn_weight = phg.nodeWeight(hn);
+      if (hn_weight == 0 || hn_weight == phg.partWeight(from)) return;
+
+      // In case of independent blocks, we only need to compute the isolated block gain,
+      // which is equal to the gain for any empty target block.
+      Gain isolated_block_gain = gain_cache_initialized ?
+        _gain_cache.penaltyTerm(hn, from) : GainComputation::computeIsolatedBlockGain(phg, hn);
+      ASSERT(!gain_cache_initialized || _gain_cache.penaltyTerm(hn, from) == GainComputation::computeIsolatedBlockGain(phg, hn));
+
+      Move current_move{from, _empty_parts[0], hn, isolated_block_gain};
+      insert_move_into_list(current_move, local_best_move_for_part.local());
+    });
+
+    // sort the moves into the global array
+    for (auto& best_move_for_part: local_best_move_for_part) {
+      for (Move& m: best_move_for_part) {
+        if (m.isValid()) {
+          insert_move_into_list(m, _global_best_move_for_part);
+        }
+      }
+    }
+  }
+}
+
+template <typename GraphAndGainTypes>
+void RepairEmptyBlocks<GraphAndGainTypes>::computeBestMovesIndividualBlockGains(PartitionedHypergraph& phg,
+                                                                                GainComputation& gain_computation) {
+  ALWAYS_ASSERT(!GainComputation::is_independent_of_block);
+
+  // If the gain depends on the target block, an equivalent of the "independent"
+  // algorithm would involve a lot of gain recomputations. Instead, we hash each
+  // node to a random target block and for each block choose the best option out
+  // of those nodes.
+  tbb::enumerable_thread_specific<vec<Move>> local_best_move_for_part(_empty_parts.size(), Move{});
+  _global_best_move_for_part.assign(_empty_parts.size(), Move{});
+  const uint32_t rand = std::uniform_int_distribution<uint32_t>(0, 1000)(_prng);
+  const uint32_t seed_offset = rand * phg.initialNumNodes();
+
+  // find best available moves in parallel, accumulate locally
+  phg.doParallelForAllNodes([&](const HypernodeID hn) {
+    const PartitionID from = phg.partID(hn);
+    const HypernodeWeight hn_weight = phg.nodeWeight(hn);
+
+    // skip weight zero nodes and if it is the only node in the block
+    if (hn_weight == 0 || hn_weight == phg.partWeight(from)) return;
+
+    // deterministically determine a target block for each node by hashing it
+    hashing::SimpleIntHash<uint32_t> sih;
+    hashing::HashRNG<hashing::SimpleIntHash<uint32_t>> hash_prng(sih, seed_offset + hn);
+    const size_t part_idx =
+      std::uniform_int_distribution<uint32_t>(0, _empty_parts.size() - 1)(hash_prng);
+    const PartitionID to = _empty_parts[part_idx];
+
+    // compute the gain for the target block
+    Gain gain;
+    if (_gain_cache.isInitialized()) {
+      gain = _gain_cache.penaltyTerm(hn, to) - (_gain_cache.blockIsAdjacent(hn, to) ?
+              _gain_cache.benefitTerm(hn, to) : _gain_cache.recomputeBenefitTerm(phg, hn, to));
+      HEAVY_REFINEMENT_ASSERT([&]{
+        RatingMap& tmp_scores = gain_computation.localScores();
+        Gain isolated_block_gain = 0;
+        gain_computation.precomputeGains(phg, hn, tmp_scores, isolated_block_gain, true);
+        Gain tmp_gain = gain_computation.gain(tmp_scores[to], isolated_block_gain);
+        tmp_scores.clear();
+        return gain == tmp_gain;
+      }());
+    } else {
+      RatingMap& tmp_scores = gain_computation.localScores();
+      Gain isolated_block_gain = 0;
+      gain_computation.precomputeGains(phg, hn, tmp_scores, isolated_block_gain, true);
+      gain = gain_computation.gain(tmp_scores[to], isolated_block_gain);
+      tmp_scores.clear();
+    }
+
+    // insert move
+    auto& best_move_for_part = local_best_move_for_part.local();
+    Move current_move{from, to, hn, gain};
+    if (moveIsBetter(current_move, best_move_for_part[part_idx])
+        && hn_weight <= _context.partition.max_part_weights[to]) {
+      best_move_for_part[part_idx] = current_move;
+    }
+  });
+
+  // insert the moves into the global array
+  for (auto& best_move_for_part: local_best_move_for_part) {
+    for (size_t i = 0; i < best_move_for_part.size(); ++i) {
+      const Move& m = best_move_for_part[i];
+      if (m.isValid() && moveIsBetter(m, _global_best_move_for_part[i])) {
+        _global_best_move_for_part[i] = m;
+      }
+    }
+  }
+}
+
+// explicitly instantiate so the compiler can generate them when compiling this cpp file
+namespace {
+  #define REPAIR_EMPTY_BLOCKS(X) RepairEmptyBlocks<X>
+}
+
+INSTANTIATE_CLASS_WITH_VALID_TRAITS(REPAIR_EMPTY_BLOCKS)
+
+}  // namespace mt_kahypar

--- a/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.h
+++ b/mt-kahypar/partition/refinement/rebalancing/repair_empty_blocks.h
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2025 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+#include <tbb/enumerable_thread_specific.h>
+
+#include "mt-kahypar/parallel/atomic_wrapper.h"
+#include "mt-kahypar/partition/context.h"
+#include "mt-kahypar/partition/refinement/gains/gain_cache_ptr.h"
+#include "mt-kahypar/utils/cast.h"
+
+namespace mt_kahypar {
+
+template <typename GraphAndGainTypes>
+class RepairEmptyBlocks {
+private:
+  using PartitionedHypergraph = typename GraphAndGainTypes::PartitionedHypergraph;
+  using GainCache = typename GraphAndGainTypes::GainCache;
+  using GainComputation = typename GraphAndGainTypes::GainComputation;
+  using RatingMap = typename GainComputation::RatingMap;
+  using AttributedGains = typename GraphAndGainTypes::AttributedGains;
+
+  static constexpr bool debug = false;
+  static constexpr bool enable_heavy_assert = false;
+
+  static constexpr size_t MAX_ROUNDS = 3;
+
+ public:
+  explicit RepairEmptyBlocks(const Context& context, GainCache& gain_cache);
+
+  // ! Repairs empty blocks of the partition with a fully deterministic algorithm.
+  // ! Receives a lambda to actually apply the provided moves.
+  template<typename Func>
+  void repairEmptyBlocks(mt_kahypar_partitioned_hypergraph_t& hypergraph,
+                         GainComputation& gain_computation,
+                         Func&& apply_move_fn) {
+    if (_context.partition.allow_empty_blocks) return;
+
+    auto& phg = utils::cast<PartitionedHypergraph>(hypergraph);
+
+    for (size_t i = 0; i < MAX_ROUNDS; ++i) {
+      computeEmptyParts(phg);
+      if (_empty_parts.empty()) break;
+
+      DBG << "Start repair move computation:" << V(_empty_parts.size());
+      if constexpr (GainComputation::is_independent_of_block) {
+        computeBestMovesBlockIndependent(phg);
+      } else {
+        computeBestMovesIndividualBlockGains(phg, gain_computation);
+      }
+
+      for (size_t j = 0; j < _global_best_move_for_part.size(); ++j) {
+        const Move& m = _global_best_move_for_part[j];
+        if (m.isValid()) {
+          ASSERT(m.from == phg.partID(m.node) && m.to == _empty_parts[j]);
+          DBG << "Apply repair move:" << V(m.node) << V(m.gain) << V(m.from) << V(m.to);
+          apply_move_fn(m);
+        }
+      }
+    }
+  }
+
+ private:
+  void computeEmptyParts(PartitionedHypergraph& phg);
+
+  void computeBestMovesBlockIndependent(PartitionedHypergraph& phg);
+
+  void computeBestMovesIndividualBlockGains(PartitionedHypergraph& phg, GainComputation& gain_computation);
+
+  const Context& _context;
+  GainCache& _gain_cache;
+  vec<bool> _is_empty;
+  vec<PartitionID> _empty_parts;
+  vec<Move> _global_best_move_for_part;
+  tbb::enumerable_thread_specific<vec<Move>> _local_best_move_for_part;
+  std::mt19937 _prng;
+};
+
+}  // namespace mt_kahypar

--- a/tests/partition/initial_partitioning/flat_initial_partitioner_test.cc
+++ b/tests/partition/initial_partitioning/flat_initial_partitioner_test.cc
@@ -201,8 +201,7 @@ TYPED_TEST_SUITE(AFlatInitialPartitionerTest, TestConfigs);
 TYPED_TEST(AFlatInitialPartitionerTest, HasValidImbalance) {
   this->execute();
 
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 TYPED_TEST(AFlatInitialPartitionerTest, AssginsEachHypernode) {
@@ -235,8 +234,7 @@ TYPED_TEST(AFlatInitialPartitionerTest, CanHandleFixedVertices) {
     }
   }
 
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 TYPED_TEST(AFlatInitialPartitionerTest, CanHandleFixedVerticesInOnlyOneBlock) {
@@ -250,8 +248,7 @@ TYPED_TEST(AFlatInitialPartitionerTest, CanHandleFixedVerticesInOnlyOneBlock) {
     }
   }
 
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 

--- a/tests/partition/initial_partitioning/pool_initial_partitioner_test.cc
+++ b/tests/partition/initial_partitioning/pool_initial_partitioner_test.cc
@@ -150,8 +150,7 @@ TYPED_TEST_SUITE(APoolInitialPartitionerTest, TestConfigs);
 
 TYPED_TEST(APoolInitialPartitionerTest, HasValidImbalance) {
   this->bipartition();
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 TYPED_TEST(APoolInitialPartitionerTest, AssginsEachHypernode) {
@@ -182,8 +181,7 @@ TYPED_TEST(APoolInitialPartitionerTest, CanHandleFixedVertices) {
     }
   }
 
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 TYPED_TEST(APoolInitialPartitionerTest, CanHandleFixedVerticesInOnlyOneBlock) {
@@ -197,8 +195,7 @@ TYPED_TEST(APoolInitialPartitionerTest, CanHandleFixedVerticesInOnlyOneBlock) {
     }
   }
 
-  ASSERT_LE(metrics::imbalance(this->partitioned_hypergraph, this->context),
-            this->context.partition.epsilon);
+  ASSERT_TRUE(metrics::isValidPartition(this->partitioned_hypergraph, this->context));
 }
 
 

--- a/tests/partition/refinement/CMakeLists.txt
+++ b/tests/partition/refinement/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(mtkahypar_tests PRIVATE
          rollback_test.cc
          advanced_rebalancer_test.cc
          deterministic_rebalancer_test.cc
+         repair_empty_blocks_test.cc
          twoway_fm_refiner_test.cc
          gain_cache_test.cc
          multitry_fm_test.cc

--- a/tests/partition/refinement/advanced_rebalancer_test.cc
+++ b/tests/partition/refinement/advanced_rebalancer_test.cc
@@ -139,7 +139,7 @@ TYPED_TEST(RebalancerTest, CanNotBeRebalanced) {
   metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
 }
 
 
@@ -191,7 +191,7 @@ TYPED_TEST(RebalancerTest, ProducesBalancedResult) {
   metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
   for (PartitionID part = 0; part < this->context.partition.k; ++part) {
     ASSERT_LE(this->partitioned_hypergraph.partWeight(part), this->context.partition.max_part_weights[part]);
   }

--- a/tests/partition/refinement/advanced_rebalancer_test.cc
+++ b/tests/partition/refinement/advanced_rebalancer_test.cc
@@ -82,6 +82,7 @@ class RebalancerTest : public Test {
 
     context.partition.objective = Hypergraph::is_graph ? Objective::cut : Objective::km1;
     context.partition.gain_policy = Hypergraph::is_graph ? GainPolicy::cut_for_graphs : GainPolicy::km1;
+    context.partition.allow_empty_blocks = false;
   }
 
   void constructFromFile() {
@@ -139,6 +140,31 @@ TYPED_TEST(RebalancerTest, CanNotBeRebalanced) {
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
   ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+}
+
+
+TYPED_TEST(RebalancerTest, RepairsEmptyBlocks) {
+  this->constructFromValues(4, 2, { {0, 1}, {1, 2} }, {1, 1, 1, 1});
+  this->context.partition.max_part_weights.resize(this->context.partition.k, 5);
+  this->context.partition.use_individual_part_weights = true;
+  this->setup();
+
+  this->partitioned_hypergraph.setOnlyNodePart(0, 0);
+  this->partitioned_hypergraph.setOnlyNodePart(1, this->context.partition.k == 2 ? 0 : 1);
+  this->partitioned_hypergraph.setOnlyNodePart(2, 0);
+  this->partitioned_hypergraph.setOnlyNodePart(3, this->context.partition.k == 2 ? 0 : 1);
+  this->partitioned_hypergraph.initializePartition();
+  mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+  this->rebalancer->initialize(phg);
+
+  Metrics metrics;
+  metrics.quality = metrics::quality(this->partitioned_hypergraph, this->context);
+  metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
+  this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
+
+  for (PartitionID block = 0; block < this->context.partition.k; ++block) {
+    ASSERT_GT(this->partitioned_hypergraph.partWeight(block), 0) << V(block);
+  }
 }
 
 

--- a/tests/partition/refinement/deterministic_jet_refiner_test.cc
+++ b/tests/partition/refinement/deterministic_jet_refiner_test.cc
@@ -178,13 +178,13 @@ TYPED_TEST_SUITE(ADeterministicJetRefiner, TestConfigs);
 TYPED_TEST(ADeterministicJetRefiner, UpdatesImbalanceCorrectly) {
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
     this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-    ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+    ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
 }
 
 TYPED_TEST(ADeterministicJetRefiner, DoesNotViolateBalanceConstraint) {
     mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
     this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-    ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon + EPS);
+    ASSERT_TRUE(this->metrics.imbalance.isValidPartition());
 }
 
 TYPED_TEST(ADeterministicJetRefiner, UpdatesMetricsCorrectly) {

--- a/tests/partition/refinement/deterministic_rebalancer_test.cc
+++ b/tests/partition/refinement/deterministic_rebalancer_test.cc
@@ -142,7 +142,7 @@ TYPED_TEST(DeterministicRebalancerTest, CanNotBeRebalanced) {
   metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
 }
 
 
@@ -192,7 +192,7 @@ TYPED_TEST(DeterministicRebalancerTest, MustMoveHeavyVertex) {
   metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
   for (PartitionID part = 0; part < this->context.partition.k; ++part) {
     ASSERT_LE(this->partitioned_hypergraph.partWeight(part), this->context.partition.max_part_weights[part]);
   }
@@ -222,7 +222,7 @@ TYPED_TEST(DeterministicRebalancerTest, ProducesBalancedResult) {
   metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
   for (PartitionID part = 0; part < this->context.partition.k; ++part) {
     ASSERT_LE(this->partitioned_hypergraph.partWeight(part), this->context.partition.max_part_weights[part]);
   }

--- a/tests/partition/refinement/deterministic_rebalancer_test.cc
+++ b/tests/partition/refinement/deterministic_rebalancer_test.cc
@@ -85,6 +85,7 @@ class DeterministicRebalancerTest : public Test {
 
     context.partition.objective = Hypergraph::is_graph ? Objective::cut : Objective::km1;
     context.partition.gain_policy = Hypergraph::is_graph ? GainPolicy::cut_for_graphs : GainPolicy::km1;
+    context.partition.allow_empty_blocks = false;
   }
 
   void constructFromFile() {
@@ -142,6 +143,31 @@ TYPED_TEST(DeterministicRebalancerTest, CanNotBeRebalanced) {
   this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
 
   ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), metrics.imbalance);
+}
+
+
+TYPED_TEST(DeterministicRebalancerTest, RepairsEmptyBlocks) {
+  this->constructFromValues(4, 2, { {0, 1}, {1, 2} }, {1, 1, 1, 1});
+  this->context.partition.max_part_weights.resize(this->context.partition.k, 5);
+  this->context.partition.use_individual_part_weights = true;
+  this->setup();
+
+  this->partitioned_hypergraph.setOnlyNodePart(0, 0);
+  this->partitioned_hypergraph.setOnlyNodePart(1, this->context.partition.k == 2 ? 0 : 1);
+  this->partitioned_hypergraph.setOnlyNodePart(2, 0);
+  this->partitioned_hypergraph.setOnlyNodePart(3, this->context.partition.k == 2 ? 0 : 1);
+  this->partitioned_hypergraph.initializePartition();
+  mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
+  this->rebalancer->initialize(phg);
+
+  Metrics metrics;
+  metrics.quality = metrics::quality(this->partitioned_hypergraph, this->context);
+  metrics.imbalance = metrics::imbalance(this->partitioned_hypergraph, this->context);
+  this->rebalancer->refine(phg, {}, metrics, std::numeric_limits<double>::max());
+
+  for (PartitionID block = 0; block < this->context.partition.k; ++block) {
+    ASSERT_GT(this->partitioned_hypergraph.partWeight(block), 0) << V(block);
+  }
 }
 
 

--- a/tests/partition/refinement/label_propagation_refiner_test.cc
+++ b/tests/partition/refinement/label_propagation_refiner_test.cc
@@ -191,13 +191,13 @@ TYPED_TEST_SUITE(ALabelPropagationRefiner, TestConfigs);
 TYPED_TEST(ALabelPropagationRefiner, UpdatesImbalanceCorrectly) {
   mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
   this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
 }
 
 TYPED_TEST(ALabelPropagationRefiner, DoesNotViolateBalanceConstraint) {
   mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
   this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-  ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon + EPS);
+  ASSERT_TRUE(this->metrics.imbalance.isValidPartition());
 }
 
 TYPED_TEST(ALabelPropagationRefiner, UpdatesMetricsCorrectly) {

--- a/tests/partition/refinement/multitry_fm_test.cc
+++ b/tests/partition/refinement/multitry_fm_test.cc
@@ -70,6 +70,7 @@ class MultiTryFMTest : public Test {
     context.partition.mode = Mode::direct;
     context.partition.epsilon = 0.25;
     context.partition.k = Config::K;
+    context.partition.allow_empty_blocks = true;
     #ifdef KAHYPAR_ENABLE_HIGHEST_QUALITY_FEATURES
     context.partition.preset_type = Hypergraph::is_static_hypergraph ?
       PresetType::default_preset : PresetType::highest_quality;
@@ -164,14 +165,14 @@ TYPED_TEST_SUITE(MultiTryFMTest, TestConfigs);
 TYPED_TEST(MultiTryFMTest, UpdatesImbalanceCorrectly) {
   mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
   this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
 }
 
 
 TYPED_TEST(MultiTryFMTest, DoesNotViolateBalanceConstraint) {
   mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(this->partitioned_hypergraph);
   this->refiner->refine(phg, {}, this->metrics, std::numeric_limits<double>::max());
-  ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon);
+  ASSERT_TRUE(this->metrics.imbalance.isValidPartition());
 }
 
 TYPED_TEST(MultiTryFMTest, UpdatesMetricsCorrectly) {
@@ -197,8 +198,8 @@ TYPED_TEST(MultiTryFMTest, AlsoWorksWithNonDefaultFeatures) {
   ASSERT_LE(this->metrics.quality, objective_before);
   ASSERT_EQ(metrics::quality(this->partitioned_hypergraph, this->context.partition.objective),
             this->metrics.quality);
-  ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon);
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+  ASSERT_TRUE(this->metrics.imbalance.isValidPartition());
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
 }
 
 TYPED_TEST(MultiTryFMTest, WorksWithRefinementNodes) {
@@ -212,8 +213,8 @@ TYPED_TEST(MultiTryFMTest, WorksWithRefinementNodes) {
   ASSERT_LE(this->metrics.quality, objective_before);
   ASSERT_EQ(metrics::quality(this->partitioned_hypergraph, this->context.partition.objective),
             this->metrics.quality);
-  ASSERT_LE(this->metrics.imbalance, this->context.partition.epsilon);
-  ASSERT_DOUBLE_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
+  ASSERT_TRUE(this->metrics.imbalance.isValidPartition());
+  ASSERT_EQ(metrics::imbalance(this->partitioned_hypergraph, this->context), this->metrics.imbalance);
 
   std::stringstream buffer;
   std::streambuf* old = std::cout.rdbuf(buffer.rdbuf());  // redirect std::cout to discard output

--- a/tests/partition/refinement/repair_empty_blocks_test.cc
+++ b/tests/partition/refinement/repair_empty_blocks_test.cc
@@ -1,0 +1,301 @@
+/*******************************************************************************
+ * MIT License
+ *
+ * This file is part of Mt-KaHyPar.
+ *
+ * Copyright (C) 2025 Nikolai Maas <nikolai.maas@kit.edu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include <memory>
+#include <functional>
+#include <random>
+
+#include "gmock/gmock.h"
+
+#include "mt-kahypar/partition/mapping/target_graph.h"
+#include "mt-kahypar/definitions.h"
+#include "mt-kahypar/io/hypergraph_factory.h"
+#include "mt-kahypar/parallel/thread_management.h"
+#include "mt-kahypar/partition/refinement/rebalancing/advanced_rebalancer.h"
+#include "mt-kahypar/partition/refinement/gains/gain_definitions.h"
+#include "mt-kahypar/utils/randomize.h"
+
+using ::testing::Test;
+
+namespace mt_kahypar {
+
+template <typename TypeTraitsT, typename GainTypesT, bool is_steiner_tree_gain, bool use_gain_cache>
+struct TestConfig {
+  using TypeTraits = TypeTraitsT;
+  using GainTypes = GainTypesT;
+  static constexpr bool steiner_tree_gain = is_steiner_tree_gain;
+  static constexpr bool with_gain_cache = use_gain_cache;
+};
+
+template<typename Config>
+class RepairEmptyBlocksTest : public Test {
+
+ public:
+  using TypeTraits = typename Config::TypeTraits;
+  using GainTypes = typename Config::GainTypes;
+  using Hypergraph = typename TypeTraits::Hypergraph;
+  using PartitionedHypergraph = typename TypeTraits::PartitionedHypergraph;
+  using HypergraphFactory = typename Hypergraph::Factory;
+  using TargetGraphFactory = typename ds::StaticGraph::Factory;
+  using GainCache = typename GainTypes::GainCache;
+  using GainComputation = typename GainTypes::GainComputation;
+  using MyRepairEmptyBlocks = RepairEmptyBlocks<GraphAndGainTypes<TypeTraits, GainTypes>>;
+
+  RepairEmptyBlocksTest() :
+          hypergraph(),
+          partitioned_hypergraph(),
+          context(),
+          gain_cache(),
+          gain_computation(),
+          target_graph(),
+          repair_empty_blocks(nullptr) {
+    parallel::initialize_tbb(std::thread::hardware_concurrency());
+    context.partition.mode = Mode::direct;
+    context.partition.epsilon = 1.5;
+    context.partition.k = 16;
+
+    context.partition.preset_type = PresetType::default_preset;
+    context.partition.instance_type = InstanceType::hypergraph;
+    context.partition.partition_type = PartitionedHypergraph::TYPE;
+    context.partition.enable_logging = false;
+
+    // Shared Memory
+    context.shared_memory.original_num_threads = std::thread::hardware_concurrency();
+    context.shared_memory.num_threads = std::thread::hardware_concurrency();
+
+    if (Config::steiner_tree_gain) {
+      context.partition.objective = Objective::steiner_tree;
+      context.partition.gain_policy = Hypergraph::is_graph ? GainPolicy::steiner_tree_for_graphs : GainPolicy::steiner_tree;
+    } else {
+      context.partition.objective = Hypergraph::is_graph ? Objective::cut : Objective::km1;
+      context.partition.gain_policy = Hypergraph::is_graph ? GainPolicy::cut_for_graphs : GainPolicy::km1;
+    }
+
+    gain_computation = std::make_unique<GainComputation>(context);
+    context.partition.allow_empty_blocks = false;
+  }
+
+  void constructFromFile() {
+    if constexpr ( Hypergraph::is_graph ) {
+      hypergraph = io::readInputFile<Hypergraph>(
+        "../tests/instances/delaunay_n10.graph", FileFormat::Metis, true, true, true);
+    } else {
+      hypergraph = io::readInputFile<Hypergraph>(
+        "../tests/instances/contracted_ibm01.hgr", FileFormat::hMetis, true, true, true);
+    }
+  }
+
+  void constructFromValues(const vec<HypernodeWeight>& hypernode_weight) {
+    const HypernodeID num_hypernodes = 18;
+    ASSERT(num_hypernodes == hypernode_weight.size());
+    if constexpr ( Hypergraph::is_graph ) {
+      hypergraph = HypergraphFactory::construct(num_hypernodes, 11,
+        { {0, 1}, {2, 3}, {4, 5}, {1, 3}, {5, 7}, {11, 13}, {14, 15}, {12, 13}, {8, 9}, {9, 14}, {12, 16} },
+        nullptr, hypernode_weight.data(), true);
+    } else {
+      hypergraph = HypergraphFactory::construct(num_hypernodes, 4,
+        { {0, 1, 2, 3, 4, 5}, {1, 3, 5, 7, 11, 13}, {15, 14, 13, 12, 11}, {8, 9, 12, 13, 16} },
+        nullptr, hypernode_weight.data(), true);
+    }
+  }
+
+  void repairEmptyBlocks() {
+    partitioned_hypergraph.initializePartition();
+    if constexpr (Config::with_gain_cache) {
+      gain_cache.reset(partitioned_hypergraph.initialNumNodes(), context.partition.k);
+      gain_cache.initializeGainCache(partitioned_hypergraph);
+    }
+
+    mt_kahypar_partitioned_hypergraph_t phg = utils::partitioned_hg_cast(partitioned_hypergraph);
+    repair_empty_blocks->repairEmptyBlocks(phg, *gain_computation, [&](const Move& m) {
+      if constexpr (Config::with_gain_cache) {
+        ASSERT_TRUE(this->partitioned_hypergraph.changeNodePart(gain_cache, m.node, m.from, m.to));
+      } else {
+        ASSERT_TRUE(this->partitioned_hypergraph.changeNodePart(m.node, m.from, m.to));
+      }
+    });
+  }
+
+  void setup() {
+    repair_empty_blocks = std::make_unique<MyRepairEmptyBlocks>(context, gain_cache);
+    partitioned_hypergraph = PartitionedHypergraph(context.partition.k, hypergraph, parallel_tag_t());
+    context.setupPartWeights(hypergraph.totalWeight());
+
+    if constexpr (Config::steiner_tree_gain) {
+      vec<std::pair<HypernodeID, HypernodeID>> edges;
+      vec<HyperedgeWeight> edges_weights;
+      for (PartitionID i = 0; i < context.partition.k; ++i) {
+        for (PartitionID j = 0; j < i; ++j) {
+          edges.emplace_back(i, j);
+          edges_weights.emplace_back(5 * i + j + 1);
+        }
+      }
+      target_graph = std::make_unique<TargetGraph>(
+        TargetGraphFactory::construct_from_graph_edges(context.partition.k, edges.size(), edges, edges_weights.data()));
+      target_graph->precomputeDistances(2);
+      partitioned_hypergraph.setTargetGraph(target_graph.get());
+    }
+  }
+
+  Hypergraph hypergraph;
+  PartitionedHypergraph partitioned_hypergraph;
+  Context context;
+  GainCache gain_cache;
+  std::unique_ptr<GainComputation> gain_computation;
+  std::unique_ptr<TargetGraph> target_graph;
+  std::unique_ptr<MyRepairEmptyBlocks> repair_empty_blocks;
+};
+
+
+typedef ::testing::Types<TestConfig<StaticHypergraphTypeTraits, Km1GainTypes, false, false>,
+                         TestConfig<StaticHypergraphTypeTraits, Km1GainTypes, false, true>
+                         ENABLE_STEINER_TREE(COMMA TestConfig<StaticHypergraphTypeTraits COMMA SteinerTreeGainTypes COMMA true COMMA false>)
+                         ENABLE_STEINER_TREE(COMMA TestConfig<StaticHypergraphTypeTraits COMMA SteinerTreeGainTypes COMMA true COMMA true>)
+                         ENABLE_GRAPHS(COMMA TestConfig<StaticGraphTypeTraits COMMA CutGainForGraphsTypes COMMA false COMMA false>) > TestConfigs;
+
+TYPED_TEST_SUITE(RepairEmptyBlocksTest, TestConfigs);
+
+
+TYPED_TEST(RepairEmptyBlocksTest, SuccessfullyRepairsEmptyBlocks) {
+  this->constructFromValues({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+  this->setup();
+
+  for (HyperedgeID hn = 0; hn < this->hypergraph.initialNumNodes(); ++hn) {
+    this->partitioned_hypergraph.setOnlyNodePart(hn, hn % 8);
+  }
+  this->repairEmptyBlocks();
+
+  for (PartitionID block = 0; block < this->context.partition.k; ++block) {
+    ASSERT_GT(this->partitioned_hypergraph.partWeight(block), 0) << V(block);
+  }
+}
+
+
+TYPED_TEST(RepairEmptyBlocksTest, SuccessfullyRepairsEmptyBlocksWithIndividualPartWeights) {
+  this->constructFromValues({4, 3, 3, 2, 2, 1, 1, 1, 3, 4, 2, 3, 1, 2, 1, 2, 1, 1});
+  this->context.partition.use_individual_part_weights = true;
+  this->context.partition.max_part_weights = {10, 10, 8, 8, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 2, 1};
+  this->context.partition.max_part_weights.resize(this->context.partition.k, 5);
+  this->setup();
+
+  for (HyperedgeID hn = 0; hn < this->hypergraph.initialNumNodes(); ++hn) {
+    this->partitioned_hypergraph.setOnlyNodePart(hn, hn % 8);
+  }
+  this->repairEmptyBlocks();
+
+  for (PartitionID block = 0; block < this->context.partition.k; ++block) {
+    ASSERT_GT(this->partitioned_hypergraph.partWeight(block), 0) << V(block);
+  }
+}
+
+
+TYPED_TEST(RepairEmptyBlocksTest, IsDeterministicWithIndividualPartWeights) {
+  this->constructFromValues({4, 3, 3, 2, 2, 1, 1, 1, 3, 4, 2, 3, 1, 2, 1, 2, 1, 1});
+
+  vec<PartitionID> partition(this->hypergraph.initialNumNodes(), kInvalidPartition);
+
+  for (size_t i = 0; i < 5; ++i) {
+    this->context.partition.use_individual_part_weights = true;
+    this->context.partition.max_part_weights = {10, 10, 8, 8, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 2, 1};
+    this->setup();
+
+    for (HyperedgeID hn = 0; hn < this->hypergraph.initialNumNodes(); ++hn) {
+      this->partitioned_hypergraph.setOnlyNodePart(hn, hn % 8);
+    }
+    this->repairEmptyBlocks();
+
+    for (HypernodeID hn: this->hypergraph.nodes()) {
+      if (i == 0) {
+        partition[hn] = this->partitioned_hypergraph.partID(hn);
+      } else {
+        ASSERT_EQ(this->partitioned_hypergraph.partID(hn), partition[hn]);
+      }
+    }
+  }
+}
+
+
+TYPED_TEST(RepairEmptyBlocksTest, IsDeterministicOnRealInstance) {
+  this->constructFromFile();
+
+  vec<PartitionID> partition(this->hypergraph.initialNumNodes(), kInvalidPartition);
+
+  for (size_t i = 0; i < 5; ++i) {
+    this->setup();
+
+    for (HyperedgeID hn = 0; hn < this->hypergraph.initialNumNodes(); ++hn) {
+      this->partitioned_hypergraph.setOnlyNodePart(hn, hn % 8);
+    }
+    this->repairEmptyBlocks();
+
+    for (HypernodeID hn: this->hypergraph.nodes()) {
+      if (i == 0) {
+        partition[hn] = this->partitioned_hypergraph.partID(hn);
+      } else {
+        ASSERT_EQ(this->partitioned_hypergraph.partID(hn), partition[hn]);
+      }
+    }
+    for (PartitionID block = 0; block < this->context.partition.k; ++block) {
+      ASSERT_GT(this->partitioned_hypergraph.partWeight(block), 0) << V(block);
+    }
+  }
+}
+
+
+TYPED_TEST(RepairEmptyBlocksTest, IsDeterministicOnRealInstanceWithIndividualPartWeights) {
+  this->constructFromFile();
+
+  vec<PartitionID> partition(this->hypergraph.initialNumNodes(), kInvalidPartition);
+
+  for (size_t i = 0; i < 5; ++i) {
+    const HypernodeWeight avg_weight = this->hypergraph.totalWeight() / 16 + 1;
+    auto map_weight = [&](const double factor) { return static_cast<HypernodeWeight>(factor * avg_weight); };
+
+    this->context.partition.use_individual_part_weights = true;
+    this->context.partition.max_part_weights = {
+      map_weight(2.0), map_weight(3.5), map_weight(3.0), map_weight(2.5),
+      map_weight(2.0), map_weight(3.5), map_weight(3.0), map_weight(2.5),
+      map_weight(0.8), map_weight(0.3), map_weight(0.1), map_weight(0.01),
+      map_weight(0.8), map_weight(0.3), map_weight(0.1), map_weight(0.01)
+    };
+    this->setup();
+
+    for (HyperedgeID hn = 0; hn < this->hypergraph.initialNumNodes(); ++hn) {
+      this->partitioned_hypergraph.setOnlyNodePart(hn, hn % 8);
+    }
+    this->repairEmptyBlocks();
+
+    for (HypernodeID hn: this->hypergraph.nodes()) {
+      if (i == 0) {
+        partition[hn] = this->partitioned_hypergraph.partID(hn);
+      } else {
+        ASSERT_EQ(this->partitioned_hypergraph.partID(hn), partition[hn]);
+      }
+    }
+  }
+}
+
+}

--- a/tests/partition/refinement/twoway_fm_refiner_test.cc
+++ b/tests/partition/refinement/twoway_fm_refiner_test.cc
@@ -102,12 +102,12 @@ static constexpr double EPS = 0.05;
 
 TEST_F(ATwoWayFmRefiner, UpdatesImbalanceCorrectly) {
   refiner->refine(metrics, *prng);
-  ASSERT_DOUBLE_EQ(metrics::imbalance(partitioned_hypergraph, context), metrics.imbalance);
+  ASSERT_EQ(metrics::imbalance(partitioned_hypergraph, context), metrics.imbalance);
 }
 
 TEST_F(ATwoWayFmRefiner, DoesNotViolateBalanceConstraint) {
   refiner->refine(metrics, *prng);
-  ASSERT_LE(metrics.imbalance, context.partition.epsilon + EPS);
+  ASSERT_LE(metrics.imbalance.imbalance_value, context.partition.epsilon + EPS);
 }
 
 TEST_F(ATwoWayFmRefiner, UpdatesMetricsCorrectly) {

--- a/tools/evaluate_bipart_partition.cc
+++ b/tools/evaluate_bipart_partition.cc
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
   std::cout << "RESULT"
             << " graph=" << context.partition.graph_filename
             << " k=" << context.partition.k
-            << " imbalance=" << metrics::imbalance(phg, context)
+            << " imbalance=" << metrics::imbalance(phg, context).imbalance_value
             << " cut=" << metrics::quality(phg, Objective::cut)
             << " km1=" << metrics::quality(phg, Objective::km1) << std::endl;
 

--- a/tools/evaluate_hmetis_partition.cc
+++ b/tools/evaluate_hmetis_partition.cc
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
   std::cout << "RESULT"
             << " graph=" << context.partition.graph_filename
             << " k=" << context.partition.k
-            << " imbalance=" << metrics::imbalance(phg, context)
+            << " imbalance=" << metrics::imbalance(phg, context).imbalance_value
             << " cut=" << metrics::quality(phg, Objective::cut)
             << " km1=" << metrics::quality(phg, Objective::km1) << std::endl;
 

--- a/tools/one_to_one_mapping.cc
+++ b/tools/one_to_one_mapping.cc
@@ -175,7 +175,7 @@ int main(int argc, char* argv[]) {
             << " k=" << context.partition.k
             << " epsilon=" << context.partition.epsilon
             << " seed=" << context.partition.seed
-            << " imbalance=" << metrics::imbalance(partitioned_hg, context)
+            << " imbalance=" << metrics::imbalance(partitioned_hg, context).imbalance_value
             << " steiner_tree=" << metrics::quality(partitioned_hg, Objective::steiner_tree)
             << " approximation_factor=" << metrics::approximationFactorForProcessMapping(partitioned_hg, context)
             << " cut=" << metrics::quality(partitioned_hg, Objective::cut)

--- a/tools/verify_partition.cc
+++ b/tools/verify_partition.cc
@@ -155,7 +155,7 @@ int main(int argc, char* argv[]) {
   std::cout << "cut =" << metrics::quality(phg, Objective::cut) << std::endl;
   std::cout << "soed =" << metrics::quality(phg, Objective::soed) << std::endl;
   std::cout << "km1 = " << metrics::quality(phg, Objective::km1) << std::endl;
-  std::cout << "imbalance = " << metrics::imbalance(phg, context) << std::endl;
+  std::cout << "imbalance = " << metrics::imbalance(phg, context).imbalance_value << std::endl;
 
   utils::delete_hypergraph(hypergraph);
 

--- a/tools/verify_target_graph_partition.cc
+++ b/tools/verify_target_graph_partition.cc
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]) {
             << " objective=" << context.partition.objective
             << " k=" << context.partition.k
             << " epsilon=" << context.partition.epsilon
-            << " imbalance=" << metrics::imbalance(partitioned_hg, context)
+            << " imbalance=" << metrics::imbalance(partitioned_hg, context).imbalance_value
             << " steiner_tree=" << metrics::quality(partitioned_hg, Objective::steiner_tree)
             << " approximation_factor=" << metrics::approximationFactorForProcessMapping(partitioned_hg, context)
             << " cut=" << metrics::quality(partitioned_hg, Objective::cut)


### PR DESCRIPTION
This fixes and refactors how Mt-KaHyPar handles the constraint that no block should be empty.

Concrete changes:
- Adds a flag to control whether empty blocks are allowed (`--allow-empty-blocks`, default is false to match the behavior of KaHyPar)
- Refactors the metrics and imbalance computation so that empty blocks are handled uniformly in one place, as well as comparing partitions in general (also useful for other constraints we might add in the future)
- Adds a (deterministic) subroutine to both rebalancers which fixes empty blocks if necessary. Note: doesn't explicitly attempt to keep blocks non-empty during refinement, in doubt the rebalancer can fix it afterwards.

Context: earlier versions kept blocks non-empty with ad-hoc logic in IP and the different refinement algorithms. Current master doesn't guarantee non-emptyness since the introduction of unconstrained refinement and the new rebalancer. However, some parts of the code still assume blocks should be non-empty which leads to inconsistencies.

In particular, this fixes an issue with deterministic Jet refinement. In some cases (large k and e), Jet would empty one of the blocks. The rebalancer would leave it empty, but the balance metric would mark the partition as invalid. Thus Jet would rollback the change and therefore achieve nothing, effectively being "paralyzed". See the following results for `k = 32, 64, 128` and `e = 0.4` on parameter tuning instances:

<img src="https://github.com/user-attachments/assets/3b56f95b-8198-49dd-a279-c70239dc64f7" width="250"/>
<img src="https://github.com/user-attachments/assets/e0a42d09-344d-4d2b-8acb-e18859e8369a" width="250"/>
<img src="https://github.com/user-attachments/assets/c6ba0f65-2d6c-464f-9db5-8ea6b85728d6" width="250"/>

For more standard parameters (smaller k and e) the performance is unchanged.

Limitations:
- Doesn't add support for general minimal block weights. However the refactoring is designed to simplify adding minimal weights later
- The uniform constraint handling is not available for FM rollback. This wouldn't be worth the effort for empty blocks, but might be added later together with minimal block weights support