### PR TITLE
Fix uncaught InvalidInputException in CLI main function

### DIFF
--- a/mt-kahypar/application/mt_kahypar.cc
+++ b/mt-kahypar/application/mt_kahypar.cc
@@ -27,6 +27,7 @@
 
 #include <iostream>
 #include <chrono>
+#include <exception>
 
 #include "mt-kahypar/io/command_line_options.h"
 #include "mt-kahypar/io/hypergraph_factory.h"
@@ -48,118 +49,126 @@ using namespace mt_kahypar;
 using HighResClockTimepoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
 int main(int argc, char* argv[]) {
+  try {
+    Context context(false);
+    processCommandLineInput(context, argc, argv);
 
-  Context context(false);
-  processCommandLineInput(context, argc, argv);
-
-  if ( context.partition.preset_type == PresetType::UNDEFINED ) {
-    ERR("No preset specified (--preset-type)");
-  }
-
-  // Determine instance (graph or hypergraph) and partition type
-  if ( context.partition.instance_type == InstanceType::UNDEFINED ) {
-    context.partition.instance_type = to_instance_type(context.partition.file_format);
-  }
-  context.partition.partition_type = to_partition_c_type(
-    context.partition.preset_type, context.partition.instance_type);
-
-
-  context.utility_id = utils::Utilities::instance().registerNewUtilityObjects();
-  if (context.partition.enable_logging) {
-    io::printBanner();
-  }
-
-  utils::Randomize::instance().setSeed(context.partition.seed);
-  if ( context.shared_memory.use_localized_random_shuffle ) {
-    utils::Randomize::instance().enableLocalizedParallelShuffle(
-      context.shared_memory.shuffle_block_size);
-  }
-
-  if constexpr (parallel::provides_hardware_information) {
-    size_t num_available_cpus = parallel::num_hardware_cpus();
-    if ( num_available_cpus < context.shared_memory.num_threads ) {
-      WARNING("There are currently only " << num_available_cpus << " cpus available. "
-        << "Setting number of threads from " << context.shared_memory.num_threads
-        << " to " << num_available_cpus);
-      context.shared_memory.num_threads = num_available_cpus;
+    if ( context.partition.preset_type == PresetType::UNDEFINED ) {
+      ERR("No preset specified (--preset-type)");
     }
-  }
 
-  // Initialize TBB task arenas on numa nodes
-  parallel::initialize_tbb(context.shared_memory.num_threads);
-
-  if constexpr (parallel::provides_hardware_information) {
-    // We set the membind policy to interleaved allocations in order to
-    // distribute allocations evenly across NUMA nodes
-    parallel::activate_interleaved_membind_policy();
-  }
-
-  // Read Hypergraph
-  utils::Timer& timer =
-    utils::Utilities::instance().getTimer(context.utility_id);
-  timer.start_timer("io_hypergraph", "I/O Hypergraph");
-  mt_kahypar_hypergraph_t hypergraph = io::readInputFile(
-      context.partition.graph_filename, context.partition.preset_type,
-      context.partition.instance_type, context.partition.file_format,
-      context.preprocessing.stable_construction_of_incident_edges,
-      /*remove_single_pin_hes=*/true, /*print_warnings=*/true);
-  timer.stop_timer("io_hypergraph");
-
-  // Read Target Graph
-  std::unique_ptr<TargetGraph> target_graph;
-  if ( context.partition.objective == Objective::steiner_tree ) {
-    if ( context.mapping.target_graph_file != "" ) {
-      target_graph = std::make_unique<TargetGraph>(
-        io::readInputFile<ds::StaticGraph>(
-          context.mapping.target_graph_file, FileFormat::Metis,
-          /*stable_construnction=*/true, /*remove_single_pin_hes=*/true, /*print_warnings=*/true));
-    } else {
-      throw InvalidInputException("No target graph file specified (use -g <file> or --target-graph=<file>)!");
+    // Determine instance (graph or hypergraph) and partition type
+    if ( context.partition.instance_type == InstanceType::UNDEFINED ) {
+      context.partition.instance_type = to_instance_type(context.partition.file_format);
     }
+    context.partition.partition_type = to_partition_c_type(
+      context.partition.preset_type, context.partition.instance_type);
+
+
+    context.utility_id = utils::Utilities::instance().registerNewUtilityObjects();
+    if (context.partition.enable_logging) {
+      io::printBanner();
+    }
+
+    utils::Randomize::instance().setSeed(context.partition.seed);
+    if ( context.shared_memory.use_localized_random_shuffle ) {
+      utils::Randomize::instance().enableLocalizedParallelShuffle(
+        context.shared_memory.shuffle_block_size);
+    }
+
+    if constexpr (parallel::provides_hardware_information) {
+      size_t num_available_cpus = parallel::num_hardware_cpus();
+      if ( num_available_cpus < context.shared_memory.num_threads ) {
+        WARNING("There are currently only " << num_available_cpus << " cpus available. "
+          << "Setting number of threads from " << context.shared_memory.num_threads
+          << " to " << num_available_cpus);
+        context.shared_memory.num_threads = num_available_cpus;
+      }
+    }
+
+    // Initialize TBB task arenas on numa nodes
+    parallel::initialize_tbb(context.shared_memory.num_threads);
+
+    if constexpr (parallel::provides_hardware_information) {
+      // We set the membind policy to interleaved allocations in order to
+      // distribute allocations evenly across NUMA nodes
+      parallel::activate_interleaved_membind_policy();
+    }
+
+    // Read Hypergraph
+    utils::Timer& timer =
+      utils::Utilities::instance().getTimer(context.utility_id);
+    timer.start_timer("io_hypergraph", "I/O Hypergraph");
+    mt_kahypar_hypergraph_t hypergraph = io::readInputFile(
+        context.partition.graph_filename, context.partition.preset_type,
+        context.partition.instance_type, context.partition.file_format,
+        context.preprocessing.stable_construction_of_incident_edges,
+        /*remove_single_pin_hes=*/true, /*print_warnings=*/true);
+    timer.stop_timer("io_hypergraph");
+
+    // Read Target Graph
+    std::unique_ptr<TargetGraph> target_graph;
+    if ( context.partition.objective == Objective::steiner_tree ) {
+      if ( context.mapping.target_graph_file != "" ) {
+        target_graph = std::make_unique<TargetGraph>(
+          io::readInputFile<ds::StaticGraph>(
+            context.mapping.target_graph_file, FileFormat::Metis,
+            /*stable_construnction=*/true, /*remove_single_pin_hes=*/true, /*print_warnings=*/true));
+      } else {
+        throw InvalidInputException("No target graph file specified (use -g <file> or --target-graph=<file>)!");
+      }
+    }
+
+    if ( context.partition.fixed_vertex_filename != "" ) {
+      timer.start_timer("read_fixed_vertices", "Read Fixed Vertex File");
+      io::addFixedVerticesFromFile(hypergraph,
+        context.partition.fixed_vertex_filename, context.partition.k);
+      timer.stop_timer("read_fixed_vertices");
+    }
+
+    // Initialize Memory Pool and Algorithm/Policy Registries
+    register_memory_pool(hypergraph, context);
+    register_algorithms_and_policies();
+
+    // Partition Hypergraph
+    HighResClockTimepoint start = std::chrono::high_resolution_clock::now();
+    mt_kahypar_partitioned_hypergraph_t partitioned_hypergraph =
+      PartitionerFacade::partition(hypergraph, context, target_graph.get());
+    HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
+
+    // Print Stats
+    std::chrono::duration<double> elapsed_seconds(end - start);
+    PartitionerFacade::printPartitioningResults(
+      partitioned_hypergraph, context, elapsed_seconds);
+
+    if ( context.partition.sp_process_output ) {
+      std::cout << PartitionerFacade::serializeResultLine(
+        partitioned_hypergraph, context, elapsed_seconds) << std::endl;
+    }
+
+    if ( context.partition.csv_output ) {
+      std::cout << PartitionerFacade::serializeCSV(
+        partitioned_hypergraph, context, elapsed_seconds) << std::endl;
+    }
+
+    if (context.partition.write_partition_file) {
+      PartitionerFacade::writePartitionFile(
+        partitioned_hypergraph, context.partition.graph_partition_filename);
+    }
+
+    parallel::MemoryPool::instance().free_memory_chunks();
+    parallel::terminate_tbb();
+
+    utils::delete_hypergraph(hypergraph);
+    utils::delete_partitioned_hypergraph(partitioned_hypergraph);
+
+    return 0;
+
+  } catch (const mt_kahypar::InvalidInputException& e) {
+    std::cerr << "\n[ERROR] " << e.what() << std::endl;
+    return 1;
+  } catch (const std::exception& e) {
+    std::cerr << "\n[FATAL ERROR] " << e.what() << std::endl;
+    return 1;
   }
-
-  if ( context.partition.fixed_vertex_filename != "" ) {
-    timer.start_timer("read_fixed_vertices", "Read Fixed Vertex File");
-    io::addFixedVerticesFromFile(hypergraph,
-      context.partition.fixed_vertex_filename, context.partition.k);
-    timer.stop_timer("read_fixed_vertices");
-  }
-
-  // Initialize Memory Pool and Algorithm/Policy Registries
-  register_memory_pool(hypergraph, context);
-  register_algorithms_and_policies();
-
-  // Partition Hypergraph
-  HighResClockTimepoint start = std::chrono::high_resolution_clock::now();
-  mt_kahypar_partitioned_hypergraph_t partitioned_hypergraph =
-    PartitionerFacade::partition(hypergraph, context, target_graph.get());
-  HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
-
-  // Print Stats
-  std::chrono::duration<double> elapsed_seconds(end - start);
-  PartitionerFacade::printPartitioningResults(
-    partitioned_hypergraph, context, elapsed_seconds);
-
-  if ( context.partition.sp_process_output ) {
-    std::cout << PartitionerFacade::serializeResultLine(
-      partitioned_hypergraph, context, elapsed_seconds) << std::endl;
-  }
-
-  if ( context.partition.csv_output ) {
-    std::cout << PartitionerFacade::serializeCSV(
-      partitioned_hypergraph, context, elapsed_seconds) << std::endl;
-  }
-
-  if (context.partition.write_partition_file) {
-    PartitionerFacade::writePartitionFile(
-      partitioned_hypergraph, context.partition.graph_partition_filename);
-  }
-
-  parallel::MemoryPool::instance().free_memory_chunks();
-  parallel::terminate_tbb();
-
-  utils::delete_hypergraph(hypergraph);
-  utils::delete_partitioned_hypergraph(partitioned_hypergraph);
-
-  return 0;
 }

--- a/mt-kahypar/application/mt_kahypar.cc
+++ b/mt-kahypar/application/mt_kahypar.cc
@@ -48,8 +48,7 @@
 using namespace mt_kahypar;
 using HighResClockTimepoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
-int main(int argc, char* argv[]) {
-  try {
+int run(int argc, char* argv[]) {
     Context context(false);
     processCommandLineInput(context, argc, argv);
 
@@ -163,12 +162,26 @@ int main(int argc, char* argv[]) {
     utils::delete_partitioned_hypergraph(partitioned_hypergraph);
 
     return 0;
+}
 
-  } catch (const mt_kahypar::InvalidInputException& e) {
-    std::cerr << "\n[ERROR] " << e.what() << std::endl;
+int main(int argc, char* argv[]) {
+#ifdef NDEBUG
+  try {
+    return run(argc, argv);
+  } catch (const InvalidInputException& e) {
+    std::cerr << "\n " << e.what() << std::endl;
+    return 1;
+  } catch (const InvalidParameterException& e) {
+    std::cerr << "\n" << e.what() << std::endl;
+    return 1;
+  } catch (const UnsupportedOperationException& e) {
+    std::cerr << "\n" << e.what() << std::endl;
     return 1;
   } catch (const std::exception& e) {
     std::cerr << "\n[FATAL ERROR] " << e.what() << std::endl;
     return 1;
   }
+#else
+  return run(argc, argv);
+#endif
 }

--- a/mt-kahypar/application/mt_kahypar.cc
+++ b/mt-kahypar/application/mt_kahypar.cc
@@ -49,119 +49,119 @@ using namespace mt_kahypar;
 using HighResClockTimepoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
 int run(int argc, char* argv[]) {
-    Context context(false);
-    processCommandLineInput(context, argc, argv);
+  Context context(false);
+  processCommandLineInput(context, argc, argv);
 
-    if ( context.partition.preset_type == PresetType::UNDEFINED ) {
-      ERR("No preset specified (--preset-type)");
+  if ( context.partition.preset_type == PresetType::UNDEFINED ) {
+    ERR("No preset specified (--preset-type)");
+  }
+
+  // Determine instance (graph or hypergraph) and partition type
+  if ( context.partition.instance_type == InstanceType::UNDEFINED ) {
+    context.partition.instance_type = to_instance_type(context.partition.file_format);
+  }
+  context.partition.partition_type = to_partition_c_type(
+    context.partition.preset_type, context.partition.instance_type);
+
+
+  context.utility_id = utils::Utilities::instance().registerNewUtilityObjects();
+  if (context.partition.enable_logging) {
+    io::printBanner();
+  }
+
+  utils::Randomize::instance().setSeed(context.partition.seed);
+  if ( context.shared_memory.use_localized_random_shuffle ) {
+    utils::Randomize::instance().enableLocalizedParallelShuffle(
+      context.shared_memory.shuffle_block_size);
+  }
+
+  if constexpr (parallel::provides_hardware_information) {
+    size_t num_available_cpus = parallel::num_hardware_cpus();
+    if ( num_available_cpus < context.shared_memory.num_threads ) {
+      WARNING("There are currently only " << num_available_cpus << " cpus available. "
+        << "Setting number of threads from " << context.shared_memory.num_threads
+        << " to " << num_available_cpus);
+      context.shared_memory.num_threads = num_available_cpus;
     }
+  }
 
-    // Determine instance (graph or hypergraph) and partition type
-    if ( context.partition.instance_type == InstanceType::UNDEFINED ) {
-      context.partition.instance_type = to_instance_type(context.partition.file_format);
+  // Initialize TBB task arenas on numa nodes
+  parallel::initialize_tbb(context.shared_memory.num_threads);
+
+  if constexpr (parallel::provides_hardware_information) {
+    // We set the membind policy to interleaved allocations in order to
+    // distribute allocations evenly across NUMA nodes
+    parallel::activate_interleaved_membind_policy();
+  }
+
+  // Read Hypergraph
+  utils::Timer& timer =
+    utils::Utilities::instance().getTimer(context.utility_id);
+  timer.start_timer("io_hypergraph", "I/O Hypergraph");
+  mt_kahypar_hypergraph_t hypergraph = io::readInputFile(
+      context.partition.graph_filename, context.partition.preset_type,
+      context.partition.instance_type, context.partition.file_format,
+      context.preprocessing.stable_construction_of_incident_edges,
+      /*remove_single_pin_hes=*/true, /*print_warnings=*/true);
+  timer.stop_timer("io_hypergraph");
+
+  // Read Target Graph
+  std::unique_ptr<TargetGraph> target_graph;
+  if ( context.partition.objective == Objective::steiner_tree ) {
+    if ( context.mapping.target_graph_file != "" ) {
+      target_graph = std::make_unique<TargetGraph>(
+        io::readInputFile<ds::StaticGraph>(
+          context.mapping.target_graph_file, FileFormat::Metis,
+          /*stable_construnction=*/true, /*remove_single_pin_hes=*/true, /*print_warnings=*/true));
+    } else {
+      throw InvalidInputException("No target graph file specified (use -g <file> or --target-graph=<file>)!");
     }
-    context.partition.partition_type = to_partition_c_type(
-      context.partition.preset_type, context.partition.instance_type);
+  }
 
+  if ( context.partition.fixed_vertex_filename != "" ) {
+    timer.start_timer("read_fixed_vertices", "Read Fixed Vertex File");
+    io::addFixedVerticesFromFile(hypergraph,
+      context.partition.fixed_vertex_filename, context.partition.k);
+    timer.stop_timer("read_fixed_vertices");
+  }
 
-    context.utility_id = utils::Utilities::instance().registerNewUtilityObjects();
-    if (context.partition.enable_logging) {
-      io::printBanner();
-    }
+  // Initialize Memory Pool and Algorithm/Policy Registries
+  register_memory_pool(hypergraph, context);
+  register_algorithms_and_policies();
 
-    utils::Randomize::instance().setSeed(context.partition.seed);
-    if ( context.shared_memory.use_localized_random_shuffle ) {
-      utils::Randomize::instance().enableLocalizedParallelShuffle(
-        context.shared_memory.shuffle_block_size);
-    }
+  // Partition Hypergraph
+  HighResClockTimepoint start = std::chrono::high_resolution_clock::now();
+  mt_kahypar_partitioned_hypergraph_t partitioned_hypergraph =
+    PartitionerFacade::partition(hypergraph, context, target_graph.get());
+  HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
 
-    if constexpr (parallel::provides_hardware_information) {
-      size_t num_available_cpus = parallel::num_hardware_cpus();
-      if ( num_available_cpus < context.shared_memory.num_threads ) {
-        WARNING("There are currently only " << num_available_cpus << " cpus available. "
-          << "Setting number of threads from " << context.shared_memory.num_threads
-          << " to " << num_available_cpus);
-        context.shared_memory.num_threads = num_available_cpus;
-      }
-    }
+  // Print Stats
+  std::chrono::duration<double> elapsed_seconds(end - start);
+  PartitionerFacade::printPartitioningResults(
+    partitioned_hypergraph, context, elapsed_seconds);
 
-    // Initialize TBB task arenas on numa nodes
-    parallel::initialize_tbb(context.shared_memory.num_threads);
+  if ( context.partition.sp_process_output ) {
+    std::cout << PartitionerFacade::serializeResultLine(
+      partitioned_hypergraph, context, elapsed_seconds) << std::endl;
+  }
 
-    if constexpr (parallel::provides_hardware_information) {
-      // We set the membind policy to interleaved allocations in order to
-      // distribute allocations evenly across NUMA nodes
-      parallel::activate_interleaved_membind_policy();
-    }
+  if ( context.partition.csv_output ) {
+    std::cout << PartitionerFacade::serializeCSV(
+      partitioned_hypergraph, context, elapsed_seconds) << std::endl;
+  }
 
-    // Read Hypergraph
-    utils::Timer& timer =
-      utils::Utilities::instance().getTimer(context.utility_id);
-    timer.start_timer("io_hypergraph", "I/O Hypergraph");
-    mt_kahypar_hypergraph_t hypergraph = io::readInputFile(
-        context.partition.graph_filename, context.partition.preset_type,
-        context.partition.instance_type, context.partition.file_format,
-        context.preprocessing.stable_construction_of_incident_edges,
-        /*remove_single_pin_hes=*/true, /*print_warnings=*/true);
-    timer.stop_timer("io_hypergraph");
+  if (context.partition.write_partition_file) {
+    PartitionerFacade::writePartitionFile(
+      partitioned_hypergraph, context.partition.graph_partition_filename);
+  }
 
-    // Read Target Graph
-    std::unique_ptr<TargetGraph> target_graph;
-    if ( context.partition.objective == Objective::steiner_tree ) {
-      if ( context.mapping.target_graph_file != "" ) {
-        target_graph = std::make_unique<TargetGraph>(
-          io::readInputFile<ds::StaticGraph>(
-            context.mapping.target_graph_file, FileFormat::Metis,
-            /*stable_construnction=*/true, /*remove_single_pin_hes=*/true, /*print_warnings=*/true));
-      } else {
-        throw InvalidInputException("No target graph file specified (use -g <file> or --target-graph=<file>)!");
-      }
-    }
+  parallel::MemoryPool::instance().free_memory_chunks();
+  parallel::terminate_tbb();
 
-    if ( context.partition.fixed_vertex_filename != "" ) {
-      timer.start_timer("read_fixed_vertices", "Read Fixed Vertex File");
-      io::addFixedVerticesFromFile(hypergraph,
-        context.partition.fixed_vertex_filename, context.partition.k);
-      timer.stop_timer("read_fixed_vertices");
-    }
+  utils::delete_hypergraph(hypergraph);
+  utils::delete_partitioned_hypergraph(partitioned_hypergraph);
 
-    // Initialize Memory Pool and Algorithm/Policy Registries
-    register_memory_pool(hypergraph, context);
-    register_algorithms_and_policies();
-
-    // Partition Hypergraph
-    HighResClockTimepoint start = std::chrono::high_resolution_clock::now();
-    mt_kahypar_partitioned_hypergraph_t partitioned_hypergraph =
-      PartitionerFacade::partition(hypergraph, context, target_graph.get());
-    HighResClockTimepoint end = std::chrono::high_resolution_clock::now();
-
-    // Print Stats
-    std::chrono::duration<double> elapsed_seconds(end - start);
-    PartitionerFacade::printPartitioningResults(
-      partitioned_hypergraph, context, elapsed_seconds);
-
-    if ( context.partition.sp_process_output ) {
-      std::cout << PartitionerFacade::serializeResultLine(
-        partitioned_hypergraph, context, elapsed_seconds) << std::endl;
-    }
-
-    if ( context.partition.csv_output ) {
-      std::cout << PartitionerFacade::serializeCSV(
-        partitioned_hypergraph, context, elapsed_seconds) << std::endl;
-    }
-
-    if (context.partition.write_partition_file) {
-      PartitionerFacade::writePartitionFile(
-        partitioned_hypergraph, context.partition.graph_partition_filename);
-    }
-
-    parallel::MemoryPool::instance().free_memory_chunks();
-    parallel::terminate_tbb();
-
-    utils::delete_hypergraph(hypergraph);
-    utils::delete_partitioned_hypergraph(partitioned_hypergraph);
-
-    return 0;
+  return 0;
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Hi,

**The Issue**
While testing the command-line tool with a few malformed `.hgr` edge cases (like 0-indexed vertices or empty lines), I noticed the application crashes with a `libc++abi abort`. The parser correctly identifies the bad formatting and throws an `InvalidInputException`, but because `main()` lacked a `try/catch` block, the exception goes uncaught and forces a hard crash.

**The Fix**
I wrapped the main execution block in `application/mt_kahypar.cc` with a `try/catch`. Now, when the parser throws an `InvalidInputException`, the CLI catches it, prints the exact error message cleanly to `std::cerr`, and gracefully exits with `return 1`. 

Tested locally on macOS and it handles the malformed files perfectly without dumping core. Let me know if you need any adjustments!